### PR TITLE
fix(release): prepare v0.3.4 recovery publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
     inputs:
       source_sha:
-        description: Immutable 40-character dev/laiyongjie HEAD SHA to preflight
+        description: Immutable 40-character main HEAD SHA to preflight
         required: true
         type: string
 
@@ -65,13 +65,13 @@ jobs:
               }
               if [ "$DISPATCH_SOURCE_SHA" != "$GITHUB_SHA" ] ||
                 [ "$DISPATCH_SOURCE_SHA" != "$GITHUB_WORKFLOW_SHA" ]; then
-                echo 'Preflight must attest the exact trusted dev workflow commit' >&2
+                echo 'Preflight must attest the exact trusted main workflow commit' >&2
                 exit 1
               fi
-              [ "$GITHUB_REF" = 'refs/heads/dev/laiyongjie' ]
+              [ "$GITHUB_REF" = 'refs/heads/main' ]
               [ "$GITHUB_REF_TYPE" = 'branch' ]
-              [ "$GITHUB_REF_NAME" = 'dev/laiyongjie' ]
-              [ "$GITHUB_WORKFLOW_REF" = "${expected_workflow_ref_prefix}refs/heads/dev/laiyongjie" ]
+              [ "$GITHUB_REF_NAME" = 'main' ]
+              [ "$GITHUB_WORKFLOW_REF" = "${expected_workflow_ref_prefix}refs/heads/main" ]
               requested_source_sha="$DISPATCH_SOURCE_SHA"
               requested_mode='preflight'
               ;;
@@ -156,20 +156,20 @@ jobs:
                 echo 'workflow_dispatch source_sha must be a lowercase full 40-character commit SHA' >&2
                 exit 1
               }
-              [ "$GITHUB_REF" = 'refs/heads/dev/laiyongjie' ] || {
-                echo "Preflight must run from trusted refs/heads/dev/laiyongjie; received $GITHUB_REF" >&2
+              [ "$GITHUB_REF" = 'refs/heads/main' ] || {
+                echo "Preflight must run from trusted refs/heads/main; received $GITHUB_REF" >&2
                 exit 1
               }
-              [ "$GITHUB_WORKFLOW_REF" = "${expected_workflow_ref_prefix}refs/heads/dev/laiyongjie" ] || {
-                echo "Preflight workflow ref is not trusted dev/laiyongjie: $GITHUB_WORKFLOW_REF" >&2
+              [ "$GITHUB_WORKFLOW_REF" = "${expected_workflow_ref_prefix}refs/heads/main" ] || {
+                echo "Preflight workflow ref is not trusted main: $GITHUB_WORKFLOW_REF" >&2
                 exit 1
               }
               [ "$source_sha" = "$DISPATCH_SOURCE_SHA" ] || {
                 echo "Dispatch input does not resolve to the exact candidate commit: $DISPATCH_SOURCE_SHA" >&2
                 exit 1
               }
-              if [ "$GITHUB_REF_TYPE" != 'branch' ] || [ "$GITHUB_REF_NAME" != 'dev/laiyongjie' ]; then
-                echo 'Preflight event is not the exact dev/laiyongjie branch' >&2
+              if [ "$GITHUB_REF_TYPE" != 'branch' ] || [ "$GITHUB_REF_NAME" != 'main' ]; then
+                echo 'Preflight event is not the exact main branch' >&2
                 exit 1
               fi
               release_mode='preflight'
@@ -232,7 +232,7 @@ jobs:
             printf 'generated_at=%s\n' "$(date -u +'%Y-%m-%dT%H:%M:%S.000Z')"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Bind remote dev, tag, and successful Required CI evidence
+      - name: Bind remote main, tag, and successful Required CI evidence
         id: remote
         shell: bash
         env:
@@ -1426,7 +1426,10 @@ jobs:
           scripts/release/verify-macos-adhoc-app.sh "$unzip_root/FyAgent.app"
 
           ditto "$APP_PATH" "$stage/FyAgent.app"
-          hdiutil create -volname 'FyAgent' -srcfolder "$stage" -ov -format UDZO "$dmg_path"
+          scripts/release/retry-hdiutil.sh \
+            "$dmg_path" \
+            -- \
+            create -volname 'FyAgent' -srcfolder "$stage" -ov -format UDZO "$dmg_path"
           hdiutil verify "$dmg_path"
           mounted=true
           hdiutil attach "$dmg_path" -readonly -nobrowse -noautoopen -mountpoint "$mount_point"
@@ -1762,7 +1765,7 @@ jobs:
         with:
           node-version-file: .node-version
 
-      - name: Revalidate frozen dev release eligibility at publish start
+      - name: Revalidate frozen main release eligibility at publish start
         shell: bash
         env:
           RELEASE_APP_VERSION: ${{ needs.eligibility.outputs.app_version }}

--- a/.trellis/spec/backend/fyagent-version-contract.md
+++ b/.trellis/spec/backend/fyagent-version-contract.md
@@ -102,17 +102,16 @@ app_version = canonical Cargo version
 release_tag = "v" + app_version
 source_sha  = lowercase full Git commit SHA
 release_mode = preflight | formal
-ci_run_id / ci_run_attempt = exact successful dev push CI attempt
+ci_run_id / ci_run_attempt = exact successful main push CI attempt
 ```
 
 Every platform, evidence, attestation, and publication step consumes those
 outputs unchanged. A downstream step must not trim `GITHUB_REF_NAME`, reread a
 different version field, substitute another source SHA, or select another CI
-attempt. Both modes require the source to equal the live remote
-`dev/laiyongjie` HEAD and bind the same successful `.github/workflows/ci.yml`
-push attempt. Formal mode additionally requires an annotated `vX.Y.Z` tag
-whose target is that exact commit; preflight is the dev-branch workflow at the
-same commit and cannot publish.
+attempt. Both modes require the source to equal the live remote `main` HEAD and
+bind the same successful `.github/workflows/ci.yml` push attempt. Formal mode
+additionally requires an annotated `vX.Y.Z` tag whose target is that exact
+commit; preflight is the `main` workflow at the same commit and cannot publish.
 
 The installer allowlist contains exactly ten versioned files:
 
@@ -184,7 +183,7 @@ attachment and does not attest itself.
   missing/extra/non-allowlisted/symlink rejection.
 - Release tests assert frozen output consumption and that the download,
   build, signing, attestation, and publication stages use the same version,
-  source SHA, CI run, and attempt. They cover dev-branch movement, annotated
+  source SHA, CI run, and attempt. They cover `main` movement, annotated
   versus lightweight tags, and exact frozen rechecks before publication.
 - Windows release tests accept `65535`, reject `65536`, and use an integer path
   that also rejects values beyond JavaScript's safe-number range without

--- a/.trellis/spec/backend/github-release-workflow.md
+++ b/.trellis/spec/backend/github-release-workflow.md
@@ -31,16 +31,19 @@ The YAML tag filter is only routing. The repository-owned eligibility engine
 accepts exactly stable `vX.Y.Z` with no prerelease, build metadata, missing
 component, or leading zero.
 
-- `workflow_dispatch` is a full five-target preflight for the current trusted
-  `dev/laiyongjie` HEAD. It may build and package native targets, prove and
-  seal Windows bytes, create workflow artifacts, and attest candidate bytes,
-  but it can never create or update a GitHub Release.
+- `workflow_dispatch` is an optional full five-target diagnostic preflight for
+  the current trusted `main` HEAD. It may build and package native targets,
+  prove and seal Windows bytes, create workflow artifacts, and attest candidate
+  bytes, but it can never create or update a GitHub Release and is not a
+  release-closure prerequisite.
 - a tag `push` is the only formal publication path. The remote tag must be an
-  annotated tag whose target commit equals the current remote
-  `dev/laiyongjie` HEAD and the exact successful full push CI source.
-- neither mode reads release authority from `main`, branch protection, a
-  ruleset, merge settings, or a Main Provenance workflow. This project does
-  not claim that those administrator controls exist.
+  annotated tag whose target commit equals the current remote `main` HEAD and
+  the exact successful full push CI source.
+- `main` is the release-authority branch. Runtime eligibility proves its live
+  remote HEAD and exact-source CI directly; it does not infer those facts from
+  branch protection, a ruleset, merge settings, or a separate provenance
+  workflow, and this project does not claim that those administrator controls
+  exist.
 - no branch push, manual signed mode, manual tag dispatch, partial target mode,
   cross-architecture substitute, local publish path, or update-in-place path
   exists.
@@ -55,10 +58,10 @@ Eligibility is the sole producer of these values:
 ```text
 app_version   = canonical Cargo stable version
 release_tag   = "v" + app_version
-source_sha    = current remote dev/laiyongjie HEAD
+source_sha    = current remote main HEAD
 workflow_sha  = source_sha
 release_mode  = preflight | formal
-ci_run_id     = exact successful dev push CI run
+ci_run_id     = exact successful main push CI run
 ci_attempt    = exact successful attempt of that run
 ```
 
@@ -67,9 +70,10 @@ attestation, and publication step consumes these values unchanged. Downstream
 jobs must not strip a ref, reread a second version source, select a newer CI
 attempt, or substitute a different source/workflow SHA.
 
-Both modes bind the same exact successful dev push CI. Preflight is therefore
-evidence for the same source that may later be tagged; it is not an unbound
-manual diagnostic. Formal mode additionally binds the remote annotated tag.
+Both modes bind the same exact successful `main` push CI. Preflight is an
+optional diagnostic for the same source that may later be tagged, not release
+authority or a closure gate. Formal mode additionally binds the remote
+annotated tag.
 
 The frozen output has exact keys:
 
@@ -102,9 +106,9 @@ Eligibility fails closed unless all of these facts agree:
 2. the workflow is `Release` at `.github/workflows/release.yml` and its
    workflow SHA equals the candidate source;
 3. the canonical version is stable `X.Y.Z` and the tag is exactly `vX.Y.Z`;
-4. the live `refs/heads/dev/laiyongjie` target equals candidate, event,
-   workflow, and checkout source SHA;
-5. preflight event/ref/workflow ref are the dev branch and its explicit
+4. the live `refs/heads/main` target equals candidate, event, workflow, and
+   checkout source SHA;
+5. preflight event/ref/workflow ref are the `main` branch and its explicit
    `source_sha` input equals the frozen source; remote tag evidence is absent;
 6. formal event/ref/workflow ref are the same version tag, the remote ref
    points to a Git `tag` object rather than directly to a commit, the annotated
@@ -112,7 +116,7 @@ Eligibility fails closed unless all of these facts agree:
 7. the CI workflow belongs to the same repository, is active, is named `CI`,
    and has path `.github/workflows/ci.yml`;
 8. among exact-source `push` runs whose head repository is the same repository
-   and whose head branch is `dev/laiyongjie`, the latest run number/attempt is
+   and whose head branch is `main`, the latest run number/attempt is
    completed successfully; an older green run cannot mask a later failed,
    cancelled, timed-out, or running attempt;
 9. the selected attempt contains exactly one completed/successful
@@ -299,7 +303,14 @@ re-evaluated when the locked Tauri CLI/bundler changes.
   Developer ID or Apple trust;
 - the DMG container itself must remain truly unsigned. ZIP and DMG package the
   same verified ad-hoc-sealed app and are re-opened to prove version and
-  executable digest identity.
+  executable digest identity;
+- DMG creation removes its explicit output before the first attempt and after
+  every failed attempt. It retries the same `hdiutil create` arguments only
+  when the captured diagnostic contains `Resource busy`, with at most five
+  attempts and `2`, `4`, `8`, and `16` second delays. Any other diagnostic, an
+  exhausted retry budget, or inability to remove partial output returns the
+  original `hdiutil` status immediately. The workflow does not pipe `hdiutil`,
+  force-detach images, or kill disk-image helpers.
 
 ### Linux
 
@@ -394,23 +405,23 @@ never called private or successful.
 
 ## 9. Failure matrix
 
-| Condition                                                                                                                  | Required result                                              |
-| -------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| Candidate/version/tag/event/workflow/dev HEAD differs                                                                      | Fail before native builds.                                   |
-| Repository name is a former owner or redirect alias, even when numeric ID is unchanged                                     | Fail before native builds; require exact `fy-agent/fyagent`. |
-| Formal tag is lightweight, points elsewhere, or changes                                                                    | Fail; never repair or move the tag.                          |
-| Exact-source dev CI is absent/running/failed/cancelled/timed out, stale, wrong identity, or lacks unique Required evidence | Fail; never accept an older green commit/attempt.            |
-| Preflight reaches a publish path or provider secret                                                                        | Static/remote gate fails.                                    |
-| Native runner, architecture, toolchain, Linux digest/OS, or source drifts                                                  | Fail that target; no fallback.                               |
-| Pinned build input ID/digest/manifest/file set drifts                                                                      | Fail before provider or trusted consumption.                 |
-| Signer configuration is partial/invalid or fresh signature proof fails                                                     | Fail; do not downgrade to unsigned.                          |
-| Windows proof/sealed binding, macOS identity, or Linux package set fails                                                   | Stop aggregation and publication.                            |
-| An intentional producer skip propagates past successful asset verification                                                 | Attestation still runs; abnormal direct needs fail visibly.  |
-| Ten/thirteen/fourteen file allowlist or digest differs                                                                     | Stop verification, attestation, or publication.              |
-| Live dev/tag/CI identity changes during the transaction                                                                    | Stop before creating the draft or before final PATCH.        |
-| A draft/published Release already exists                                                                                   | Refuse update, replacement, or deletion.                     |
-| Upload/re-download/pre-PATCH verification fails                                                                            | Leave draft untouched and report it.                         |
-| Final PATCH is failed or ambiguous                                                                                         | Observe once; do not retry/delete or claim completion.       |
+| Condition                                                                                                                   | Required result                                              |
+| --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| Candidate/version/tag/event/workflow/main HEAD differs                                                                      | Fail before native builds.                                   |
+| Repository name is a former owner or redirect alias, even when numeric ID is unchanged                                      | Fail before native builds; require exact `fy-agent/fyagent`. |
+| Formal tag is lightweight, points elsewhere, or changes                                                                     | Fail; never repair or move the tag.                          |
+| Exact-source main CI is absent/running/failed/cancelled/timed out, stale, wrong identity, or lacks unique Required evidence | Fail; never accept an older green commit/attempt.            |
+| Preflight reaches a publish path or provider secret                                                                         | Static/remote gate fails.                                    |
+| Native runner, architecture, toolchain, Linux digest/OS, or source drifts                                                   | Fail that target; no fallback.                               |
+| Pinned build input ID/digest/manifest/file set drifts                                                                       | Fail before provider or trusted consumption.                 |
+| Signer configuration is partial/invalid or fresh signature proof fails                                                      | Fail; do not downgrade to unsigned.                          |
+| Windows proof/sealed binding, macOS identity, or Linux package set fails                                                    | Stop aggregation and publication.                            |
+| An intentional producer skip propagates past successful asset verification                                                  | Attestation still runs; abnormal direct needs fail visibly.  |
+| Ten/thirteen/fourteen file allowlist or digest differs                                                                      | Stop verification, attestation, or publication.              |
+| Live main/tag/CI identity changes during the transaction                                                                    | Stop before creating the draft or before final PATCH.        |
+| A draft/published Release already exists                                                                                    | Refuse update, replacement, or deletion.                     |
+| Upload/re-download/pre-PATCH verification fails                                                                             | Leave draft untouched and report it.                         |
+| Final PATCH is failed or ambiguous                                                                                          | Observe once; do not retry/delete or claim completion.       |
 
 ## 10. Validation and evidence boundary
 
@@ -430,17 +441,20 @@ architecture, GitHub attestation, or public Release evidence. The manual
 Windows install lifecycle is diagnostic evidence outside this Release
 closure. Closure requires, in order:
 
-1. one unified work push whose current dev HEAD completes full
-   `CI / Required`;
-2. a successful same-SHA dispatch preflight;
-3. an annotated stable tag at that SHA and successful formal workflow;
-4. a public, non-prerelease, Latest Release with exact assets, disclosure,
+1. the release change is merged to `main`, and that exact current remote HEAD
+   completes `CI / Required` successfully;
+2. an annotated stable tag is created directly at that SHA and its single
+   formal build workflow succeeds;
+3. a public, non-prerelease, Latest Release has exact assets, disclosure,
    digests, metadata, and attestation;
-5. any later optional bookkeeping push is a new dev HEAD and must satisfy its
-   own CI requirements; it is not part of the release transaction.
+4. any later optional bookkeeping push is a new `main` HEAD and must satisfy
+   its own CI requirements; it is not part of the release transaction.
+
+A same-SHA dispatch preflight may be run for diagnosis, but closure neither
+requires nor infers success from it.
 
 `windows-11-arm` remains public preview and may block the run. Unsigned Windows
 installers may trigger trust prompts; disclosure, SHA-256, and attestation make
 the origin auditable but are not equivalent to Authenticode. The repository's
-unprotected `main` and lack of Main Provenance remain accepted out-of-scope
-risks and are not represented as release guarantees.
+administrative branch-protection and provenance-workflow settings remain
+outside runtime eligibility and are not represented as release guarantees.

--- a/docs/fyagent/development/ci-release/release.md
+++ b/docs/fyagent/development/ci-release/release.md
@@ -9,21 +9,23 @@ notes under `.trellis/spec/` are optional AI-assistance review material.
 ## Exact-source progression
 
 ```text
-current remote development-branch HEAD
+merge into main
+  -> current remote main HEAD
   -> successful full push CI for that exact SHA
-  -> same-SHA dispatch preflight, never publication
-  -> frozen branch state
   -> annotated stable tag targeting that exact SHA
-  -> formal native build and evidence workflow
+  -> one formal native build and evidence workflow
   -> private draft upload and re-download verification
   -> one final publication transition
 ```
 
-Both preflight and formal mode require the same current development-branch
-source and successful push-CI evidence. Dispatch can build and verify candidate
-assets but its publication condition is always false. A formal run refuses a
-lightweight tag, a moved branch, stale green CI, identity mismatch, partial
-signer configuration, incomplete native evidence, or asset drift.
+Formal mode requires the current remote `main` source and successful push-CI
+evidence for that exact SHA. A same-SHA dispatch preflight remains available as
+an optional diagnostic, but it is not a release-closure prerequisite and its
+publication condition is always false. The shortest authoritative path is
+therefore `main` merge -> exact-SHA `CI / Required` success -> annotated tag ->
+one formal build. A formal run refuses a lightweight tag, a moved `main`, stale
+green CI, identity mismatch, partial signer configuration, incomplete native
+evidence, or asset drift.
 
 Platform acceptance is successful build and packaging on each matching native
 runner. Windows additionally requires strict unsigned/signing proof and the

--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -14,6 +14,7 @@ Note；合入来源和边界记录在
 
 ## FyAgent
 
+- [v0.3.4 (English)](v0.3.4-en.md)
 - [v0.3.3 (English)](v0.3.3-en.md)
 - [v0.3.2 (English)](v0.3.2-en.md)
 - [v0.3.1 unpublished candidate (English)](v0.3.1-en.md)

--- a/docs/release-notes/v0.3.4-en.md
+++ b/docs/release-notes/v0.3.4-en.md
@@ -1,0 +1,217 @@
+# FyAgent v0.3.4
+
+> [!IMPORTANT]
+> FyAgent remains under active development. Back up important configuration
+> before upgrading, and review the trust and verification boundaries below
+> before installing.
+>
+> The v0.3.4 publication contract requires exactly 14 non-empty attachments:
+> ten installers, three release-evidence JSON files, and one Sigstore bundle.
+> The workflow verifies that exact set before publication. This document does
+> not by itself claim that an independent post-publication re-download review
+> has been completed.
+
+> [!WARNING]
+> Do not infer Windows installer signing from the Release title or file name.
+> The formal workflow appends an evidence-backed signing table to the end of
+> these notes from the published `signing-status.json`.
+>
+> If an installer row reports `NotSigned`, expect Windows SmartScreen to warn
+> and do not treat the file as Authenticode-signed. If it reports a verified
+> signature, confirm the publisher and timestamp status in the appended table,
+> then inspect `signing-status.json` for the signer- and timestamp-certificate
+> evidence. Verify the SHA-256 digest, source SHA, and attestation as well. Do
+> not disable SmartScreen or weaken organization-managed security policy.
+
+## Highlights
+
+- **Windows state follows the signed-in Explorer user:** FyAgent freezes the
+  active Explorer Shell identity and its Profile, LocalAppData, and
+  RoamingAppData paths before user-owned application state is initialized.
+  Approving UAC with a different administrator account no longer redirects
+  configuration, database, logs, WebView data, Codex Desktop installation,
+  restart, or launch into the elevation account.
+- **Protected current-user Codex Desktop installation:** the elevated
+  application verifies and pins the accepted MSIX, copies it into an immutable
+  operation below a fixed Windows CommonApplicationData bridge, authenticates
+  the exact `asInvoker` helper, and admits current-user PackageManager only
+  after both sides agree on package identity.
+- **Architecture-specific Windows NSIS installers:** v0.3.4 provides x64 and
+  ARM64 payloads in per-machine setup executables built on matching native
+  Windows runners. MSI, WiX, and portable ZIP are not release formats. Setup
+  and uninstall check both FyAgent processes and never force-terminate them.
+- **Single-flight lifecycle and bounded cleanup:** installation, exit, and
+  restart share one process-lifetime claim. Unknown post-admission state is
+  quarantined; normal cleanup requires a valid terminal result, its matching
+  authenticated terminal frame, and a clean pipe close.
+- **Main-bound release authority:** formal publication binds the annotated tag,
+  canonical version, current remote `main` HEAD, and that exact SHA's successful
+  `CI / Required` push result. A manual preflight remains optional and cannot
+  publish; it is not required before the single formal native build.
+- **Resilient macOS packaging:** the DMG creator now retries only the exact
+  transient `hdiutil` `Resource busy` condition with a short, fixed bound.
+  Unrelated errors still fail immediately, and all existing DMG verification,
+  read-only remount, app digest, ad-hoc signature, and unsigned-container gates
+  remain mandatory.
+
+## Windows current-user security boundary
+
+The helper accepts one fixed current-user MSIX installation operation. It does
+not accept an arbitrary executable, command, path, URI, host, package source,
+bridge root, installer scope, or validation bypass. The parent authenticates
+the helper process, session, user SID, and pinned executable before sending one
+bounded bridge control. The helper independently verifies the bridge object and
+package identity before waiting for explicit admission.
+
+The retired all-users deployment DTOs, headless/runas helper path,
+control/job-file interface, Stage and Provision operations, HTTP/network
+package sources, Temp/cwd/install-root package fallbacks, and arbitrary
+path/URI inputs are not part of the shipped path.
+
+Interactive directory selection and silent `/D=` installation use standard
+NSIS and Windows handling. Before setup, maintenance, migration, or uninstall
+mutates payloads, it asks the user to close `fyagent.exe` and
+`fyagent-user-helper.exe`; silent and passive modes abort while either process
+is running. Uninstall preserves FyAgent databases, configuration, OAuth state,
+backups, other user data, PackageBridge operations, and unrelated files in a
+custom installation directory.
+
+## Download and trust guidance
+
+### Windows
+
+Choose the setup executable matching the machine architecture:
+
+```text
+FyAgent-0.3.4-Windows-x64-setup.exe
+FyAgent-0.3.4-Windows-arm64-setup.exe
+```
+
+Read the **Windows installer signing status** table appended to these notes and
+verify the matching `signing-status.json`, SHA-256 digest, source SHA, and
+attestation before installing.
+
+### macOS
+
+Choose the DMG or ZIP; both contain the Universal application:
+
+```text
+FyAgent-0.3.4-macOS.dmg
+FyAgent-0.3.4-macOS.zip
+```
+
+The universal app is ad-hoc signed with no certificate identity and that
+signature is verified before packaging. It is not signed with an Apple
+Developer ID and is not notarized. The DMG container is unsigned. Gatekeeper
+may therefore block the first launch. After first attempting to open FyAgent,
+use **System Settings → Privacy & Security → Open Anyway** only after checking
+the Release evidence. Do not disable Gatekeeper or remove quarantine metadata.
+
+### Linux
+
+Choose the architecture and package format matching the host:
+
+```text
+FyAgent-0.3.4-Linux-x86_64.AppImage
+FyAgent-0.3.4-Linux-x86_64.deb
+FyAgent-0.3.4-Linux-x86_64.rpm
+FyAgent-0.3.4-Linux-arm64.AppImage
+FyAgent-0.3.4-Linux-arm64.deb
+FyAgent-0.3.4-Linux-arm64.rpm
+```
+
+Flatpak remains a local diagnostic conversion and is not a formal v0.3.4
+installer.
+
+## Exact Release attachment contract
+
+The formal Release must contain exactly these ten installer assets:
+
+```text
+FyAgent-0.3.4-macOS.dmg
+FyAgent-0.3.4-macOS.zip
+FyAgent-0.3.4-Windows-x64-setup.exe
+FyAgent-0.3.4-Windows-arm64-setup.exe
+FyAgent-0.3.4-Linux-x86_64.AppImage
+FyAgent-0.3.4-Linux-x86_64.deb
+FyAgent-0.3.4-Linux-x86_64.rpm
+FyAgent-0.3.4-Linux-arm64.AppImage
+FyAgent-0.3.4-Linux-arm64.deb
+FyAgent-0.3.4-Linux-arm64.rpm
+```
+
+It must also contain exactly these four evidence attachments:
+
+```text
+download-manifest.json
+build-metadata.json
+signing-status.json
+artifact-attestation.sigstore.json
+```
+
+That is 14 attachments total. The attestation has 13 subjects: the ten
+installers plus `download-manifest.json`, `build-metadata.json`, and
+`signing-status.json`. The copied Sigstore bundle is the fourteenth attachment
+and does not attest itself. A missing, duplicate, renamed, empty, stale, or
+extra attachment blocks publication.
+
+## Compatibility and upgrade notes
+
+- The database schema remains at version 16. This release introduces no
+  database schema or user-data migration.
+- Existing provider, settings, Skills, backup, `fyagent://v1/import`, and
+  third-party `/v1` contracts remain owned by their current implementation.
+- The minimum supported Windows version is unchanged.
+- The known v0.3.0 MSI product is removed synchronously before the new NSIS
+  payload is written; unexpected migration results abort instead of continuing
+  with a partially replaced installation.
+
+See the
+[installation guide](https://github.com/fy-agent/fyagent/blob/v0.3.4/docs/user-manual/en/1-getting-started/1.2-installation.md)
+for platform-specific installation steps.
+
+## Known verification and security boundaries
+
+- **No Windows HIL was run for this delivery.** Available evidence covers
+  executable contracts, portable tests, Windows-target compilation, native
+  x64/ARM64 build and packaging, signing or unsigned proof, exact-asset
+  verification, and review. It does not prove setup/uninstall behavior,
+  Explorer/UAC token handling, WebView2 user-data paths, Windows registry
+  behavior, PackageManager file-URI behavior, effective ACL enforcement or
+  mutation denial, terminal cleanup, or orphan recovery on a real Windows
+  10/11 x64 or ARM64 machine.
+- The current-user helper is not a protected process. Code already running as
+  the same Shell user can attempt memory, handle, or process manipulation within
+  that user's existing PackageManager authority.
+- The NSIS process lookup is a point-in-time safety check, not an atomic
+  interlock against a new process launch immediately before filesystem
+  mutation. Setup never force-terminates FyAgent or its helper.
+- A `NotSigned` Windows result can trigger SmartScreen warnings. SHA-256,
+  source-SHA binding, and attestation are not a substitute for Authenticode
+  publisher trust.
+- The macOS application has only an identity-free ad-hoc signature; the DMG is
+  unsigned, and neither is Developer ID signed or notarized.
+- This Release does not claim independent post-publication re-download
+  verification, administrator-enforced repository rulesets, or a separate Main
+  Provenance attestation.
+
+## Version provenance
+
+The existing annotated `v0.3.1`, `v0.3.2`, and `v0.3.3` tags remain at their
+original commits and are not moved, deleted, or reused. Their failed or
+unpublished workflows did not create a stable Release. FyAgent v0.3.4 is the
+recovery publication of the Windows current-user runtime, NSIS installer, CI,
+release, tooling, and documentation changes described above, including the
+bounded macOS disk-image creation recovery.
+
+## Source and licensing
+
+FyAgent-owned components and modifications remain under the repository's
+published PolyForm Noncommercial terms. Upstream-derived material retains its
+original notices and license ancestry.
+
+See
+[LICENSE](https://github.com/fy-agent/fyagent/blob/v0.3.4/LICENSE),
+[LICENSING.md](https://github.com/fy-agent/fyagent/blob/v0.3.4/LICENSING.md),
+and
+[THIRD_PARTY_NOTICES.md](https://github.com/fy-agent/fyagent/blob/v0.3.4/THIRD_PARTY_NOTICES.md).

--- a/scripts/release/dev-release-eligibility.d.mts
+++ b/scripts/release/dev-release-eligibility.d.mts
@@ -159,8 +159,8 @@ export const RELEASE_WORKFLOW_NAME: "Release";
 export const RELEASE_WORKFLOW_PATH: ".github/workflows/release.yml";
 export const CI_WORKFLOW_NAME: "CI";
 export const CI_WORKFLOW_PATH: ".github/workflows/ci.yml";
-export const DEV_BRANCH: "dev/laiyongjie";
-export const DEV_REF: "refs/heads/dev/laiyongjie";
+export const DEV_BRANCH: "main";
+export const DEV_REF: "refs/heads/main";
 export const REQUIRED_JOB_NAME: "CI / Required";
 
 export function evaluateDevReleaseEligibility(

--- a/scripts/release/dev-release-eligibility.mjs
+++ b/scripts/release/dev-release-eligibility.mjs
@@ -9,7 +9,8 @@ export const RELEASE_WORKFLOW_NAME = "Release";
 export const RELEASE_WORKFLOW_PATH = ".github/workflows/release.yml";
 export const CI_WORKFLOW_NAME = "CI";
 export const CI_WORKFLOW_PATH = ".github/workflows/ci.yml";
-export const DEV_BRANCH = "dev/laiyongjie";
+// Kept as a compatibility export for repository-owned release tooling.
+export const DEV_BRANCH = "main";
 export const DEV_REF = `refs/heads/${DEV_BRANCH}`;
 export const REQUIRED_JOB_NAME = "CI / Required";
 
@@ -580,7 +581,7 @@ function selectLatestSuccessfulCi(input, sourceSha) {
     selectedRun.conclusion !== "success"
   ) {
     fail(
-      "latest exact-source dev push CI run/attempt must be completed successfully",
+      `latest exact-source ${DEV_BRANCH} push CI run/attempt must be completed successfully`,
     );
   }
   validateCiEvidence(input.ciEvidence, selectedRun, sourceSha);

--- a/scripts/release/release-contract.d.mts
+++ b/scripts/release/release-contract.d.mts
@@ -140,7 +140,7 @@ export interface BuildMetadata {
 export const PRODUCT_NAME: "FyAgent";
 export const EXPECTED_REPOSITORY: "fy-agent/fyagent";
 export const EXPECTED_REPOSITORY_ID: "1313497021";
-export const RELEASE_BRANCH: "dev/laiyongjie";
+export const RELEASE_BRANCH: "main";
 export const RELEASE_WORKFLOW_PATH: ".github/workflows/release.yml";
 export const CI_WORKFLOW_PATH: ".github/workflows/ci.yml";
 export const DOWNLOAD_MANIFEST_NAME: "download-manifest.json";

--- a/scripts/release/release-contract.mjs
+++ b/scripts/release/release-contract.mjs
@@ -11,7 +11,7 @@ import { basename, join } from "node:path";
 export const PRODUCT_NAME = "FyAgent";
 export const EXPECTED_REPOSITORY = "fy-agent/fyagent";
 export const EXPECTED_REPOSITORY_ID = "1313497021";
-export const RELEASE_BRANCH = "dev/laiyongjie";
+export const RELEASE_BRANCH = "main";
 export const RELEASE_WORKFLOW_PATH = ".github/workflows/release.yml";
 export const CI_WORKFLOW_PATH = ".github/workflows/ci.yml";
 export const DOWNLOAD_MANIFEST_NAME = "download-manifest.json";

--- a/scripts/release/retry-hdiutil.sh
+++ b/scripts/release/retry-hdiutil.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+export LC_ALL=C
+
+if [ "$#" -lt 3 ] || [ "$2" != "--" ]; then
+  echo "Usage: retry-hdiutil.sh <output-path> -- <hdiutil-arguments...>" >&2
+  exit 2
+fi
+
+output_path="$1"
+shift 2
+
+if [ -z "$output_path" ] || [ "$#" -eq 0 ]; then
+  echo "retry-hdiutil.sh requires a non-empty output path and hdiutil arguments" >&2
+  exit 2
+fi
+
+log_file="$(mktemp "${TMPDIR:-/tmp}/fyagent-hdiutil.XXXXXX")"
+cleanup_log() {
+  rm -f -- "$log_file"
+}
+trap cleanup_log EXIT
+
+if ! rm -f -- "$output_path"; then
+  echo "Unable to remove the existing hdiutil output: $output_path" >&2
+  exit 1
+fi
+
+attempt=1
+max_attempts=5
+
+# Capture directly to a file so diagnostic inspection never puts hdiutil in a
+# pipeline with a reader that can exit while the disk-image helper is active.
+while true; do
+  if hdiutil "$@" >"$log_file" 2>&1; then
+    cat "$log_file"
+    exit 0
+  else
+    status=$?
+  fi
+
+  cat "$log_file" >&2
+  if ! rm -f -- "$output_path"; then
+    echo "Unable to remove the partial hdiutil output: $output_path" >&2
+    exit "$status"
+  fi
+
+  if ! grep -Fq -- 'Resource busy' "$log_file"; then
+    exit "$status"
+  fi
+  if [ "$attempt" -ge "$max_attempts" ]; then
+    exit "$status"
+  fi
+
+  delay=$((1 << attempt))
+  echo "hdiutil reported Resource busy; retrying attempt $((attempt + 1)) of $max_attempts after ${delay}s" >&2
+  sleep "$delay"
+  attempt=$((attempt + 1))
+done

--- a/scripts/release/verify-dev-release-remote.mjs
+++ b/scripts/release/verify-dev-release-remote.mjs
@@ -281,9 +281,9 @@ async function collectRemoteDev(client, repoPath) {
   const branchObject = normalizeRef(
     branchResponse.body,
     DEV_REF,
-    "dev branch ref",
+    "main branch ref",
   );
-  expectEqual(branchObject.type, "commit", "dev branch ref object type");
+  expectEqual(branchObject.type, "commit", "main branch ref object type");
   return {
     name: DEV_BRANCH,
     ref: DEV_REF,

--- a/scripts/tasks/release-check.mjs
+++ b/scripts/tasks/release-check.mjs
@@ -7,6 +7,7 @@ const CI_SAFE_TESTS = Object.freeze([
   "tests/devReleaseEligibility.test.ts",
   "tests/devReleaseRemote.test.ts",
   "tests/releaseWorkflow.test.ts",
+  "tests/hdiutilRetry.test.ts",
   "tests/downloadManifest.test.ts",
   "tests/releaseAssets.test.ts",
   "tests/windowsNsisContract.test.ts",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1777,7 +1777,7 @@ dependencies = [
 
 [[package]]
 name = "fyagent"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1855,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "fyagent-user-helper"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "embed-resource",
  "windows",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "user-helper"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.3"
+version = "0.3.4"
 
 [package]
 name = "fyagent"

--- a/tests/devReleaseEligibility.test.ts
+++ b/tests/devReleaseEligibility.test.ts
@@ -67,7 +67,7 @@ function ciRun(
       path: ".github/workflows/ci.yml",
     },
     event: "push",
-    headBranch: "dev/laiyongjie",
+    headBranch: "main",
     headSha: SOURCE_SHA,
     status: "completed",
     conclusion: "success",
@@ -80,9 +80,7 @@ function validInput(
 ): DevReleaseEligibilityInput {
   const releaseTag = "v0.3.1";
   const ref =
-    mode === "preflight"
-      ? "refs/heads/dev/laiyongjie"
-      : `refs/tags/${releaseTag}`;
+    mode === "preflight" ? "refs/heads/main" : `refs/tags/${releaseTag}`;
   return {
     schema: DEV_RELEASE_ELIGIBILITY_INPUT_SCHEMA,
     repository: { ...REPOSITORY },
@@ -90,7 +88,7 @@ function validInput(
       dispatchSourceSha: mode === "preflight" ? SOURCE_SHA : null,
       name: mode === "preflight" ? "workflow_dispatch" : "push",
       ref,
-      refName: mode === "preflight" ? "dev/laiyongjie" : releaseTag,
+      refName: mode === "preflight" ? "main" : releaseTag,
       refType: mode === "preflight" ? "branch" : "tag",
       sha: SOURCE_SHA,
     },
@@ -106,8 +104,8 @@ function validInput(
       sourceSha: SOURCE_SHA,
     },
     remoteDev: {
-      name: "dev/laiyongjie",
-      ref: "refs/heads/dev/laiyongjie",
+      name: "main",
+      ref: "refs/heads/main",
       headSha: SOURCE_SHA,
     },
     remoteTag:
@@ -172,9 +170,9 @@ function bindEvidenceToRun(input: MutableRecord, run: MutableRecord) {
   input.ciEvidence.checkRuns = [requiredCheck(run.id, run.runAttempt)];
 }
 
-describe("dev release identity", () => {
+describe("main release identity", () => {
   it.each(["preflight", "formal"] as const)(
-    "freezes the exact eligible %s identity and successful dev CI attempt",
+    "freezes the exact eligible %s identity and successful main CI attempt",
     (mode) => {
       const output = evaluateDevReleaseEligibility(validInput(mode));
 
@@ -257,15 +255,16 @@ describe("dev release identity", () => {
       (input: MutableRecord) => (input.candidate.sourceSha = OTHER_SHA),
     ],
     [
-      "remote dev branch",
-      (input: MutableRecord) => (input.remoteDev.name = "main"),
+      "remote authority branch",
+      (input: MutableRecord) => (input.remoteDev.name = "dev/laiyongjie"),
     ],
     [
-      "remote dev ref",
-      (input: MutableRecord) => (input.remoteDev.ref = "refs/heads/main"),
+      "remote authority ref",
+      (input: MutableRecord) =>
+        (input.remoteDev.ref = "refs/heads/dev/laiyongjie"),
     ],
     [
-      "moved remote dev HEAD",
+      "moved remote main HEAD",
       (input: MutableRecord) => (input.remoteDev.headSha = OTHER_SHA),
     ],
   ])("rejects wrong %s identity", (_label, mutate) => {
@@ -279,7 +278,7 @@ describe("dev release identity", () => {
     ],
     [
       "branch ref",
-      (input: MutableRecord) => (input.event.ref = "refs/heads/main"),
+      (input: MutableRecord) => (input.event.ref = "refs/heads/dev/laiyongjie"),
     ],
     [
       "branch ref type",
@@ -287,7 +286,7 @@ describe("dev release identity", () => {
     ],
     [
       "branch ref name",
-      (input: MutableRecord) => (input.event.refName = "main"),
+      (input: MutableRecord) => (input.event.refName = "dev/laiyongjie"),
     ],
     [
       "workflow ref",
@@ -326,7 +325,7 @@ describe("dev release identity", () => {
       "workflow ref",
       (input: MutableRecord) =>
         (input.workflow.ref =
-          "fy-agent/fyagent/.github/workflows/release.yml@refs/heads/dev/laiyongjie"),
+          "fy-agent/fyagent/.github/workflows/release.yml@refs/heads/main"),
     ],
     [
       "missing annotated tag",
@@ -358,7 +357,7 @@ describe("dev release identity", () => {
   });
 });
 
-describe("exact dev push CI admission", () => {
+describe("exact main push CI admission", () => {
   it("selects the newest exact-source run and rerun attempt", () => {
     const input = mutableInput();
     const oldOtherSource = ciRun({
@@ -442,7 +441,7 @@ describe("exact dev push CI admission", () => {
     ],
     [
       "wrong run branch",
-      (input: MutableRecord) => (input.ciRuns[0].headBranch = "main"),
+      (input: MutableRecord) => (input.ciRuns[0].headBranch = "dev/laiyongjie"),
     ],
     [
       "wrong run SHA",
@@ -453,14 +452,14 @@ describe("exact dev push CI admission", () => {
     expectRejected(mutate);
   });
 
-  it("does not accept an old green commit after the dev branch moves", () => {
+  it("does not accept an old green commit after the main branch moves", () => {
     expectRejected((input) => {
       input.event.sha = OTHER_SHA;
       input.event.dispatchSourceSha = OTHER_SHA;
       input.workflow.sha = OTHER_SHA;
       input.candidate.sourceSha = OTHER_SHA;
       input.remoteDev.headSha = OTHER_SHA;
-    }, /no dev\/laiyongjie push CI run exists/);
+    }, /no main push CI run exists/);
   });
 
   it.each([
@@ -479,7 +478,7 @@ describe("exact dev push CI admission", () => {
             conclusion,
           }),
         );
-      }, /latest exact-source dev push CI run\/attempt must be completed successfully/);
+      }, /latest exact-source main push CI run\/attempt must be completed successfully/);
     },
   );
 

--- a/tests/devReleaseRemote.test.ts
+++ b/tests/devReleaseRemote.test.ts
@@ -42,9 +42,7 @@ type FixtureOptions = {
 function context(mode: Mode = "preflight"): DevReleaseRemoteContext {
   const releaseTag = "v0.3.1";
   const ref =
-    mode === "preflight"
-      ? "refs/heads/dev/laiyongjie"
-      : `refs/tags/${releaseTag}`;
+    mode === "preflight" ? "refs/heads/main" : `refs/tags/${releaseTag}`;
   return {
     token: TOKEN,
     apiBase: "https://api.github.com",
@@ -52,7 +50,7 @@ function context(mode: Mode = "preflight"): DevReleaseRemoteContext {
     repositoryId: "1313497021",
     eventName: mode === "preflight" ? "workflow_dispatch" : "push",
     ref,
-    refName: mode === "preflight" ? "dev/laiyongjie" : releaseTag,
+    refName: mode === "preflight" ? "main" : releaseTag,
     refType: mode === "preflight" ? "branch" : "tag",
     eventSha: SOURCE_SHA,
     workflowName: "Release",
@@ -93,7 +91,7 @@ function rawRun({
     name: "CI",
     path: ".github/workflows/ci.yml",
     event: "push",
-    head_branch: "dev/laiyongjie",
+    head_branch: "main",
     head_sha: headSha,
     status: "completed",
     conclusion: "success",
@@ -170,9 +168,9 @@ function fixtureFetch(options: FixtureOptions = {}) {
     if (path === "/repos/fy-agent/fyagent") {
       return jsonResponse(options.repository ?? REPOSITORY);
     }
-    if (path === "/repos/fy-agent/fyagent/git/ref/heads/dev/laiyongjie") {
+    if (path === "/repos/fy-agent/fyagent/git/ref/heads/main") {
       return jsonResponse({
-        ref: "refs/heads/dev/laiyongjie",
+        ref: "refs/heads/main",
         object: { type: "commit", sha: options.branchSha ?? SOURCE_SHA },
       });
     }
@@ -207,7 +205,7 @@ function fixtureFetch(options: FixtureOptions = {}) {
     if (
       path === `/repos/fy-agent/fyagent/actions/workflows/${WORKFLOW_ID}/runs`
     ) {
-      expect(url.searchParams.get("branch")).toBe("dev/laiyongjie");
+      expect(url.searchParams.get("branch")).toBe("main");
       expect(url.searchParams.get("event")).toBe("push");
       expect(url.searchParams.get("head_sha")).toBe(SOURCE_SHA);
       if (url.searchParams.get("page") === "2") {
@@ -229,7 +227,7 @@ function fixtureFetch(options: FixtureOptions = {}) {
         });
       }
       const next =
-        "<https://api.github.com/repos/fy-agent/fyagent/actions/workflows/314159/runs?branch=dev%2Flaiyongjie&event=push&head_sha=" +
+        "<https://api.github.com/repos/fy-agent/fyagent/actions/workflows/314159/runs?branch=main&event=push&head_sha=" +
         `${SOURCE_SHA}&per_page=100&page=2>; rel="next"`;
       return jsonResponse(
         {
@@ -435,7 +433,7 @@ describe("dev release remote evidence", () => {
     ).rejects.toThrow(/ciEvidence\.runAttempt/);
   });
 
-  it("rejects when the dev branch moves", async () => {
+  it("rejects when the main branch moves", async () => {
     const fixture = fixtureFetch({ branchSha: OTHER_SHA });
 
     await expect(
@@ -580,13 +578,13 @@ describe("remote verifier environment", () => {
       GITHUB_REPOSITORY: "fy-agent/fyagent",
       GITHUB_REPOSITORY_ID: "1313497021",
       GITHUB_EVENT_NAME: "workflow_dispatch",
-      GITHUB_REF: "refs/heads/dev/laiyongjie",
-      GITHUB_REF_NAME: "dev/laiyongjie",
+      GITHUB_REF: "refs/heads/main",
+      GITHUB_REF_NAME: "main",
       GITHUB_REF_TYPE: "branch",
       GITHUB_SHA: SOURCE_SHA,
       GITHUB_WORKFLOW: "Release",
       GITHUB_WORKFLOW_REF:
-        "fy-agent/fyagent/.github/workflows/release.yml@refs/heads/dev/laiyongjie",
+        "fy-agent/fyagent/.github/workflows/release.yml@refs/heads/main",
       GITHUB_WORKFLOW_SHA: SOURCE_SHA,
       RELEASE_APP_VERSION: "0.3.1",
       RELEASE_TAG: "v0.3.1",

--- a/tests/hdiutilRetry.test.ts
+++ b/tests/hdiutilRetry.test.ts
@@ -1,0 +1,185 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const ROOT = path.resolve(__dirname, "..");
+const RETRY_HDIUTIL = path.join(ROOT, "scripts", "release", "retry-hdiutil.sh");
+const temporaryRoots: string[] = [];
+
+function createFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "fyagent-hdiutil-"));
+  temporaryRoots.push(root);
+  const binRoot = path.join(root, "bin");
+  const callRoot = path.join(root, "calls");
+  const outputPath = path.join(root, "release assets", "FyAgent test.dmg");
+  const statePath = path.join(root, "attempt.txt");
+  const sleepLog = path.join(root, "sleep.log");
+  fs.mkdirSync(binRoot);
+  fs.mkdirSync(callRoot);
+  fs.mkdirSync(path.dirname(outputPath));
+
+  fs.writeFileSync(
+    path.join(binRoot, "hdiutil"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+
+attempt=0
+if [ -f "$FYAGENT_FAKE_STATE" ]; then
+  attempt="$(<"$FYAGENT_FAKE_STATE")"
+fi
+attempt=$((attempt + 1))
+printf '%s\n' "$attempt" > "$FYAGENT_FAKE_STATE"
+
+args_file="$FYAGENT_FAKE_CALL_ROOT/args.$attempt"
+: > "$args_file"
+for argument in "$@"; do
+  printf '%s\n' "$argument" >> "$args_file"
+done
+
+if [ -e "$FYAGENT_FAKE_OUTPUT" ]; then
+  echo 'stale partial output reached hdiutil' >&2
+  exit 97
+fi
+
+: > "$FYAGENT_FAKE_OUTPUT"
+if [ "$attempt" -le "$FYAGENT_FAKE_BUSY_FAILURES" ]; then
+  echo 'hdiutil: create failed - Resource busy' >&2
+  exit 73
+fi
+if [ "$FYAGENT_FAKE_MODE" = fail ]; then
+  echo 'hdiutil: create failed - permission denied' >&2
+  exit 42
+fi
+
+echo 'created: fake disk image'
+`,
+    { mode: 0o755 },
+  );
+  fs.writeFileSync(
+    path.join(binRoot, "sleep"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$1" >> "$FYAGENT_FAKE_SLEEP_LOG"
+`,
+    { mode: 0o755 },
+  );
+
+  function run(
+    busyFailures: number,
+    mode: "fail" | "succeed",
+    hdiutilArguments: string[],
+  ) {
+    fs.writeFileSync(outputPath, "stale output");
+    return spawnSync(
+      "bash",
+      [RETRY_HDIUTIL, outputPath, "--", ...hdiutilArguments],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FYAGENT_FAKE_BUSY_FAILURES: String(busyFailures),
+          FYAGENT_FAKE_CALL_ROOT: callRoot,
+          FYAGENT_FAKE_MODE: mode,
+          FYAGENT_FAKE_OUTPUT: outputPath,
+          FYAGENT_FAKE_SLEEP_LOG: sleepLog,
+          FYAGENT_FAKE_STATE: statePath,
+          PATH: `${binRoot}:${process.env.PATH ?? ""}`,
+        },
+      },
+    );
+  }
+
+  function calls(): string[][] {
+    if (!fs.existsSync(statePath)) return [];
+    const count = Number(fs.readFileSync(statePath, "utf8").trim());
+    return Array.from({ length: count }, (_, index) =>
+      fs
+        .readFileSync(path.join(callRoot, `args.${index + 1}`), "utf8")
+        .trimEnd()
+        .split("\n"),
+    );
+  }
+
+  function sleeps(): string[] {
+    return fs.existsSync(sleepLog)
+      ? fs.readFileSync(sleepLog, "utf8").trim().split("\n")
+      : [];
+  }
+
+  return { calls, outputPath, run, sleeps };
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+});
+
+describe("hdiutil Resource busy retry", () => {
+  it("removes partial output and succeeds after two Resource busy failures", () => {
+    const fixture = createFixture();
+    const args = [
+      "create",
+      "-volname",
+      "FyAgent",
+      "-srcfolder",
+      "/tmp/stage",
+      "-ov",
+      "-format",
+      "UDZO",
+      fixture.outputPath,
+    ];
+
+    const result = fixture.run(2, "succeed", args);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(fixture.calls()).toEqual([args, args, args]);
+    expect(fixture.sleeps()).toEqual(["2", "4"]);
+    expect(fs.existsSync(fixture.outputPath)).toBe(true);
+  });
+
+  it("returns the original status immediately for a non-Resource busy error", () => {
+    const fixture = createFixture();
+    const args = ["create", "-format", "UDZO", fixture.outputPath];
+
+    const result = fixture.run(0, "fail", args);
+
+    expect(result.status, result.stderr).toBe(42);
+    expect(fixture.calls()).toEqual([args]);
+    expect(fixture.sleeps()).toEqual([]);
+    expect(fs.existsSync(fixture.outputPath)).toBe(false);
+  });
+
+  it("stops after five Resource busy failures with bounded backoff", () => {
+    const fixture = createFixture();
+    const args = ["create", "-format", "UDZO", fixture.outputPath];
+
+    const result = fixture.run(5, "succeed", args);
+
+    expect(result.status, result.stderr).toBe(73);
+    expect(fixture.calls()).toEqual([args, args, args, args, args]);
+    expect(fixture.sleeps()).toEqual(["2", "4", "8", "16"]);
+    expect(fs.existsSync(fixture.outputPath)).toBe(false);
+  });
+
+  it("preserves every hdiutil argument without shell re-parsing", () => {
+    const fixture = createFixture();
+    const args = [
+      "create",
+      "-volname",
+      "Fy Agent * $(unchanged)",
+      "-srcfolder",
+      "/tmp/stage with spaces",
+      "--opaque=value with spaces",
+      fixture.outputPath,
+    ];
+
+    const result = fixture.run(0, "succeed", args);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(fixture.calls()).toEqual([args]);
+    expect(fixture.sleeps()).toEqual([]);
+  });
+});

--- a/tests/releaseAssets.test.ts
+++ b/tests/releaseAssets.test.ts
@@ -47,8 +47,7 @@ const identity: ReleaseIdentity = {
   repository: "fy-agent/fyagent",
   repositoryId: "1313497021",
   workflowPath: ".github/workflows/release.yml",
-  workflowRef:
-    "fy-agent/fyagent/.github/workflows/release.yml@refs/heads/dev/laiyongjie",
+  workflowRef: "fy-agent/fyagent/.github/workflows/release.yml@refs/heads/main",
   workflowSha: "b".repeat(40),
   runId: "123456",
   runAttempt: "2",
@@ -420,7 +419,7 @@ describe("release asset and metadata contract", () => {
   });
 
   it("freezes the NSIS-only Windows assets and the complete release file sets", () => {
-    expect(RELEASE_BRANCH).toBe("dev/laiyongjie");
+    expect(RELEASE_BRANCH).toBe("main");
     expect(expectedInstallerNames("0.3.0")).toHaveLength(10);
     expect(expectedInstallerNames("0.3.0")).toContain(
       "FyAgent-0.3.0-Windows-x64-setup.exe",
@@ -577,7 +576,7 @@ describe("release asset and metadata contract", () => {
         runAttempt: "2",
         event: "workflow_dispatch",
         mode: "preflight",
-        ref: "fy-agent/fyagent/.github/workflows/release.yml@refs/heads/dev/laiyongjie",
+        ref: "fy-agent/fyagent/.github/workflows/release.yml@refs/heads/main",
         sha: "b".repeat(40),
       },
       requiredCi: {
@@ -732,9 +731,9 @@ describe("release asset and metadata contract", () => {
       "preflight workflow ref",
       {
         workflowRef:
-          "fy-agent/fyagent/.github/workflows/release.yml@refs/heads/main",
+          "fy-agent/fyagent/.github/workflows/release.yml@refs/heads/dev/laiyongjie",
       },
-      /Preflight must use the trusted dev\/laiyongjie workflow ref/,
+      /Preflight must use the trusted main workflow ref/,
     ],
     [
       "formal workflow ref",

--- a/tests/releaseWorkflow.test.ts
+++ b/tests/releaseWorkflow.test.ts
@@ -72,6 +72,12 @@ const MACOS_ADHOC_VERIFIER = path.join(
   "release",
   "verify-macos-adhoc-app.sh",
 );
+const MACOS_HDIUTIL_RETRY = path.join(
+  ROOT,
+  "scripts",
+  "release",
+  "retry-hdiutil.sh",
+);
 const PLATFORM_METADATA_WRITER = path.join(
   ROOT,
   "scripts",
@@ -636,7 +642,7 @@ describe("FyAgent release workflow", () => {
     }
     expect(notes).toContain("14 attachments total");
     expect(notes).toContain("13 subjects");
-    expect(notes).toContain("dev/laiyongjie");
+    expect(notes).toContain("main");
     expect(notes).toContain("NotSigned");
     expect(notes).toMatch(/Developer\s+ID/u);
     expect(notes).toContain("not notarized");
@@ -711,14 +717,14 @@ describe("FyAgent release workflow", () => {
     ).rejects.toThrow(/Unexpected trusted build input entry/u);
   });
 
-  it("supports an immutable dev preflight and stable tag candidates without publishing dispatches", () => {
+  it("supports an immutable main preflight and stable tag candidates without publishing dispatches", () => {
     const trigger = source.slice(0, source.indexOf("\npermissions:"));
     expect(trigger).toContain('      - "v*.*.*"');
     expect(trigger).not.toContain('      - "v*"');
     expect(trigger).not.toMatch(/^\s+- ["']v\d+\.\d+\.\d+["']\s*$/mu);
     expect(trigger).toContain("workflow_dispatch:");
     expect(trigger).toContain("source_sha:");
-    expect(trigger).toContain("dev/laiyongjie HEAD SHA");
+    expect(trigger).toContain("main HEAD SHA");
     expect(trigger).toContain("required: true");
     expect(source).toContain("release_mode='preflight'");
     expect(source).toContain("release_mode='formal'");
@@ -1035,7 +1041,7 @@ describe("FyAgent release workflow", () => {
     );
   });
 
-  it("binds repository, dev HEAD, annotated formal tag, and exact Required CI through the repository-owned verifier", () => {
+  it("binds repository, main HEAD, annotated formal tag, and exact Required CI through the repository-owned verifier", () => {
     const eligibility = source.slice(
       source.indexOf("\n  eligibility:\n"),
       source.indexOf("\n  build-windows:\n"),
@@ -1047,7 +1053,8 @@ describe("FyAgent release workflow", () => {
     expect(eligibility).toContain("path: candidate-source");
     expect(eligibility).not.toContain("installer-actions");
     expect(eligibility).not.toContain("pnpm install");
-    expect(eligibility).toContain("refs/heads/dev/laiyongjie");
+    expect(eligibility).toContain("refs/heads/main");
+    expect(eligibility).not.toContain("refs/heads/dev/laiyongjie");
     expect(eligibility).toContain('"refs/tags/$GITHUB_REF_NAME"');
     expect(eligibility).toContain('release_tag="v$app_version"');
     expect(eligibility).toContain('check --tag "$release_tag"');
@@ -1090,11 +1097,11 @@ describe("FyAgent release workflow", () => {
     expect(eligibility).toContain("checks: read");
     expect(eligibility).not.toContain("merge-base --is-ancestor");
     expect(eligibility).not.toContain("refs/remotes/origin/main");
-    expect(eligibility).not.toContain("branch=main");
+    expect(eligibility).not.toContain("branch=dev/laiyongjie");
     expect(
       namedStepBlock(
         eligibility,
-        "Bind remote dev, tag, and successful Required CI evidence",
+        "Bind remote main, tag, and successful Required CI evidence",
       ),
     ).not.toContain("\n        if:");
   });
@@ -1752,6 +1759,7 @@ jobs:
       source.indexOf("\n  pin-release-build-inputs:\n"),
     );
     const macAdhocVerifier = read(MACOS_ADHOC_VERIFIER);
+    const hdiutilRetry = read(MACOS_HDIUTIL_RETRY);
     expect(trackedMode(MACOS_ADHOC_VERIFIER)).toBe("100755");
     const tauriConfig = JSON.parse(read(TAURI_CONFIG)) as {
       bundle?: { macOS?: { signingIdentity?: string } };
@@ -1765,6 +1773,22 @@ jobs:
     expect(source).not.toContain("notarytool");
     expect(source).toContain("hdiutil attach");
     expect(source).toContain("-readonly");
+    expectExactLine(macJob, "          scripts/release/retry-hdiutil.sh \\");
+    expectExactLine(macJob, '            "$dmg_path" \\');
+    expectExactLine(macJob, "            -- \\");
+    expectExactLine(
+      macJob,
+      '            create -volname \'FyAgent\' -srcfolder "$stage" -ov -format UDZO "$dmg_path"',
+    );
+    expect(hdiutilRetry).toContain("max_attempts=5");
+    expect(hdiutilRetry).toContain("grep -Fq -- 'Resource busy'");
+    expect(hdiutilRetry).toContain("delay=$((1 << attempt))");
+    expect(hdiutilRetry).toContain('hdiutil "$@" >"$log_file" 2>&1');
+    expect(hdiutilRetry).not.toContain(" | ");
+    expect(hdiutilRetry).not.toContain("|| true");
+    expect(macJob).not.toContain("hdiutil create -volname");
+    expect(macJob).not.toContain("hdiutil detach -force");
+    expect(macJob).not.toMatch(/kill[^\n]*diskimages/iu);
     expect(tauriConfig.bundle?.macOS).not.toHaveProperty("signingIdentity");
     expect(macJob).not.toContain("APPLE_SIGNING_IDENTITY");
     expect(macJob).toContain(
@@ -1859,7 +1883,7 @@ jobs:
       "GITHUB_WORKFLOW_SHA: ${{ github.workflow_sha }}",
     );
     expect(publish).toContain(
-      "Revalidate frozen dev release eligibility at publish start",
+      "Revalidate frozen main release eligibility at publish start",
     );
     expect(
       publish.match(/node scripts\/release\/verify-dev-release-remote\.mjs/gu),

--- a/tests/writePlatformMetadata.test.ts
+++ b/tests/writePlatformMetadata.test.ts
@@ -45,7 +45,7 @@ function releaseIdentity(mode: "preflight" | "formal"): ReleaseIdentity {
     workflowRef:
       mode === "formal"
         ? "fy-agent/fyagent/.github/workflows/release.yml@refs/tags/v0.3.0"
-        : "fy-agent/fyagent/.github/workflows/release.yml@refs/heads/dev/laiyongjie",
+        : "fy-agent/fyagent/.github/workflows/release.yml@refs/heads/main",
     workflowSha: sourceSha,
     runId: "123456",
     runAttempt: "2",


### PR DESCRIPTION
## Summary

- retry macOS `hdiutil create` only for the exact transient `Resource busy` diagnostic, with bounded cleanup and backoff
- bind formal release eligibility directly to the current `main` HEAD and its exact successful `CI / Required` push result
- prepare the immutable v0.3.4 version and release notes, with preflight retained as an optional non-publishing diagnostic

## Validation

- `node scripts/version.mjs check --tag v0.3.4`
- `node --test tests/version.test.mjs` (21 passed)
- `mise run release:check` (571 contract tests + 4 native-fetch tests passed)
- `mise run release:check -- --ci` (499 tests passed, including hdiutil retry coverage)
- Prettier, `bash -n`, and `git diff --check`

After merge, the intended publication path is the exact merge SHA's successful main push `CI / Required`, followed directly by one annotated `v0.3.4` tag and one formal Release build.
