### PR TITLE
fix(release): harden native preflight bootstrap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -365,21 +365,23 @@ jobs:
           persist-credentials: false
           ref: ${{ needs.eligibility.outputs.source_sha }}
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          run_install: false
-
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .node-version
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          run_install: false
+          cache: false
 
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           toolchain: 1.97.1
           target: ${{ matrix.rust_target }}
+          cache: false
 
       - name: Verify native runner and frozen toolchain
         shell: pwsh
@@ -625,20 +627,38 @@ jobs:
           persist-credentials: false
           ref: ${{ needs.eligibility.outputs.source_sha }}
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          run_install: false
+      - name: Trust exact checked-out workspace for container Git
+        shell: bash
+        run: |
+          set -euo pipefail
+          [ "$PWD" = "$GITHUB_WORKSPACE" ] || {
+            echo "Linux container workspace drift: $PWD != $GITHUB_WORKSPACE" >&2
+            exit 1
+          }
+          git config --global --unset-all safe.directory 2>/dev/null || true
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          [ "$(git config --get-all safe.directory)" = "$GITHUB_WORKSPACE" ] || {
+            echo 'Linux container Git trust is not limited to the exact workspace' >&2
+            exit 1
+          }
+          [ "$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)" = "$SOURCE_SHA" ]
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .node-version
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          run_install: false
+          cache: false
+
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           toolchain: 1.97.1
+          cache: false
 
       - name: Verify native source and frozen toolchain
         shell: bash
@@ -747,21 +767,23 @@ jobs:
           persist-credentials: false
           ref: ${{ needs.eligibility.outputs.source_sha }}
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          run_install: false
-
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .node-version
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          run_install: false
+          cache: false
 
       - name: Setup Rust with both universal targets
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           toolchain: 1.97.1
           target: aarch64-apple-darwin,x86_64-apple-darwin
+          cache: false
 
       - name: Verify frozen source and toolchain
         shell: bash

--- a/.trellis/spec/backend/github-release-workflow.md
+++ b/.trellis/spec/backend/github-release-workflow.md
@@ -116,6 +116,12 @@ Direct third-party Actions use reviewed full 40-character commit SHAs. Required
 Release jobs do not use `*-latest` runners. Actions do not install or execute
 mise. Release jobs do not restore or save dependency caches; candidate build
 code cannot populate a trusted-main cache later consumed by formal release.
+The native build jobs establish the repository-declared Node version before
+running non-standalone `pnpm/action-setup`, whose installer requires `npm` on
+`PATH`; relying on a runner image's incidental npm installation is invalid.
+Both pnpm setup and `setup-rust-toolchain` declare `cache: false` explicitly.
+The Rust action enables `Swatinem/rust-cache` by default when that input is
+omitted, so absence of the field is not evidence that Release caching is off.
 
 | Target group      | Runner             | Build user space                       | Required output                    |
 | ----------------- | ------------------ | -------------------------------------- | ---------------------------------- |
@@ -137,6 +143,14 @@ building, so a wrong host plus binfmt cannot impersonate a native target. There
 is no QEMU or opposite-architecture fallback. ARM runner unavailability is a
 retryable infrastructure failure, not authorization to cross-build or publish
 a reduced asset set.
+
+GitHub job containers restore their ordinary `HOME` after checkout has written
+its temporary global Git configuration. Each Linux build therefore clears any
+inherited global `safe.directory` values, adds only the exact
+`$GITHUB_WORKSPACE` path, proves that it is the sole value visible across the
+effective configuration scopes, and immediately proves its HEAD equals the
+frozen source SHA. Wildcard or additional safe-directory trust, recursive
+ownership changes, or disabling Git's ownership check are forbidden.
 
 Each target proves Node 24.19.0, pnpm 10.12.3, and Rust 1.97.1 at runtime. Its
 metadata records the actual runner image variables and tool versions; an absent
@@ -271,21 +285,22 @@ rulesets and is not described as atomic administrator protection.
 
 ## 8. Failure Matrix
 
-| Condition                                                                                                     | Required result                                                              |
-| ------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| Dispatch SHA is not full/lowercase or differs from trusted main workflow/event provenance                     | Fail eligibility before any platform build.                                  |
-| Formal ref, workflow ref, tag commit, event commit, product version, or source differ                         | Fail eligibility; do not build or publish.                                   |
-| Latest same-SHA main CI attempt is absent, running, failed, cancelled, or lacks the unique Required job/check | Fail eligibility; an older success is not accepted.                          |
-| A native runner/architecture, Ubuntu child digest, or tool version drifts                                     | Fail that platform job; no fallback target is allowed.                       |
-| Windows manifest/helper/MSI structure/payload/unsigned assertion fails                                        | Fail Windows output before artifact upload.                                  |
-| macOS app is not universal, identity differs, distribution identity/ticket exists, or ZIP/DMG copies differ   | Fail macOS output before artifact upload.                                    |
-| Linux package count/version/architecture differs                                                              | Fail Linux output before artifact upload.                                    |
-| Artifact tree or exact ten/twelve/thirteen allowlist differs                                                  | Fail verification/attestation/publish.                                       |
-| Mandatory attestation or bundle is absent                                                                     | Fail; do not characterize hashes alone as v0.3.0 provenance success.         |
-| Dispatch reaches publish                                                                                      | Static workflow test fails; remote preflight must create no Release.         |
-| A draft or published Release already exists                                                                   | Refuse to update, replace, or delete it.                                     |
-| Upload/re-download fails before final PATCH                                                                   | Leave the draft untouched, report ID/URL, and require manual decision.       |
-| Final PATCH has a failed or ambiguous outcome                                                                 | Read state by ID, report draft/published/unknown, and never retry or delete. |
+| Condition                                                                                                         | Required result                                                                                                     |
+| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Dispatch SHA is not full/lowercase or differs from trusted main workflow/event provenance                         | Fail eligibility before any platform build.                                                                         |
+| Formal ref, workflow ref, tag commit, event commit, product version, or source differ                             | Fail eligibility; do not build or publish.                                                                          |
+| Latest same-SHA main CI attempt is absent, running, failed, cancelled, or lacks the unique Required job/check     | Fail eligibility; an older success is not accepted.                                                                 |
+| A native runner/architecture, Ubuntu child digest, or tool version drifts                                         | Fail that platform job; no fallback target is allowed.                                                              |
+| Node is not established before pnpm, a Linux container lacks exact workspace trust, or a Release cache is enabled | Fail platform bootstrap; do not rely on runner-preinstalled tools, wildcard Git trust, or implicit Action defaults. |
+| Windows manifest/helper/MSI structure/payload/unsigned assertion fails                                            | Fail Windows output before artifact upload.                                                                         |
+| macOS app is not universal, identity differs, distribution identity/ticket exists, or ZIP/DMG copies differ       | Fail macOS output before artifact upload.                                                                           |
+| Linux package count/version/architecture differs                                                                  | Fail Linux output before artifact upload.                                                                           |
+| Artifact tree or exact ten/twelve/thirteen allowlist differs                                                      | Fail verification/attestation/publish.                                                                              |
+| Mandatory attestation or bundle is absent                                                                         | Fail; do not characterize hashes alone as v0.3.0 provenance success.                                                |
+| Dispatch reaches publish                                                                                          | Static workflow test fails; remote preflight must create no Release.                                                |
+| A draft or published Release already exists                                                                       | Refuse to update, replace, or delete it.                                                                            |
+| Upload/re-download fails before final PATCH                                                                       | Leave the draft untouched, report ID/URL, and require manual decision.                                              |
+| Final PATCH has a failed or ambiguous outcome                                                                     | Read state by ID, report draft/published/unknown, and never retry or delete.                                        |
 
 ## 9. Validation and Evidence Boundary
 

--- a/.trellis/spec/backend/windows-release-boundary.md
+++ b/.trellis/spec/backend/windows-release-boundary.md
@@ -135,6 +135,14 @@ or an unbounded argv payload.
   `asInvoker`. The unsigned v0.3.0 workflow explicitly selects `release` and
   verifies the embedded application manifest in the target release executable
   before and after MSI bundling, including exact x64/ARM64 PE Machine.
+- The manifest verifier never depends on `mt.exe` being present on `PATH`.
+  It enumerates version directories only below the standard Windows SDK
+  `Windows Kits\10\bin` roots, selects the newest architecture-matched `x64`
+  or `arm64` tool by parsed SDK version, and invokes that resolved absolute
+  path. A missing architecture-matched SDK tool is a release failure; PATH
+  fallback, opposite-architecture fallback, or downloading a verifier is
+  forbidden. The tool reads `RT_MANIFEST` resource ID 1 and never executes the
+  application.
 - Final MSI payload admission is read-only: the verifier resolves the unique
   File key `Path`, reads its embedded cabinet through `_Streams`, asks system
   `expand.exe` to extract only that fixed key into a fresh temporary root, and

--- a/scripts/release/verify-windows-release-manifest.ps1
+++ b/scripts/release/verify-windows-release-manifest.ps1
@@ -15,6 +15,53 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
+function Resolve-WindowsSdkManifestTool {
+  param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('x64', 'arm64')]
+    [string]$TargetArchitecture
+  )
+
+  $sdkArchitecture = if ($TargetArchitecture -eq 'arm64') { 'arm64' } else { 'x64' }
+  $programRoots = @(
+    [Environment]::GetEnvironmentVariable('ProgramFiles(x86)'),
+    [Environment]::GetEnvironmentVariable('ProgramFiles')
+  ) |
+    Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+    Sort-Object -Unique
+
+  $candidates = @(
+    foreach ($programRoot in $programRoots) {
+      $sdkBinRoot = Join-Path $programRoot 'Windows Kits\10\bin'
+      if (-not (Test-Path -LiteralPath $sdkBinRoot -PathType Container)) {
+        continue
+      }
+
+      foreach ($versionDirectory in Get-ChildItem -LiteralPath $sdkBinRoot -Directory) {
+        $sdkVersion = $null
+        if (-not [Version]::TryParse($versionDirectory.Name, [ref]$sdkVersion)) {
+          continue
+        }
+        $toolPath = Join-Path $versionDirectory.FullName "$sdkArchitecture\mt.exe"
+        if (Test-Path -LiteralPath $toolPath -PathType Leaf) {
+          [PSCustomObject]@{
+            Version = $sdkVersion
+            Path = (Resolve-Path -LiteralPath $toolPath).Path
+          }
+        }
+      }
+    }
+  )
+
+  $selected = $candidates |
+    Sort-Object -Property @{ Expression = 'Version'; Descending = $true }, @{ Expression = 'Path'; Descending = $false } |
+    Select-Object -First 1
+  if ($null -eq $selected) {
+    throw "Architecture-matched Windows SDK mt.exe was not found for $TargetArchitecture"
+  }
+  return [string]$selected.Path
+}
+
 $resolvedExe = (Resolve-Path -LiteralPath $ExePath).Path
 $bytes = [IO.File]::ReadAllBytes($resolvedExe)
 if ($bytes.Length -lt 0x40 -or $bytes[0] -ne 0x4d -or $bytes[1] -ne 0x5a) {
@@ -47,10 +94,11 @@ if (
 $safePhase = $Phase -replace '[^A-Za-z0-9_.-]', '-'
 $manifestPath = Join-Path $env:RUNNER_TEMP "fyagent-release-${safePhase}.manifest"
 Remove-Item -LiteralPath $manifestPath -Force -ErrorAction SilentlyContinue
-Get-Command mt.exe -ErrorAction Stop | Out-Null
+$mtPath = Resolve-WindowsSdkManifestTool -TargetArchitecture $Architecture
+Write-Host "Using Windows SDK Manifest Tool: $mtPath"
 
 # mt.exe only reads the PE RT_MANIFEST resource; this verifier never executes fyagent.exe.
-& mt.exe "-inputresource:$resolvedExe;#1" "-out:$manifestPath" -nologo
+& $mtPath "-inputresource:$resolvedExe;#1" "-out:$manifestPath" -nologo
 if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
   throw "mt.exe did not extract RT_MANIFEST from ${resolvedExe} during ${Phase}"
 }

--- a/tests/releaseWorkflow.test.ts
+++ b/tests/releaseWorkflow.test.ts
@@ -104,6 +104,27 @@ const CI_WORKFLOW = path.resolve(
   "ci.yml",
 );
 
+function workflowJobBlock(source: string, job: string, nextJob: string) {
+  const start = source.indexOf(`\n  ${job}:\n`);
+  const end = source.indexOf(`\n  ${nextJob}:\n`);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
+function namedStepBlock(source: string, name: string) {
+  const start = source.indexOf(`\n      - name: ${name}\n`);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const end = source.indexOf("\n      - name:", start + 1);
+  return source.slice(start, end < 0 ? source.length : end);
+}
+
+function expectExactLine(source: string, line: string) {
+  expect(
+    source.split(/\r?\n/).filter((candidate) => candidate === line),
+  ).toEqual([line]);
+}
+
 describe("FyAgent release workflow", () => {
   const source = fs.readFileSync(RELEASE_WORKFLOW, "utf8");
   const windowsMsiVerifier = fs.readFileSync(WINDOWS_MSI_VERIFIER, "utf8");
@@ -155,11 +176,80 @@ describe("FyAgent release workflow", () => {
       expect(source).toContain(runner);
     }
     expect(source).not.toMatch(/runs-on:\s*[^\n]*-latest/);
-    expect(source).not.toContain("cache:");
     expect(source).not.toContain("actions/cache");
+    expect(source).not.toContain("cache: true");
+    expect(source).not.toContain("cache: pnpm");
     expect(source.match(/uses: actions\/checkout@/g)).toHaveLength(
       source.match(/persist-credentials: false/g)?.length ?? 0,
     );
+  });
+
+  it("bootstraps native jobs without implicit tools, broad Git trust, or caches", () => {
+    const nativeJobs = [
+      {
+        block: workflowJobBlock(source, "build-windows", "build-linux"),
+        rustStep: "Setup Rust",
+      },
+      {
+        block: workflowJobBlock(source, "build-linux", "build-macos"),
+        rustStep: "Setup Rust",
+      },
+      {
+        block: workflowJobBlock(source, "build-macos", "verify-assets"),
+        rustStep: "Setup Rust with both universal targets",
+      },
+    ];
+
+    for (const { block, rustStep } of nativeJobs) {
+      const nodeIndex = block.indexOf("- name: Setup Node.js");
+      const pnpmIndex = block.indexOf("- name: Setup pnpm");
+      expect(nodeIndex).toBeGreaterThanOrEqual(0);
+      expect(pnpmIndex).toBeGreaterThan(nodeIndex);
+      const nodeStep = namedStepBlock(block, "Setup Node.js");
+      const pnpmStep = namedStepBlock(block, "Setup pnpm");
+      const rustSetupStep = namedStepBlock(block, rustStep);
+      expect(nodeStep).toContain("uses: actions/setup-node@");
+      expect(nodeStep).toContain("          node-version-file: .node-version");
+      expect(pnpmStep).toContain("uses: pnpm/action-setup@");
+      expectExactLine(pnpmStep, "          run_install: false");
+      expectExactLine(pnpmStep, "          cache: false");
+      expect(rustSetupStep).toContain(
+        "uses: actions-rust-lang/setup-rust-toolchain@",
+      );
+      expectExactLine(rustSetupStep, "          cache: false");
+    }
+
+    const linux = nativeJobs[1].block;
+    const checkoutIndex = linux.indexOf("- name: Checkout immutable source");
+    const trustIndex = linux.indexOf(
+      "- name: Trust exact checked-out workspace for container Git",
+    );
+    const nodeIndex = linux.indexOf("- name: Setup Node.js");
+    expect(checkoutIndex).toBeGreaterThanOrEqual(0);
+    expect(trustIndex).toBeGreaterThan(checkoutIndex);
+    expect(nodeIndex).toBeGreaterThan(trustIndex);
+    const trustStep = namedStepBlock(
+      linux,
+      "Trust exact checked-out workspace for container Git",
+    );
+    expectExactLine(
+      trustStep,
+      "          git config --global --unset-all safe.directory 2>/dev/null || true",
+    );
+    expectExactLine(
+      trustStep,
+      '          git config --global --add safe.directory "$GITHUB_WORKSPACE"',
+    );
+    expectExactLine(
+      trustStep,
+      '          [ "$(git config --get-all safe.directory)" = "$GITHUB_WORKSPACE" ] || {',
+    );
+    expectExactLine(
+      trustStep,
+      '          [ "$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)" = "$SOURCE_SHA" ]',
+    );
+    expect(trustStep.match(/safe\.directory/g)).toHaveLength(3);
+    expect(source).not.toMatch(/safe\.directory\s+["']?\*["']?/);
   });
 
   it("uses read-only defaults and isolates attestation and publish writes", () => {
@@ -247,7 +337,29 @@ describe("FyAgent release workflow", () => {
     expect(source).not.toContain("${{ secrets.");
     expect(source).not.toContain("signtool.exe sign");
 
-    expect(windowsManifestVerifier).toContain("mt.exe");
+    expect(windowsManifestVerifier).toContain("Resolve-WindowsSdkManifestTool");
+    expect(windowsManifestVerifier).toContain("ProgramFiles(x86)");
+    expect(windowsManifestVerifier).toContain("Windows Kits\\10\\bin");
+    expect(windowsManifestVerifier).toContain("[Version]::TryParse");
+    expect(windowsManifestVerifier).toContain(
+      "$sdkArchitecture = if ($TargetArchitecture -eq 'arm64') { 'arm64' } else { 'x64' }",
+    );
+    expect(windowsManifestVerifier).toContain('"$sdkArchitecture\\mt.exe"');
+    expect(windowsManifestVerifier).toContain(
+      "Sort-Object -Property @{ Expression = 'Version'; Descending = $true }",
+    );
+    expect(windowsManifestVerifier).toContain("Select-Object -First 1");
+    expect(windowsManifestVerifier).toContain(
+      'throw "Architecture-matched Windows SDK mt.exe was not found for $TargetArchitecture"',
+    );
+    expect(windowsManifestVerifier).toContain(
+      "$mtPath = Resolve-WindowsSdkManifestTool -TargetArchitecture $Architecture",
+    );
+    expect(windowsManifestVerifier).toContain(
+      '& $mtPath "-inputresource:$resolvedExe;#1" "-out:$manifestPath" -nologo',
+    );
+    expect(windowsManifestVerifier).not.toContain("Get-Command mt.exe");
+    expect(windowsManifestVerifier).not.toContain("& mt.exe");
     expect(windowsManifestVerifier).toContain("RT_MANIFEST");
     expect(windowsManifestVerifier).toContain("requireAdministrator");
     expect(windowsManifestVerifier).toContain("0xAA64");


### PR DESCRIPTION
## Summary

- establish the repository-pinned Node toolchain before pnpm installation on all native release jobs
- disable pnpm and Rust setup caches explicitly so formal builds do not inherit implicit Action defaults
- constrain Linux container Git trust to the one frozen workspace and immediately verify its source SHA
- resolve the architecture-matched Windows SDK Manifest Tool by absolute path instead of relying on PATH
- strengthen workflow contracts and regression coverage for these boundaries

## Why

Exact-main unsigned preflight run 31238817378 failed closed before publication:

- Linux x64: pnpm setup attempted to spawn npm before Node was installed
- Linux ARM64: Git rejected the mounted workspace as dubious ownership after checkout restored the container HOME
- Windows x64 and ARM64: application builds succeeded, but the manifest verifier could not find mt.exe on PATH

The macOS Universal target succeeded. Exact-asset aggregation, attestation, and publish were skipped, and no Release was created.

## Validation

- release contract suite: 14 files, 124 tests
- Native Fetch strict deprecation probe: 4 tests
- focused release workflow tests: 18 tests
- TypeScript typecheck and formatting checks
- actionlint 1.7.12
- PowerShell AST parser
- local Windows SDK resolver probes for x64 and ARM64
- Trellis task context validation
- independent diff review

## Release boundary

This change does not create or move a tag, publish a Release, change the exact ten installers, change the twelve attestation subjects, or weaken formal-only publication. A new exact-main full-matrix preflight remains required after merge.