### PR TITLE
Restore the For You Agent identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
   <img src="assets/brand/github/for-you-gate.svg" width="104" alt="FyAgent For You Gate">
   <h1>FyAgent</h1>
-  <p><strong>帮你拥有属于自己的 AI。</strong></p>
-  <p>AI 时代的个人智能控制中心，也是你掌握 AI 的方向盘。</p>
+  <p><strong>For You Agent</strong>——AI 时代的个人随身数字人格。</p>
+  <p>把你的模型、供应商、技能、提示词和工作方式，带到每一个 AI 工具里。</p>
   <p><a href="README_EN.md">English</a> · <a href="README_JA.md">日本語</a></p>
   <p>
     <a href="https://github.com/fy-agent/fyagent/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/fy-agent/fyagent?style=flat-square&label=release&color=0B66FF"></a>

--- a/tests/currentDocsContract.test.ts
+++ b/tests/currentDocsContract.test.ts
@@ -479,7 +479,12 @@ describe("current FyAgent documentation authority", () => {
     const english = read("README_EN.md");
     const japanese = read("README_JA.md");
 
-    expect(chinese).toContain("帮你拥有属于自己的 AI。");
+    expect(chinese).toContain(
+      "<strong>For You Agent</strong>——AI 时代的个人随身数字人格。",
+    );
+    expect(chinese).toContain(
+      "把你的模型、供应商、技能、提示词和工作方式，带到每一个 AI 工具里。",
+    );
     expect(chinese).toContain('href="README_EN.md">English</a>');
     expect(english).toContain('href="README.md">简体中文</a>');
     expect(japanese).toContain('href="README_EN.md">English</a>');


### PR DESCRIPTION
## What changed

- Restore the approved Chinese README hero: `For You Agent——AI 时代的个人随身数字人格。`
- Restore the line about carrying models, providers, skills, prompts, and ways of working across AI tools.
- Lock both lines in the documentation contract so the human meaning of the name cannot be replaced accidentally.

## Why

`FyAgent = For You Agent` is the human meaning behind the product name. The previous hero rewrite weakened that relationship.

## Verification

- `tests/currentDocsContract.test.ts`: 11 tests passed with Node.js 24.19.0.
- TypeScript test formatting passed.
- `git diff --check` passed.
