### PR TITLE
docs/i18n: split Grok Official grok login hints from xAI device-code expiry

### DIFF
--- a/src/components/SubscriptionQuotaFooter.tsx
+++ b/src/components/SubscriptionQuotaFooter.tsx
@@ -16,7 +16,7 @@ interface SubscriptionQuotaViewProps {
   quota: SubscriptionQuota | undefined;
   loading: boolean;
   refetch: () => void;
-  /** 用于 `subscription.expiredHint` 的 {tool} 插值；解耦了 hook 的 appId */
+  /** Selects expiry copy: Official Grok, xAI Auth Center, or generic CLI `{tool}`. */
   appIdForExpiredHint: string;
   inline?: boolean;
 }
@@ -79,6 +79,19 @@ function formatResetTime(
 
 /** 不需要在 inline 模式显示的 tier */
 const HIDDEN_INLINE_TIERS = new Set(["seven_day_sonnet"]);
+
+/** Official Grok → terminal `grok login`; xAI device-code → Auth Center. */
+export function getSubscriptionExpiredHintKey(
+  appIdForExpiredHint: string,
+): string {
+  if (appIdForExpiredHint === "grok" || appIdForExpiredHint === "grokbuild") {
+    return "subscription.grokOfficialExpiredHint";
+  }
+  if (appIdForExpiredHint === "xai_oauth") {
+    return "subscription.xaiOauthExpiredHint";
+  }
+  return "subscription.expiredHint";
+}
 
 /** 格式化相对时间（与 UsageFooter 一致） */
 function formatRelativeTime(
@@ -154,7 +167,9 @@ export const SubscriptionQuotaView: React.FC<SubscriptionQuotaViewProps> = ({
             <div>
               <span className="font-medium">{t("subscription.expired")}</span>
               <span className="ml-2 text-amber-500/70 dark:text-amber-400/70">
-                {t("subscription.expiredHint", { tool: appIdForExpiredHint })}
+                {t(getSubscriptionExpiredHintKey(appIdForExpiredHint), {
+                  tool: appIdForExpiredHint,
+                })}
               </span>
             </div>
           </div>
@@ -424,7 +439,7 @@ const SubscriptionQuotaFooter: React.FC<SubscriptionQuotaFooterProps> = ({
       quota={quota}
       loading={loading}
       refetch={refetch}
-      // expiredHint 里的 {tool} 是 CLI 命令名：Grok 的命令是 `grok` 而非 appId
+      // Official Grok maps to the `grok` CLI id; copy then says `grok login`.
       appIdForExpiredHint={appId === "grokbuild" ? "grok" : appId}
       inline={inline}
     />

--- a/src/components/providers/forms/GrokBuildProviderForm.tsx
+++ b/src/components/providers/forms/GrokBuildProviderForm.tsx
@@ -430,6 +430,14 @@ export function GrokBuildProviderForm({
             presetCategoryLabels={presetCategoryLabels}
             onPresetChange={handlePresetChange}
             category={category}
+            categoryHint={
+              category === "official"
+                ? t("providerForm.grokOfficialHint", {
+                    defaultValue:
+                      "Grok Official uses an empty config. After you save, run `grok login` in a terminal. FyAgent does not log in for you and does not write ~/.grok/auth.json.",
+                  })
+                : undefined
+            }
           />
         )}
 

--- a/src/components/providers/forms/ProviderPresetSelector.tsx
+++ b/src/components/providers/forms/ProviderPresetSelector.tsx
@@ -120,6 +120,8 @@ interface ProviderPresetSelectorProps {
   onUniversalPresetSelect?: (preset: UniversalProviderPreset) => void;
   onManageUniversalProviders?: () => void;
   category?: ProviderCategory; // 当前选中的分类
+  /** When set, replaces the category-derived hint (e.g. Grok Official). */
+  categoryHint?: ReactNode;
 }
 
 export function ProviderPresetSelector({
@@ -130,6 +132,7 @@ export function ProviderPresetSelector({
   onUniversalPresetSelect,
   onManageUniversalProviders,
   category,
+  categoryHint,
 }: Readonly<ProviderPresetSelectorProps>) {
   const { t } = useTranslation();
   const [searchOpen, setSearchOpen] = useState(false);
@@ -452,7 +455,9 @@ export function ProviderPresetSelector({
         </div>
       )}
 
-      <p className="text-xs text-muted-foreground">{getCategoryHint()}</p>
+      <p className="text-xs text-muted-foreground">
+        {categoryHint ?? getCategoryHint()}
+      </p>
     </div>
   );
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1199,6 +1199,7 @@
     "customApiKeyHint": "💡 Custom configuration requires manually filling all necessary fields",
     "omoHint": "💡 OMO config manages Agent model assignments and supports both oh-my-openagent.jsonc and oh-my-opencode.jsonc",
     "officialHint": "💡 Official provider uses browser login, no API Key needed",
+    "grokOfficialHint": "💡 Grok Official uses an empty config. After you save, run `grok login` in a terminal. FyAgent does not log in for you and does not write ~/.grok/auth.json.",
     "providerKeyStatusLoading": "Provider identifier status is still loading. Please try again shortly.",
     "getApiKey": "Get API Key",
     "presets": {
@@ -3180,6 +3181,8 @@
     "extraUsage": "Extra Usage",
     "expired": "Session expired",
     "expiredHint": "Run the {{tool}} command to refresh your login",
+    "grokOfficialExpiredHint": "Run `grok login` in a terminal to refresh this login.",
+    "xaiOauthExpiredHint": "Re-authenticate this xAI account in Auth Center.",
     "queryFailed": "Query failed",
     "refresh": "Refresh"
   },

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1297,6 +1297,7 @@
     "customApiKeyHint": "💡 カスタム設定では必要な項目をすべて手動で入力してください",
     "omoHint": "💡 OMO 設定は Agent のモデル割り当てを管理し、oh-my-openagent.jsonc / oh-my-opencode.jsonc の両方に対応します",
     "officialHint": "💡 公式プロバイダーはブラウザログインで、API Key は不要です",
+    "grokOfficialHint": "💡 Grok Official は空の設定を使います。保存後、ターミナルで `grok login` を実行してください。FyAgent は代わりにログインせず、~/.grok/auth.json にも書き込みません。",
     "providerKeyStatusLoading": "プロバイダー識別子の状態を読み込んでいます。しばらくしてからもう一度お試しください",
     "getApiKey": "API Key を取得",
     "presets": {
@@ -3278,6 +3279,8 @@
     "extraUsage": "超過使用量",
     "expired": "セッション期限切れ",
     "expiredHint": "{{tool}}コマンドを実行してログインを更新してください",
+    "grokOfficialExpiredHint": "このログインを更新するには、ターミナルで `grok login` を実行してください。",
+    "xaiOauthExpiredHint": "認証センターでこの xAI アカウントを再認証してください。",
     "queryFailed": "クエリに失敗しました",
     "refresh": "更新"
   }

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1297,6 +1297,7 @@
     "customApiKeyHint": "自訂設定需手動填寫所有必要欄位",
     "omoHint": "OMO 設定管理 Agent 模型指派，相容 oh-my-openagent.jsonc / oh-my-opencode.jsonc",
     "officialHint": "官方供應商使用瀏覽器登入，無需設定 API Key",
+    "grokOfficialHint": "Grok Official 使用空設定。儲存後請在終端機執行 `grok login`。FyAgent 不會代為登入，也不會寫入 ~/.grok/auth.json。",
     "providerKeyStatusLoading": "正在載入供應商識別碼狀態，請稍後再試",
     "getApiKey": "取得 API Key",
     "presets": {
@@ -3278,6 +3279,8 @@
     "extraUsage": "超額用量",
     "expired": "工作階段已過期",
     "expiredHint": "請執行 {{tool}} 命令重新整理登入",
+    "grokOfficialExpiredHint": "請在終端機執行 `grok login` 以重新整理此登入。",
+    "xaiOauthExpiredHint": "請到驗證中心重新登入此 xAI 帳號。",
     "queryFailed": "查詢失敗",
     "refresh": "重新整理"
   }

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1199,6 +1199,7 @@
     "customApiKeyHint": "💡 自定义配置需手动填写所有必要字段",
     "omoHint": "💡 OMO 配置管理 Agent 模型分配，兼容 oh-my-openagent.jsonc / oh-my-opencode.jsonc",
     "officialHint": "💡 官方供应商使用浏览器登录，无需配置 API Key",
+    "grokOfficialHint": "💡 Grok Official 使用空配置。保存后请在终端运行 `grok login`。FyAgent 不会代为登录，也不会写入 ~/.grok/auth.json。",
     "providerKeyStatusLoading": "正在加载供应商标识状态，请稍后再试",
     "getApiKey": "获取 API Key",
     "presets": {
@@ -3180,6 +3181,8 @@
     "extraUsage": "超额用量",
     "expired": "会话已过期",
     "expiredHint": "请运行 {{tool}} 命令刷新登录",
+    "grokOfficialExpiredHint": "请在终端运行 `grok login` 以刷新此登录。",
+    "xaiOauthExpiredHint": "请到认证中心重新登录此 xAI 账号。",
     "queryFailed": "查询失败",
     "refresh": "刷新"
   },

--- a/tests/components/GrokBuildProviderForm.test.tsx
+++ b/tests/components/GrokBuildProviderForm.test.tsx
@@ -24,6 +24,46 @@ vi.mock("@/components/JsonEditor", () => ({
 }));
 
 describe("GrokBuildProviderForm", () => {
+  it("tells the user to run grok login after selecting Grok Official", async () => {
+    const user = userEvent.setup();
+    render(
+      <GrokBuildProviderForm
+        submitLabel="Save"
+        onSubmit={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Grok Official/ }));
+
+    expect(screen.getByText(/grok login/)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/官方供应商使用浏览器登录/),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/browser login/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("API Key")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("raw-config")).not.toBeInTheDocument();
+    expect(screen.queryByText(/xAI OAuth/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/xaiOauth/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/device code/i)).not.toBeInTheDocument();
+  });
+
+  it("does not show the grok login lecture on third-party presets", async () => {
+    const user = userEvent.setup();
+    render(
+      <GrokBuildProviderForm
+        submitLabel="Save"
+        onSubmit={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /PatewayAI/ }));
+
+    expect(screen.queryByText(/grok login/)).not.toBeInTheDocument();
+    expect(screen.getByLabelText("API Key")).toBeInTheDocument();
+  });
+
   it("offers curated Grok Build presets and applies one", async () => {
     const user = userEvent.setup();
     const { container } = render(

--- a/tests/components/ProviderPresetSelector.test.tsx
+++ b/tests/components/ProviderPresetSelector.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import type { TFunction } from "i18next";
 import { useForm } from "react-hook-form";
+import type { ReactNode } from "react";
 import { Form } from "@/components/ui/form";
 import type { ProviderCategory } from "@/types";
 import {
@@ -111,9 +112,13 @@ function getIds(entries: ReadonlyArray<{ id: string }>) {
 function renderSelector({
   entries = presetEntries,
   onPresetChange = vi.fn(),
+  category,
+  categoryHint,
 }: {
   entries?: TestPresetEntry[];
   onPresetChange?: (value: string) => void;
+  category?: ProviderCategory;
+  categoryHint?: ReactNode;
 } = {}) {
   const Wrapper = () => {
     const form = useForm();
@@ -125,6 +130,8 @@ function renderSelector({
           presetEntries={entries}
           presetCategoryLabels={presetCategoryLabels}
           onPresetChange={onPresetChange}
+          category={category}
+          categoryHint={categoryHint}
         />
       </Form>
     );
@@ -577,5 +584,22 @@ describe("ProviderPresetSelector", () => {
     expect(
       screen.getByRole("button", { name: "preset.gamma" }),
     ).toBeInTheDocument();
+  });
+
+  it("keeps the generic officialHint for non-Grok official providers", () => {
+    renderSelector({ category: "official" });
+
+    expect(screen.getByText(/浏览器登录/)).toBeInTheDocument();
+    expect(screen.queryByText(/grok login/)).not.toBeInTheDocument();
+  });
+
+  it("renders a categoryHint override instead of the generic official hint", () => {
+    renderSelector({
+      category: "official",
+      categoryHint: "After save, run grok login in a terminal.",
+    });
+
+    expect(screen.getByText(/grok login/)).toBeInTheDocument();
+    expect(screen.queryByText(/浏览器登录/)).not.toBeInTheDocument();
   });
 });

--- a/tests/components/SubscriptionQuotaFooter.test.tsx
+++ b/tests/components/SubscriptionQuotaFooter.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from "@testing-library/react";
+import i18n from "i18next";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import SubscriptionQuotaFooter, {
+  getSubscriptionExpiredHintKey,
+  SubscriptionQuotaView,
+} from "@/components/SubscriptionQuotaFooter";
+import en from "@/i18n/locales/en.json";
+import ja from "@/i18n/locales/ja.json";
+import zhTW from "@/i18n/locales/zh-TW.json";
+import zh from "@/i18n/locales/zh.json";
+import type { SubscriptionQuota } from "@/types/subscription";
+
+const mockUseSubscriptionQuota = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/query/subscription", () => ({
+  useSubscriptionQuota: (...args: unknown[]) =>
+    mockUseSubscriptionQuota(...args),
+}));
+
+const expiredQuota: SubscriptionQuota = {
+  tool: "grok",
+  credentialStatus: "expired",
+  credentialMessage: "Please re-login with `grok login`.",
+  success: false,
+  tiers: [],
+  extraUsage: null,
+  error: null,
+  queriedAt: Date.now(),
+};
+
+describe("getSubscriptionExpiredHintKey", () => {
+  it("keeps Official Grok, xAI OAuth, and generic CLI expiry copy on separate keys", () => {
+    expect(getSubscriptionExpiredHintKey("grok")).toBe(
+      "subscription.grokOfficialExpiredHint",
+    );
+    expect(getSubscriptionExpiredHintKey("grokbuild")).toBe(
+      "subscription.grokOfficialExpiredHint",
+    );
+    expect(getSubscriptionExpiredHintKey("xai_oauth")).toBe(
+      "subscription.xaiOauthExpiredHint",
+    );
+    expect(getSubscriptionExpiredHintKey("claude")).toBe(
+      "subscription.expiredHint",
+    );
+    expect(getSubscriptionExpiredHintKey("codex")).toBe(
+      "subscription.expiredHint",
+    );
+    expect(getSubscriptionExpiredHintKey("codex_oauth")).toBe(
+      "subscription.expiredHint",
+    );
+  });
+});
+
+describe("official and generic expiry copy", () => {
+  beforeEach(() => {
+    i18n.addResourceBundle("zh", "translation", zh, true, true);
+    mockUseSubscriptionQuota.mockReturnValue({
+      data: expiredQuota,
+      isFetching: false,
+      refetch: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    i18n.removeResourceBundle("zh", "translation");
+    i18n.addResourceBundle("zh", "translation", {});
+  });
+
+  it("points Official Grok expiry at a terminal grok login", () => {
+    render(<SubscriptionQuotaFooter appId="grokbuild" isCurrent />);
+
+    expect(screen.getByText(/grok login/)).toBeInTheDocument();
+    expect(screen.queryByText(/认证中心/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/xai_oauth/)).not.toBeInTheDocument();
+  });
+
+  it("keeps generic CLI expiry copy for non-Grok tools", () => {
+    render(
+      <SubscriptionQuotaView
+        quota={expiredQuota}
+        loading={false}
+        refetch={() => {}}
+        appIdForExpiredHint="claude"
+      />,
+    );
+
+    expect(screen.getByText(/请运行 claude 命令刷新登录/)).toBeInTheDocument();
+    expect(screen.queryByText(/grok login/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/认证中心/)).not.toBeInTheDocument();
+  });
+});
+
+describe("official expiry locale copy", () => {
+  it("keeps the grok login literal in every locale", () => {
+    for (const locale of [zh, en, ja, zhTW]) {
+      expect(locale.providerForm.grokOfficialHint).toContain("grok login");
+      expect(locale.subscription.grokOfficialExpiredHint).toContain(
+        "grok login",
+      );
+      expect(locale.subscription.xaiOauthExpiredHint).not.toContain(
+        "grok login",
+      );
+    }
+  });
+});

--- a/tests/components/XaiOauthQuotaFooter.test.tsx
+++ b/tests/components/XaiOauthQuotaFooter.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from "@testing-library/react";
+import i18n from "i18next";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SubscriptionQuotaView } from "@/components/SubscriptionQuotaFooter";
+import XaiOauthQuotaFooter from "@/components/XaiOauthQuotaFooter";
+import en from "@/i18n/locales/en.json";
+import ja from "@/i18n/locales/ja.json";
+import zhTW from "@/i18n/locales/zh-TW.json";
+import zh from "@/i18n/locales/zh.json";
+import type { SubscriptionQuota } from "@/types/subscription";
+
+const mockUseXaiOauthQuota = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/query/subscription", () => ({
+  useXaiOauthQuota: (...args: unknown[]) => mockUseXaiOauthQuota(...args),
+}));
+
+const expiredQuota: SubscriptionQuota = {
+  tool: "xai_oauth",
+  credentialStatus: "expired",
+  credentialMessage: null,
+  success: false,
+  tiers: [],
+  extraUsage: null,
+  error: null,
+  queriedAt: Date.now(),
+};
+
+describe("XaiOauthQuotaFooter expiry copy", () => {
+  beforeEach(() => {
+    i18n.addResourceBundle("zh", "translation", zh, true, true);
+    mockUseXaiOauthQuota.mockReturnValue({
+      data: expiredQuota,
+      isFetching: false,
+      refetch: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    i18n.removeResourceBundle("zh", "translation");
+    i18n.addResourceBundle("zh", "translation", {});
+  });
+
+  it("points expired xAI OAuth credentials at Auth Center", () => {
+    render(<XaiOauthQuotaFooter isCurrent />);
+
+    expect(screen.getByText(/认证中心/)).toBeInTheDocument();
+    expect(screen.queryByText(/grok login/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/xai_oauth/)).not.toBeInTheDocument();
+  });
+
+  it("does not send xAI expiry to a CLI command via SubscriptionQuotaView", () => {
+    render(
+      <SubscriptionQuotaView
+        quota={expiredQuota}
+        loading={false}
+        refetch={() => {}}
+        appIdForExpiredHint="xai_oauth"
+      />,
+    );
+
+    expect(screen.getByText(/认证中心/)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/请运行 xai_oauth 命令刷新登录/),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("xAI OAuth expiry locale copy", () => {
+  it("mentions Auth Center in every locale and never grok login", () => {
+    expect(zh.subscription.xaiOauthExpiredHint).toMatch(/认证中心/);
+    expect(en.subscription.xaiOauthExpiredHint).toMatch(
+      /Auth Center|Authentication Center/,
+    );
+    expect(ja.subscription.xaiOauthExpiredHint).toMatch(/認証センター/);
+    expect(zhTW.subscription.xaiOauthExpiredHint).toMatch(/驗證中心|認證中心/);
+
+    for (const locale of [zh, en, ja, zhTW]) {
+      expect(locale.subscription.xaiOauthExpiredHint).not.toContain(
+        "grok login",
+      );
+      expect(locale.subscription.xaiOauthExpiredHint).not.toContain(
+        "xai_oauth",
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Slice 1 only: Official Grok copy now names terminal `grok login`; xAI device-code expiry stays in Auth Center.
- Four locales updated. FyAgent still does not write `~/.grok/auth.json`.
- No install, env, failover, session-header, MCP/Skills, or quota-card work.

Closes #107

## Test plan
- [x] `mise run test:i18n`
- [x] focused `mise run test:unit` for GrokBuildProviderForm / SubscriptionQuotaFooter / XaiOauthQuotaFooter / ProviderPresetSelector and related Grok panels
- [x] `mise run rust:test -- grok`
- [x] `mise run rust:test -- env_checker`
- [x] `mise run rust:test -- xai_oauth`