### PR TITLE
fix(release): recover unsigned formal publication

### DIFF
--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -14,6 +14,7 @@ Note；合入来源和边界记录在
 
 ## FyAgent
 
+- [v0.3.3 (English)](v0.3.3-en.md)
 - [v0.3.2 (English)](v0.3.2-en.md)
 - [v0.3.1 unpublished candidate (English)](v0.3.1-en.md)
 - [v0.3.0 (中文)](v0.3.0-zh.md)

--- a/docs/release-notes/v0.3.3-en.md
+++ b/docs/release-notes/v0.3.3-en.md
@@ -1,0 +1,298 @@
+# FyAgent v0.3.3
+
+> [!IMPORTANT]
+> FyAgent remains under active development. Back up important configuration
+> before upgrading, and review the trust and verification boundaries below
+> before installing.
+>
+> The v0.3.3 publication contract requires exactly 14 non-empty attachments:
+> ten installers, three release-evidence JSON files, and one Sigstore bundle.
+> The workflow verifies that exact set before publication. This document does
+> not by itself claim that an independent post-publication re-download review
+> has been completed.
+
+> [!WARNING]
+> Do not infer Windows installer signing from the Release title or file name.
+> The formal workflow appends an evidence-backed signing table to the end of
+> these notes from the published `signing-status.json`.
+>
+> If an installer row reports `NotSigned`, expect Windows SmartScreen to warn
+> and do not treat the file as Authenticode-signed. If it reports a verified
+> signature, confirm the publisher and timestamp status in the appended table,
+> then inspect the published `signing-status.json` for the signer- and
+> timestamp-certificate evidence. Verify the SHA-256 digest, source SHA, and
+> attestation as well. Do not disable SmartScreen or weaken
+> organization-managed security policy.
+
+## Highlights
+
+- **Windows state follows the signed-in Explorer user:** FyAgent now freezes the
+  active Explorer Shell identity and its Profile, LocalAppData, and
+  RoamingAppData paths before user-owned application state is initialized.
+  When UAC is approved with a different administrator account, configuration,
+  database, logs, WebView data, Codex Desktop discovery, installation, restart,
+  and launch remain bound to the signed-in Explorer user instead of drifting
+  into the elevation account.
+- **Narrow current-user Codex Desktop installation helper:** the Windows bundle
+  now includes a separate `asInvoker` helper with no Tauri UI/runtime. It
+  accepts only one fixed current-user MSIX installation operation. The helper
+  does not accept an arbitrary executable, command, path, URI, host, package
+  source, bridge root, installer scope, or validation bypass.
+- **Protected local package bridge:** the elevated application verifies and pins
+  the accepted Codex Desktop MSIX, copies it into one immutable operation below
+  a fixed Windows CommonApplicationData bridge, authenticates the exact
+  Explorer-user helper, and admits installation only after both sides agree on
+  the pinned package identity. The stable bridge root permits authenticated
+  users to traverse it but not list or mutate it; each operation grants the
+  exact Explorer user only the minimum read/traverse access required by
+  current-user PackageManager.
+- **Windows installers move from MSI to NSIS:** v0.3.3 provides
+  architecture-specific x64 and ARM64 payloads in per-machine NSIS setup
+  executables built on matching native Windows runners. MSI, WiX, and portable
+  ZIP are no longer release formats. Setup and uninstall use the canonical
+  FyAgent icon, check both `fyagent.exe` and `fyagent-user-helper.exe`, ask
+  running processes to close normally, and never force-terminate them.
+- **Safer upgrade and uninstall ownership:** setup recognizes only the frozen
+  v0.3.0 MSI product identities during migration. Uninstall removes
+  installer-owned payloads, shortcuts, registration, the uninstaller, and
+  empty installer directories while preserving FyAgent databases,
+  configuration, OAuth state, backups, other user data, PackageBridge
+  operations, and unrelated files in a custom installation directory.
+- **Single-flight installer lifecycle:** installer start, normal application
+  exit, and restart now claim the same process-lifetime slot. A running,
+  cancellation-pending, or quarantined installation prevents a second job and
+  prevents a normal renderer-triggered exit or restart from invalidating the
+  active operation.
+- **More complete CI diagnostics:** pull requests and merge queues classify
+  changes by owned repository domain, unknown paths fail closed, and selected
+  checks retain independent outcome reporting before the stable
+  `CI / Required` aggregate decides the result. Pushes to the development
+  release branch continue to run the complete CI surface required for release
+  eligibility.
+- **Fail-closed release transaction:** preflight binds one exact development
+  branch SHA to its successful full push CI and builds without publishing.
+  Formal publication additionally binds the annotated tag, canonical version,
+  current `dev/laiyongjie` HEAD, trusted workflow, native build evidence,
+  signing state, exact attachments, and attestation before the workflow performs
+  its one draft-to-stable publication transaction.
+- **Current, responsibility-oriented documentation:** contributor setup now
+  uses the standalone `mise` workflow and maintained development documents.
+  Historical Trellis task material remains optional assistance rather than a
+  build, CI, contribution, or release prerequisite.
+
+## Windows current-user security boundary
+
+The Windows Codex Desktop path uses one immutable Shell-user context from
+startup through package discovery, installation/update, post-verification,
+restart, and launch. Package inventory is queried for that explicit user SID
+and accepts only the trusted Stable package identity. Zero matches means not
+installed; one trusted match is accepted; multiple trusted matches fail closed
+instead of selecting another user or package implicitly.
+
+The helper communication path uses a bounded, versioned protocol over one
+first-created local pipe. The parent authenticates the helper process, session,
+user SID, and pinned executable before sending one fixed bridge control. The
+helper independently verifies the bridge object and package identity, reports
+`Started`, and waits for explicit parent admission before it can call
+current-user `PackageManager.AddPackageByUriAsync`.
+
+Only a valid Windows terminal result, its matching authenticated terminal
+frame, and a clean pipe close permit normal bridge cleanup. A timeout, protocol
+failure, early exit, crash, ambiguous terminal state, or unclean close leaves
+the job quarantined and retains an immutable known-operation orphan for a later
+bounded elevated cleanup attempt. The installer does not enumerate, repair, or
+remove PackageBridge.
+
+The retired all-users deployment DTOs, headless/runas helper path,
+control/job-file interface, Stage and Provision operations, HTTP/network
+package sources, Temp/cwd/install-root package fallbacks, and arbitrary
+path/URI inputs are not part of the shipped path.
+
+## Windows installer behavior
+
+Interactive directory selection and silent `/D=` installation use standard
+NSIS and Windows handling. FyAgent does not impose an additional custom
+absolute/fixed/local/UNC/reparse/drive-type, ACL-owner, or protected-folder
+admission rule on the selected directory. Malformed input can still be rejected
+by NSIS or Windows, and an actual filesystem or registration write can still
+fail.
+
+Before installation, update, maintenance, migration, or uninstall mutates
+payloads, setup checks the main application and the fixed helper. Interactive
+mode offers Retry or Cancel after asking the user to close them normally;
+silent and passive modes abort while either process is running.
+
+The former `%ProgramData%\FyAgent\runtime` is no longer created, repaired, or
+required. Cleanup is best-effort and limited to exact known legacy names opened
+through held native handles. Unknown, inaccessible, reparse, malformed,
+non-empty, or changing content is preserved.
+
+## Release engineering fixes
+
+- The formal unsigned Windows transform now normalizes empty environment entries
+  so explicit unsigned mode proceeds while provider configuration validation
+  remains fail-closed.
+- The isolated release version contract now includes the current-user helper
+  manifest instead of failing when it validates the complete Cargo workspace.
+- The NSIS process-safety macro is defined before its first expansion, fixing
+  native x64 and ARM64 MakeNSIS compilation.
+- Windows native tests use isolated staging identities and bounded retry
+  behavior for transient file replacement, while preserving the original
+  failure when retry eligibility is not met.
+- CI outcome collection reports the selected domain failures through the final
+  aggregate instead of treating the first failing diagnostic as the complete
+  result.
+
+## Download and trust guidance
+
+### Windows
+
+Choose the setup executable matching the machine architecture:
+
+```text
+FyAgent-0.3.3-Windows-x64-setup.exe
+FyAgent-0.3.3-Windows-arm64-setup.exe
+```
+
+Read the **Windows installer signing status** table appended to these notes and
+verify the matching `signing-status.json`, SHA-256 digest, source SHA, and
+attestation before installing.
+
+### macOS
+
+Choose the DMG or ZIP; both contain the Universal application:
+
+```text
+FyAgent-0.3.3-macOS.dmg
+FyAgent-0.3.3-macOS.zip
+```
+
+The universal app is ad-hoc signed with no certificate identity and that
+signature is verified before packaging. It is not signed with an Apple
+Developer ID and is not notarized. The DMG container is unsigned. Gatekeeper
+may therefore block the first launch.
+
+After first attempting to open FyAgent, use the supported **System Settings →
+Privacy & Security → Open Anyway** flow and confirm only after checking the
+Release evidence. Do not disable Gatekeeper or remove quarantine metadata.
+
+### Linux
+
+Choose the architecture and package format matching the host:
+
+```text
+FyAgent-0.3.3-Linux-x86_64.AppImage
+FyAgent-0.3.3-Linux-x86_64.deb
+FyAgent-0.3.3-Linux-x86_64.rpm
+FyAgent-0.3.3-Linux-arm64.AppImage
+FyAgent-0.3.3-Linux-arm64.deb
+FyAgent-0.3.3-Linux-arm64.rpm
+```
+
+Flatpak remains a local diagnostic conversion and is not a formal v0.3.3
+installer.
+
+## Exact Release attachment contract
+
+The formal Release must contain exactly these ten installer assets:
+
+```text
+FyAgent-0.3.3-macOS.dmg
+FyAgent-0.3.3-macOS.zip
+FyAgent-0.3.3-Windows-x64-setup.exe
+FyAgent-0.3.3-Windows-arm64-setup.exe
+FyAgent-0.3.3-Linux-x86_64.AppImage
+FyAgent-0.3.3-Linux-x86_64.deb
+FyAgent-0.3.3-Linux-x86_64.rpm
+FyAgent-0.3.3-Linux-arm64.AppImage
+FyAgent-0.3.3-Linux-arm64.deb
+FyAgent-0.3.3-Linux-arm64.rpm
+```
+
+It must also contain exactly these four evidence attachments:
+
+```text
+download-manifest.json
+build-metadata.json
+signing-status.json
+artifact-attestation.sigstore.json
+```
+
+That is 14 attachments total. The attestation has 13 subjects: the ten
+installers plus `download-manifest.json`, `build-metadata.json`, and
+`signing-status.json`. The copied Sigstore bundle is the fourteenth attachment
+and does not attest itself. A missing, duplicate, renamed, empty, stale, or
+extra attachment blocks publication.
+
+## Compatibility and upgrade notes
+
+- The database schema remains at version 16. This release introduces no database
+  schema or user-data migration.
+- Existing provider, settings, Skills, backup, `fyagent://v1/import`, and
+  third-party `/v1` contracts remain owned by their current implementation.
+- The minimum supported Windows version is unchanged.
+- Windows distribution changes from MSI to architecture-specific NSIS setup
+  executables. The known v0.3.0 MSI product is removed synchronously before the
+  new payload is written; unexpected migration results abort rather than
+  continuing with a partially replaced installation.
+- Important configuration should still be backed up before any application
+  upgrade.
+
+See the
+[installation guide](https://github.com/fy-agent/fyagent/blob/v0.3.3/docs/user-manual/en/1-getting-started/1.2-installation.md)
+for platform-specific installation steps.
+
+## Known verification and security boundaries
+
+- **No Windows HIL was run for this delivery.** The available evidence covers
+  executable contracts, portable tests, Windows-target compilation, native
+  x64/ARM64 build and packaging, signing or unsigned proof, exact-asset
+  verification, and review. It does not prove setup/uninstall behavior,
+  Explorer/UAC token handling, WebView2 user-data paths, Windows registry
+  behavior, PackageManager file-URI behavior, effective ACL enforcement or
+  mutation denial, terminal cleanup, or orphan recovery on a real Windows 10/11
+  x64 or ARM64 machine.
+- The current-user helper is not a protected process. Code already running as
+  the same Shell user can attempt memory, handle, or process manipulation within
+  that user's existing PackageManager authority. Resisting that attacker would
+  require a separately designed trusted broker or service.
+- Administrator force-termination, process crashes, and operating-system
+  shutdown are not durable terminal proof. They can leave an immutable
+  PackageBridge operation orphan for a later elevated application cleanup.
+- The NSIS process lookup is a point-in-time safety check, not an atomic
+  interlock against a new process launch immediately before filesystem
+  mutation. Setup never force-terminates FyAgent or its helper.
+- A `NotSigned` Windows result can trigger SmartScreen warnings. SHA-256,
+  source-SHA binding, and attestation provide integrity and provenance evidence
+  but are not a substitute for Authenticode publisher trust.
+- The macOS application has only an identity-free ad-hoc signature; the DMG is
+  unsigned, and neither is Developer ID signed or notarized.
+- Trellis remains optional contributor tooling. This release removes FyAgent's
+  former custom hook-hardening overlay and retains the upstream Trellis 0.6.14
+  hooks as-is; those hooks must not be treated as equivalent to the former
+  containment checks.
+- The release workflow provides exact-source, native-build, attachment, signing,
+  and attestation gates. This Release does not claim independent
+  post-publication re-download verification, administrator-enforced repository
+  rulesets, or a separate Main Provenance attestation.
+
+## Version provenance
+
+The existing annotated `v0.3.1` tag remains an unpublished historical candidate
+at its original commit. The annotated `v0.3.2` tag likewise remains at its
+original commit after its formal workflow failed before publication. Neither
+tag was moved, deleted, or reused. FyAgent v0.3.3 is the recovery publication
+of the Windows current-user runtime, NSIS installer, CI, release, tooling, and
+documentation changes described above.
+
+## Source and licensing
+
+FyAgent-owned components and modifications remain under the repository's
+published PolyForm Noncommercial terms. Upstream-derived material retains its
+original notices and license ancestry.
+
+See
+[LICENSE](https://github.com/fy-agent/fyagent/blob/v0.3.3/LICENSE),
+[LICENSING.md](https://github.com/fy-agent/fyagent/blob/v0.3.3/LICENSING.md),
+and
+[THIRD_PARTY_NOTICES.md](https://github.com/fy-agent/fyagent/blob/v0.3.3/THIRD_PARTY_NOTICES.md).

--- a/scripts/release/windows-signing.mjs
+++ b/scripts/release/windows-signing.mjs
@@ -149,8 +149,12 @@ export function resolveSignerConfiguration(environment) {
     SIGNING_MODE_NAME,
   );
   const mode = environment[SIGNING_MODE_NAME];
-  const supplied = SIGNER_CONFIGURATION_NAMES.filter((name) =>
-    Object.prototype.hasOwnProperty.call(environment, name),
+  // Windows can preserve a cleared process variable as an empty child entry.
+  // Provider mode still validates every required own key below.
+  const supplied = SIGNER_CONFIGURATION_NAMES.filter(
+    (name) =>
+      Object.prototype.hasOwnProperty.call(environment, name) &&
+      environment[name] !== "",
   );
 
   if (!hasMode) {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1777,7 +1777,7 @@ dependencies = [
 
 [[package]]
 name = "fyagent"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1855,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "fyagent-user-helper"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "embed-resource",
  "windows",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "user-helper"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3"
 
 [package]
 name = "fyagent"

--- a/tests/releaseWorkflow.test.ts
+++ b/tests/releaseWorkflow.test.ts
@@ -1392,13 +1392,27 @@ describe("FyAgent release workflow", () => {
     expect(transform).toContain(
       "SIGNING_MODE_CONFIG: ${{ vars.FYAGENT_WINDOWS_SIGNING_MODE }}",
     );
-    expect(transform).toContain("$hasProviderConfig");
+    expect(transform).toContain(
+      "$providerConfig | Where-Object { $_ -cne '' }",
+    );
+    expect(transform.match(/if \(\$hasProviderConfig\)/gu)).toHaveLength(2);
+    expect(transform).toContain(
+      "$requiredProviderConfig | Where-Object { $_ -ceq '' }",
+    );
+    expect(transform).toContain(
+      "if ([string]$env:SIGNER_CREDENTIAL_CONFIG -cne '')",
+    );
     expect(transform).toContain("$stagingSignerEnvironment");
     expect(transform).toContain("$managedSignerEnvironment");
     expect(transform).toContain(
       "@($managedSignerEnvironment + $stagingSignerEnvironment)",
     );
     expect(transform).toContain("[IO.File]::Delete($adapterPath)");
+    expect(
+      transform.indexOf("foreach ($name in $stagingSignerEnvironment)"),
+    ).toBeLessThan(
+      transform.indexOf("node scripts/release/windows-signing.mjs transform"),
+    );
     expect(transform.slice(transform.indexOf("run: |"))).not.toContain(
       "${{ secrets.",
     );

--- a/tests/windowsSigningAdapter.test.ts
+++ b/tests/windowsSigningAdapter.test.ts
@@ -248,10 +248,19 @@ describe("Windows signing adapter configuration", () => {
     expect(ATTESTATION_BUNDLE_NAME).toBe("artifact-attestation.sigstore.json");
   });
 
-  it("selects unsigned mode only when the provider selector and inputs are absent", () => {
+  it("selects unsigned mode when provider inputs are absent or cleared", () => {
     expect(resolveSignerConfiguration({})).toBeNull();
     expect(
       resolveSignerConfiguration({ FYAGENT_WINDOWS_SIGNING_MODE: "unsigned" }),
+    ).toBeNull();
+    expect(
+      resolveSignerConfiguration({
+        FYAGENT_WINDOWS_SIGNING_MODE: "unsigned",
+        FYAGENT_WINDOWS_SIGNER_ADAPTER: "",
+        FYAGENT_WINDOWS_SIGN_EXPECTED_PUBLISHER: "",
+        FYAGENT_WINDOWS_SIGN_EXPECTED_CERTIFICATE_SHA256: "",
+        FYAGENT_WINDOWS_SIGNER_CREDENTIAL: "",
+      }),
     ).toBeNull();
     expect(() =>
       resolveSignerConfiguration({
@@ -554,6 +563,38 @@ describe("Windows signing asset evidence", () => {
     expect(
       parsePeImage(readFileSync(assetPath)).certificateSize,
     ).toBeGreaterThan(0);
+  });
+
+  it("keeps an explicitly unsigned formal candidate unchanged after Windows clears provider keys", () => {
+    const directory = temporaryDirectory();
+    const assetPath = writeAsset(directory, "x64");
+    const originalBytes = readFileSync(assetPath);
+    let signerCount = 0;
+
+    transformWindowsCandidate(
+      {
+        assetPath,
+        architecture: "x64",
+        version,
+        sourceSha,
+        environment: {
+          FYAGENT_WINDOWS_SIGNING_MODE: "unsigned",
+          FYAGENT_WINDOWS_SIGNER_ADAPTER: "",
+          FYAGENT_WINDOWS_SIGN_EXPECTED_PUBLISHER: "",
+          FYAGENT_WINDOWS_SIGN_EXPECTED_CERTIFICATE_SHA256: "",
+          FYAGENT_WINDOWS_SIGNER_CREDENTIAL: "",
+        },
+      },
+      {
+        probeAuthenticode: () => unsignedEvidence(),
+        invokeSigner: () => {
+          signerCount += 1;
+        },
+      },
+    );
+
+    expect(signerCount).toBe(0);
+    expect(readFileSync(assetPath)).toEqual(originalBytes);
   });
 
   it("rejects command failure and Authenticode-only byte violations", () => {


### PR DESCRIPTION
## Summary

- normalize Windows-empty signer environment entries in explicit unsigned formal mode while keeping provider validation fail-closed
- add resolver, transform, and workflow regression coverage
- prepare the immutable recovery release as v0.3.3 without moving or reusing the failed v0.3.2 tag

## Validation

- `mise run release:check` (571 release contract tests and 4 native-fetch tests passed)
- focused release/version/signing tests: 149 passed
- `mise run version:check -- --tag v0.3.3`
- `git diff --check`

## Release boundary

The annotated v0.3.2 tag remains unchanged. Formal publication will use a new annotated v0.3.3 tag after the exact merged SHA satisfies the development-branch release gates.