### PR TITLE
Use clearer AI account language

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="assets/brand/github/for-you-gate.svg" width="104" alt="FyAgent For You Gate">
   <h1>FyAgent</h1>
   <p><strong>For You Agent</strong>——AI 时代的个人随身数字人格。</p>
-  <p>把你的模型、供应商、技能、提示词和工作方式，带到每一个 AI 工具里。</p>
+  <p>把你的模型、AI 账号、技能、提示词和工作方式，带到每一个 AI 工具里。</p>
   <p><a href="README_EN.md">English</a> · <a href="README_JA.md">日本語</a></p>
   <p>
     <a href="https://github.com/fy-agent/fyagent/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/fy-agent/fyagent?style=flat-square&label=release&color=0B66FF"></a>

--- a/tests/currentDocsContract.test.ts
+++ b/tests/currentDocsContract.test.ts
@@ -483,7 +483,7 @@ describe("current FyAgent documentation authority", () => {
       "<strong>For You Agent</strong>——AI 时代的个人随身数字人格。",
     );
     expect(chinese).toContain(
-      "把你的模型、供应商、技能、提示词和工作方式，带到每一个 AI 工具里。",
+      "把你的模型、AI 账号、技能、提示词和工作方式，带到每一个 AI 工具里。",
     );
     expect(chinese).toContain('href="README_EN.md">English</a>');
     expect(english).toContain('href="README.md">简体中文</a>');


### PR DESCRIPTION
## Summary

- replace the technical `供应商` wording in the Chinese README hero with the clearer `AI 账号`
- keep the documentation contract aligned with the public-facing copy
- update the GitHub About description to the same wording

## Verification

- `tests/currentDocsContract.test.ts`: 11 tests passed
- Prettier check passed
- `git diff --check` passed
