### PR TITLE
feat(apply): presentation ApplyWorkspace and fake coordinator (Refs #41)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -69,6 +69,7 @@ pub use mcp::{
 };
 pub use prompt::Prompt;
 pub use provider::{Provider, ProviderMeta};
+pub use services::configuration_apply;
 pub use services::{
     profile::{ProfilePayload, ProfileScope, ProfileService},
     provider::reapply_current_codex_official_live,

--- a/src-tauri/src/services/configuration_apply/backup.rs
+++ b/src-tauri/src/services/configuration_apply/backup.rs
@@ -1,0 +1,56 @@
+//! Job-owned in-process backup receipt. No wire serialization, no SQLite.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Closed resource kinds the fake adapter may declare.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackupResourceKind {
+    CodexLiveConfig,
+}
+
+/// Process-local receipt that a backup bundle was committed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BackupReceipt {
+    pub resource_count: u16,
+}
+
+/// Why a fake backup could not be created.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackupError {
+    NoResources,
+}
+
+/// In-memory backup store used by the fake coordinator.
+pub struct FakeBackupStore {
+    available: AtomicBool,
+}
+
+impl FakeBackupStore {
+    pub fn new() -> Self {
+        Self {
+            available: AtomicBool::new(false),
+        }
+    }
+
+    pub fn create_from_declared_resources(
+        &self,
+        resources: &[BackupResourceKind],
+    ) -> Result<BackupReceipt, BackupError> {
+        let resource_count = match u16::try_from(resources.len()) {
+            Ok(0) | Err(_) => return Err(BackupError::NoResources),
+            Ok(count) => count,
+        };
+        self.available.store(true, Ordering::Release);
+        Ok(BackupReceipt { resource_count })
+    }
+
+    pub fn is_available(&self) -> bool {
+        self.available.load(Ordering::Acquire)
+    }
+}
+
+impl Default for FakeBackupStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src-tauri/src/services/configuration_apply/mod.rs
+++ b/src-tauri/src/services/configuration_apply/mod.rs
@@ -1,0 +1,155 @@
+//! Process-local configuration-apply coordinator with a fake Provider adapter.
+//!
+//! Does not persist jobs, resolve #35 secrets, or wire production commands.
+
+mod backup;
+mod provider;
+mod runtime;
+
+pub use backup::{BackupError, BackupReceipt, BackupResourceKind, FakeBackupStore};
+pub use provider::{
+    FakeProviderAdapter, FakeWriterMode, ProviderHttpSpy, ReadbackError, ReadbackMatch, WriteError,
+    WriteReceipt,
+};
+pub use runtime::{ApplyRuntime, CancellationHandle, WorkerAcquireError};
+
+/// Backend job terminal/non-terminal status. `not_started` is renderer-only.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApplyJobStatus {
+    Planned,
+    Running,
+    Succeeded,
+    Warning,
+    Failed,
+    Cancelled,
+}
+
+/// Observed local effect after the run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApplyEffect {
+    None,
+    Applied,
+    Partial,
+    Unknown,
+}
+
+/// Recovery actions the fake coordinator may surface. Closed set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApplyRecoveryAction {
+    RetryReadback,
+    RestoreBackup,
+    RetryRefresh,
+    RegeneratePlan,
+}
+
+/// Binary observables for the process-local fake run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApplyRunOutcome {
+    pub status: ApplyJobStatus,
+    pub effect: ApplyEffect,
+    pub writer_count: u64,
+    pub outbound_provider_http_count: u64,
+    pub recovery_actions: Vec<ApplyRecoveryAction>,
+}
+
+/// Fake coordinator: backup → writer once → readback → effect.
+pub struct FakeApplyCoordinator {
+    runtime: ApplyRuntime,
+    adapter: FakeProviderAdapter,
+    backup: FakeBackupStore,
+}
+
+impl FakeApplyCoordinator {
+    pub fn succeeding() -> Self {
+        Self {
+            runtime: ApplyRuntime::new(),
+            adapter: FakeProviderAdapter::succeeding(),
+            backup: FakeBackupStore::new(),
+        }
+    }
+
+    pub fn failing_writer() -> Self {
+        Self {
+            runtime: ApplyRuntime::new(),
+            adapter: FakeProviderAdapter::failing(),
+            backup: FakeBackupStore::new(),
+        }
+    }
+
+    pub fn request_cancel(&self) {
+        self.runtime.request_cancel();
+    }
+
+    pub fn run(&self) -> ApplyRunOutcome {
+        let _worker = match self.runtime.try_acquire_worker() {
+            Ok(guard) => guard,
+            Err(WorkerAcquireError::AlreadyActive | WorkerAcquireError::Poisoned) => {
+                return self.finish(
+                    ApplyJobStatus::Failed,
+                    ApplyEffect::None,
+                    vec![ApplyRecoveryAction::RegeneratePlan],
+                );
+            }
+        };
+
+        if self.runtime.cancel_requested() {
+            return self.finish(ApplyJobStatus::Cancelled, ApplyEffect::None, Vec::new());
+        }
+
+        let declared = [BackupResourceKind::CodexLiveConfig];
+        if self
+            .backup
+            .create_from_declared_resources(&declared)
+            .is_err()
+        {
+            return self.finish(
+                ApplyJobStatus::Failed,
+                ApplyEffect::None,
+                vec![ApplyRecoveryAction::RegeneratePlan],
+            );
+        }
+
+        if self.runtime.cancel_requested() {
+            return self.finish(ApplyJobStatus::Cancelled, ApplyEffect::None, Vec::new());
+        }
+
+        match self.adapter.write_once() {
+            Ok(_receipt) => {}
+            Err(WriteError::ManagedWriteFailed | WriteError::WriterAlreadyUsed) => {
+                let recovery = if self.backup.is_available() {
+                    vec![ApplyRecoveryAction::RestoreBackup]
+                } else {
+                    vec![ApplyRecoveryAction::RegeneratePlan]
+                };
+                return self.finish(ApplyJobStatus::Failed, ApplyEffect::None, recovery);
+            }
+        }
+
+        match self.adapter.readback() {
+            Ok(_matched) => {
+                self.finish(ApplyJobStatus::Succeeded, ApplyEffect::Applied, Vec::new())
+            }
+            Err(ReadbackError::Mismatch) => self.finish(
+                ApplyJobStatus::Failed,
+                ApplyEffect::Unknown,
+                vec![ApplyRecoveryAction::RetryReadback],
+            ),
+        }
+    }
+
+    fn finish(
+        &self,
+        status: ApplyJobStatus,
+        effect: ApplyEffect,
+        recovery_actions: Vec<ApplyRecoveryAction>,
+    ) -> ApplyRunOutcome {
+        self.runtime.emit_terminal();
+        ApplyRunOutcome {
+            status,
+            effect,
+            writer_count: self.adapter.writer_count(),
+            outbound_provider_http_count: self.adapter.outbound_http_count(),
+            recovery_actions,
+        }
+    }
+}

--- a/src-tauri/src/services/configuration_apply/provider.rs
+++ b/src-tauri/src/services/configuration_apply/provider.rs
@@ -1,0 +1,106 @@
+//! Fake Codex Provider adapter: one writer call, readback, outbound HTTP spy.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+/// Counts Provider HTTP that the adapter would make. Fake path never increments.
+#[derive(Debug, Default)]
+pub struct ProviderHttpSpy {
+    count: AtomicU64,
+}
+
+impl ProviderHttpSpy {
+    pub fn new() -> Self {
+        Self {
+            count: AtomicU64::new(0),
+        }
+    }
+
+    pub fn record_outbound(&self) {
+        self.count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn count(&self) -> u64 {
+        self.count.load(Ordering::Relaxed)
+    }
+}
+
+/// How the single fake writer invocation behaves.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FakeWriterMode {
+    Succeed,
+    Fail,
+}
+
+/// Successful local write that has not yet been read back.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WriteReceipt {
+    pub resource_count: u16,
+}
+
+/// Successful non-sensitive readback match.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReadbackMatch {
+    pub resource_count: u16,
+}
+
+/// Writer-side failure. Never a network error: the fake does not dial.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WriteError {
+    WriterAlreadyUsed,
+    ManagedWriteFailed,
+}
+
+/// Readback-side failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReadbackError {
+    Mismatch,
+}
+
+/// Process-local fake around the "call writer exactly once" contract.
+pub struct FakeProviderAdapter {
+    mode: FakeWriterMode,
+    writer_count: AtomicU64,
+    http: Arc<ProviderHttpSpy>,
+}
+
+impl FakeProviderAdapter {
+    pub fn succeeding() -> Self {
+        Self::with_mode(FakeWriterMode::Succeed)
+    }
+
+    pub fn failing() -> Self {
+        Self::with_mode(FakeWriterMode::Fail)
+    }
+
+    fn with_mode(mode: FakeWriterMode) -> Self {
+        Self {
+            mode,
+            writer_count: AtomicU64::new(0),
+            http: Arc::new(ProviderHttpSpy::new()),
+        }
+    }
+
+    pub fn write_once(&self) -> Result<WriteReceipt, WriteError> {
+        let prior = self.writer_count.fetch_add(1, Ordering::AcqRel);
+        if prior != 0 {
+            return Err(WriteError::WriterAlreadyUsed);
+        }
+        match self.mode {
+            FakeWriterMode::Succeed => Ok(WriteReceipt { resource_count: 1 }),
+            FakeWriterMode::Fail => Err(WriteError::ManagedWriteFailed),
+        }
+    }
+
+    pub fn readback(&self) -> Result<ReadbackMatch, ReadbackError> {
+        Ok(ReadbackMatch { resource_count: 1 })
+    }
+
+    pub fn writer_count(&self) -> u64 {
+        self.writer_count.load(Ordering::Acquire)
+    }
+
+    pub fn outbound_http_count(&self) -> u64 {
+        self.http.count()
+    }
+}

--- a/src-tauri/src/services/configuration_apply/runtime.rs
+++ b/src-tauri/src/services/configuration_apply/runtime.rs
@@ -1,0 +1,85 @@
+//! Process-local cancel handles, one-worker-per-job guard, and event sink.
+//! Does not retain snapshot, plan, secret, or backup bytes.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard, TryLockError};
+
+/// Cooperative cancel flag shared by the coordinator and cancel command.
+#[derive(Clone, Debug)]
+pub struct CancellationHandle {
+    requested: Arc<AtomicBool>,
+}
+
+impl CancellationHandle {
+    pub fn new() -> Self {
+        Self {
+            requested: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    pub fn request(&self) {
+        self.requested.store(true, Ordering::Release);
+    }
+
+    pub fn is_requested(&self) -> bool {
+        self.requested.load(Ordering::Acquire)
+    }
+}
+
+impl Default for CancellationHandle {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Why a worker could not start.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkerAcquireError {
+    AlreadyActive,
+    Poisoned,
+}
+
+/// Process-local apply runtime: cancel + single worker + sink, no durable state.
+pub struct ApplyRuntime {
+    cancel: CancellationHandle,
+    worker: Mutex<()>,
+    emissions: std::sync::atomic::AtomicU64,
+}
+
+impl ApplyRuntime {
+    pub fn new() -> Self {
+        Self {
+            cancel: CancellationHandle::new(),
+            worker: Mutex::new(()),
+            emissions: std::sync::atomic::AtomicU64::new(0),
+        }
+    }
+
+    pub fn request_cancel(&self) {
+        self.cancel.request();
+    }
+
+    pub fn cancel_requested(&self) -> bool {
+        self.cancel.is_requested()
+    }
+
+    /// One worker per coordinator instance. Does not persist job identity.
+    pub fn try_acquire_worker(&self) -> Result<MutexGuard<'_, ()>, WorkerAcquireError> {
+        match self.worker.try_lock() {
+            Ok(guard) => Ok(guard),
+            Err(TryLockError::WouldBlock) => Err(WorkerAcquireError::AlreadyActive),
+            Err(TryLockError::Poisoned(_)) => Err(WorkerAcquireError::Poisoned),
+        }
+    }
+
+    /// Sink records only that a terminal transition was published, not the body.
+    pub fn emit_terminal(&self) {
+        self.emissions.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+impl Default for ApplyRuntime {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -3,6 +3,7 @@ pub mod codex_desktop;
 pub mod codex_oauth_models;
 pub mod coding_plan;
 pub mod config;
+pub mod configuration_apply;
 pub mod env_checker;
 pub mod env_manager;
 pub mod mcp;

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -54,6 +54,28 @@ pub fn official_provider_supports_proxy_takeover(app_type: &AppType, provider: &
         && crate::proxy::providers::is_codex_official_provider(provider)
 }
 
+/// Apply-phase per-app write lock. Same lock as `lock_switch_for_app`.
+/// Not an activation lease.
+pub struct ProviderWriteLease {
+    _guard: Option<tokio::sync::OwnedMutexGuard<()>>,
+}
+
+impl ProviderWriteLease {
+    pub fn acquire(state: &AppState, app_type: &AppType) -> Self {
+        let guard = if matches!(
+            app_type,
+            AppType::Claude | AppType::Codex | AppType::Gemini | AppType::GrokBuild
+        ) {
+            Some(futures::executor::block_on(
+                state.proxy_service.lock_switch_for_app(app_type.as_str()),
+            ))
+        } else {
+            None
+        };
+        Self { _guard: guard }
+    }
+}
+
 /// 统一会话开关变更后，立即按新开关状态重写当前官方 Codex 供应商的
 /// live 配置，使开关即时生效（无需等下一次切换）。
 /// 当前供应商非官方（或不存在）时为 no-op：注入只作用于官方配置，
@@ -3612,16 +3634,7 @@ impl ProviderService {
         // restore backup. Serialize them per app, then decide from the locked
         // current state so a just-started takeover cannot be overwritten by a
         // normal live write.
-        let _switch_guard = if matches!(
-            app_type,
-            AppType::Claude | AppType::Codex | AppType::Gemini | AppType::GrokBuild
-        ) {
-            Some(futures::executor::block_on(
-                state.proxy_service.lock_switch_for_app(app_type.as_str()),
-            ))
-        } else {
-            None
-        };
+        let _switch_guard = ProviderWriteLease::acquire(state, &app_type);
 
         // Backup or live placeholders mean the live file is owned by proxy
         // takeover, even if the proxy server is temporarily stopped or is in the

--- a/src-tauri/tests/configuration_apply.rs
+++ b/src-tauri/tests/configuration_apply.rs
@@ -1,0 +1,51 @@
+use fyagent_lib::configuration_apply::{
+    ApplyEffect, ApplyJobStatus, ApplyRecoveryAction, FakeApplyCoordinator,
+};
+
+#[test]
+fn configuration_apply_cancel_before_write_closes_with_effect_none() {
+    // Given: a process-local fake coordinator that has not started writing
+    let coordinator = FakeApplyCoordinator::succeeding();
+    coordinator.request_cancel();
+
+    // When: the run observes cancel at the last pre-write safe point
+    let outcome = coordinator.run();
+
+    // Then: typed none, no writer invocation
+    assert_eq!(outcome.effect, ApplyEffect::None);
+    assert_eq!(outcome.status, ApplyJobStatus::Cancelled);
+    assert_eq!(outcome.writer_count, 0);
+}
+
+#[test]
+fn configuration_apply_writer_fail_is_not_green() {
+    // Given: a fake adapter whose single writer call fails
+    let coordinator = FakeApplyCoordinator::failing_writer();
+
+    // When: the coordinator runs backup → writer → readback
+    let outcome = coordinator.run();
+
+    // Then: not green, no success effect, recovery is required
+    assert_ne!(outcome.status, ApplyJobStatus::Succeeded);
+    assert_ne!(outcome.effect, ApplyEffect::Applied);
+    assert_eq!(outcome.status, ApplyJobStatus::Failed);
+    assert!(
+        outcome
+            .recovery_actions
+            .iter()
+            .any(|action| matches!(action, ApplyRecoveryAction::RestoreBackup)),
+        "writer failure must expose restore recovery"
+    );
+}
+
+#[test]
+fn configuration_apply_makes_zero_outbound_provider_http_calls() {
+    // Given: a succeeding fake coordinator with an outbound HTTP spy
+    let coordinator = FakeApplyCoordinator::succeeding();
+
+    // When: the fake adapter runs the full local path
+    let outcome = coordinator.run();
+
+    // Then: the spy records no Provider HTTP
+    assert_eq!(outcome.outbound_provider_http_count, 0);
+}

--- a/src/v2/pages/models/apply/ApplyWorkspace.tsx
+++ b/src/v2/pages/models/apply/ApplyWorkspace.tsx
@@ -1,0 +1,167 @@
+import { CheckCircleIcon } from "@phosphor-icons/react/dist/csr/CheckCircle";
+import { CircleIcon } from "@phosphor-icons/react/dist/csr/Circle";
+import { CircleNotchIcon } from "@phosphor-icons/react/dist/csr/CircleNotch";
+import { MinusCircleIcon } from "@phosphor-icons/react/dist/csr/MinusCircle";
+import { WarningCircleIcon } from "@phosphor-icons/react/dist/csr/WarningCircle";
+import { XCircleIcon } from "@phosphor-icons/react/dist/csr/XCircle";
+
+import { applyFixtures, type ApplyScenario } from "./fixtures";
+import {
+  assertNever,
+  createApplyViewModel,
+  type ApplyPresentation,
+  type ApplyStepPresentation,
+  type ApplyStepStatus,
+} from "./view-model";
+import "./apply-workspace.css";
+
+export type ApplyWorkspaceProps = {
+  readonly scenario?: ApplyScenario;
+};
+
+function StepStatusIcon({ status }: { readonly status: ApplyStepStatus }) {
+  switch (status) {
+    case "succeeded":
+      return <CheckCircleIcon className="fy-apply-icon" size={18} weight="fill" aria-hidden />;
+    case "running":
+      return (
+        <CircleNotchIcon
+          className="fy-apply-icon fy-apply-spin"
+          size={18}
+          weight="bold"
+          aria-hidden
+        />
+      );
+    case "warning":
+      return <WarningCircleIcon className="fy-apply-icon" size={18} weight="fill" aria-hidden />;
+    case "failed":
+      return <XCircleIcon className="fy-apply-icon" size={18} weight="fill" aria-hidden />;
+    case "cancelled":
+      return <MinusCircleIcon className="fy-apply-icon" size={18} weight="fill" aria-hidden />;
+    case "planned":
+    case "not_started":
+      return <CircleIcon className="fy-apply-icon" size={18} weight="regular" aria-hidden />;
+    default:
+      return assertNever(status);
+  }
+}
+
+function PlanPane({ view }: { readonly view: ApplyPresentation }) {
+  return (
+    <section className="fy-apply-pane fy-apply-plan" data-testid="apply-plan">
+      <h2>已确认变更</h2>
+      <div className="fy-apply-plan-meta">
+        <strong>{view.plan.actionLabel}</strong>
+        <span>{`逻辑资源 ${String(view.plan.resourceCount)} 项`}</span>
+        <em data-valid={view.plan.baselineValid ? "true" : "false"}>
+          {view.plan.baselineValid ? "基线有效" : "基线已失效"}
+        </em>
+      </div>
+    </section>
+  );
+}
+
+function TimelinePane({ view }: { readonly view: ApplyPresentation }) {
+  return (
+    <section className="fy-apply-pane fy-apply-timeline" data-testid="apply-timeline">
+      <h2>执行进度</h2>
+      <ol className="fy-apply-step-list" aria-label="应用步骤">
+        {view.steps.map((step) => (
+          <StepRow key={step.stepId} step={step} />
+        ))}
+      </ol>
+    </section>
+  );
+}
+
+function StepRow({ step }: { readonly step: ApplyStepPresentation }) {
+  return (
+    <li
+      className="fy-apply-step"
+      data-status={step.status}
+      aria-current={step.current ? "step" : undefined}
+    >
+      <StepStatusIcon status={step.status} />
+      <strong className="fy-apply-step-copy">{step.label}</strong>
+      <em>{step.statusLabel}</em>
+    </li>
+  );
+}
+
+function OutcomePane({ view }: { readonly view: ApplyPresentation }) {
+  return (
+    <section className="fy-apply-pane fy-apply-outcome" data-testid="apply-outcome">
+      <h2 className="fy-visually-hidden">应用结果</h2>
+      <p className="fy-visually-hidden" aria-live="polite">
+        {view.title}
+      </p>
+      <h3 className="fy-apply-outcome-title">{view.title}</h3>
+      <p className="fy-apply-outcome-copy">{view.subtitle}</p>
+      <p className="fy-apply-effect">{`效果：${view.effectLabel}`}</p>
+      {view.backupAvailable ? <p className="fy-apply-backup">备份可用</p> : null}
+      {view.failureLabel ? <p className="fy-apply-failure">{view.failureLabel}</p> : null}
+      {view.notices.map((notice) => (
+        <p key={notice} className="fy-apply-notice">
+          {notice}
+        </p>
+      ))}
+      {view.evidence.length > 0 ? (
+        <ul className="fy-apply-evidence">
+          {view.evidence.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      ) : null}
+      {view.observedUsageCopy ? (
+        <p className="fy-apply-usage">{view.observedUsageCopy}</p>
+      ) : null}
+      <div className="fy-apply-actions">
+        {view.actions.map((action) => (
+          <button
+            key={action.kind}
+            className="fy-apply-action"
+            type="button"
+            data-primary={action.primary ? "true" : "false"}
+          >
+            {action.label}
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function ApplyWorkspace({
+  scenario = "succeeded",
+}: ApplyWorkspaceProps) {
+  const view = createApplyViewModel(applyFixtures[scenario]);
+
+  return (
+    <section
+      className="fy-apply-workspace"
+      aria-labelledby="fy-apply-title"
+      data-testid="apply-workspace"
+      data-data-source="prototype"
+      data-status={view.status}
+      data-effect={view.effect}
+    >
+      <header className="fy-apply-header">
+        <div className="fy-apply-title-group">
+          <h1 id="fy-apply-title">应用配置</h1>
+          <div className="fy-apply-context-row">
+            <strong className="fy-apply-prototype-status">前端原型 · 模拟数据</strong>
+            <span className="fy-apply-outbound-note">不发送测试请求</span>
+          </div>
+        </div>
+        <span className="fy-apply-status-badge" data-status={view.status}>
+          {view.statusLabel}
+        </span>
+      </header>
+      <div className="fy-apply-grid">
+        <PlanPane view={view} />
+        <TimelinePane view={view} />
+        <OutcomePane view={view} />
+      </div>
+    </section>
+  );
+}

--- a/src/v2/pages/models/apply/ApplyWorkspace.tsx
+++ b/src/v2/pages/models/apply/ApplyWorkspace.tsx
@@ -1,10 +1,3 @@
-import { CheckCircleIcon } from "@phosphor-icons/react/dist/csr/CheckCircle";
-import { CircleIcon } from "@phosphor-icons/react/dist/csr/Circle";
-import { CircleNotchIcon } from "@phosphor-icons/react/dist/csr/CircleNotch";
-import { MinusCircleIcon } from "@phosphor-icons/react/dist/csr/MinusCircle";
-import { WarningCircleIcon } from "@phosphor-icons/react/dist/csr/WarningCircle";
-import { XCircleIcon } from "@phosphor-icons/react/dist/csr/XCircle";
-
 import { applyFixtures, type ApplyScenario } from "./fixtures";
 import {
   assertNever,
@@ -19,28 +12,18 @@ export type ApplyWorkspaceProps = {
   readonly scenario?: ApplyScenario;
 };
 
-function StepStatusIcon({ status }: { readonly status: ApplyStepStatus }) {
+function StepStatusMark({ status }: { readonly status: ApplyStepStatus }) {
   switch (status) {
     case "succeeded":
-      return <CheckCircleIcon className="fy-apply-icon" size={18} weight="fill" aria-hidden />;
     case "running":
-      return (
-        <CircleNotchIcon
-          className="fy-apply-icon fy-apply-spin"
-          size={18}
-          weight="bold"
-          aria-hidden
-        />
-      );
     case "warning":
-      return <WarningCircleIcon className="fy-apply-icon" size={18} weight="fill" aria-hidden />;
     case "failed":
-      return <XCircleIcon className="fy-apply-icon" size={18} weight="fill" aria-hidden />;
     case "cancelled":
-      return <MinusCircleIcon className="fy-apply-icon" size={18} weight="fill" aria-hidden />;
     case "planned":
     case "not_started":
-      return <CircleIcon className="fy-apply-icon" size={18} weight="regular" aria-hidden />;
+      return (
+        <span className="fy-apply-icon" data-status={status} aria-hidden />
+      );
     default:
       return assertNever(status);
   }
@@ -63,7 +46,10 @@ function PlanPane({ view }: { readonly view: ApplyPresentation }) {
 
 function TimelinePane({ view }: { readonly view: ApplyPresentation }) {
   return (
-    <section className="fy-apply-pane fy-apply-timeline" data-testid="apply-timeline">
+    <section
+      className="fy-apply-pane fy-apply-timeline"
+      data-testid="apply-timeline"
+    >
       <h2>执行进度</h2>
       <ol className="fy-apply-step-list" aria-label="应用步骤">
         {view.steps.map((step) => (
@@ -81,7 +67,7 @@ function StepRow({ step }: { readonly step: ApplyStepPresentation }) {
       data-status={step.status}
       aria-current={step.current ? "step" : undefined}
     >
-      <StepStatusIcon status={step.status} />
+      <StepStatusMark status={step.status} />
       <strong className="fy-apply-step-copy">{step.label}</strong>
       <em>{step.statusLabel}</em>
     </li>
@@ -90,7 +76,10 @@ function StepRow({ step }: { readonly step: ApplyStepPresentation }) {
 
 function OutcomePane({ view }: { readonly view: ApplyPresentation }) {
   return (
-    <section className="fy-apply-pane fy-apply-outcome" data-testid="apply-outcome">
+    <section
+      className="fy-apply-pane fy-apply-outcome"
+      data-testid="apply-outcome"
+    >
       <h2 className="fy-visually-hidden">应用结果</h2>
       <p className="fy-visually-hidden" aria-live="polite">
         {view.title}
@@ -98,8 +87,12 @@ function OutcomePane({ view }: { readonly view: ApplyPresentation }) {
       <h3 className="fy-apply-outcome-title">{view.title}</h3>
       <p className="fy-apply-outcome-copy">{view.subtitle}</p>
       <p className="fy-apply-effect">{`效果：${view.effectLabel}`}</p>
-      {view.backupAvailable ? <p className="fy-apply-backup">备份可用</p> : null}
-      {view.failureLabel ? <p className="fy-apply-failure">{view.failureLabel}</p> : null}
+      {view.backupAvailable ? (
+        <p className="fy-apply-backup">备份可用</p>
+      ) : null}
+      {view.failureLabel ? (
+        <p className="fy-apply-failure">{view.failureLabel}</p>
+      ) : null}
       {view.notices.map((notice) => (
         <p key={notice} className="fy-apply-notice">
           {notice}
@@ -149,7 +142,9 @@ export function ApplyWorkspace({
         <div className="fy-apply-title-group">
           <h1 id="fy-apply-title">应用配置</h1>
           <div className="fy-apply-context-row">
-            <strong className="fy-apply-prototype-status">前端原型 · 模拟数据</strong>
+            <strong className="fy-apply-prototype-status">
+              前端原型 · 模拟数据
+            </strong>
             <span className="fy-apply-outbound-note">不发送测试请求</span>
           </div>
         </div>

--- a/src/v2/pages/models/apply/apply-workspace.css
+++ b/src/v2/pages/models/apply/apply-workspace.css
@@ -215,26 +215,44 @@
 }
 
 .fy-apply-icon {
+  box-sizing: border-box;
+  width: 14px;
+  height: 14px;
+  flex: 0 0 14px;
+  border: 1.5px solid currentColor;
+  border-radius: 999px;
   color: var(--fy-text-tertiary);
+  background: transparent;
 }
 
-.fy-apply-step[data-status="succeeded"] .fy-apply-icon {
+.fy-apply-step[data-status="succeeded"] .fy-apply-icon,
+.fy-apply-icon[data-status="succeeded"] {
   color: var(--fy-success);
+  background: currentColor;
 }
 
-.fy-apply-step[data-status="warning"] .fy-apply-icon {
+.fy-apply-step[data-status="warning"] .fy-apply-icon,
+.fy-apply-icon[data-status="warning"] {
   color: var(--fy-warning);
+  background: currentColor;
 }
 
-.fy-apply-step[data-status="failed"] .fy-apply-icon {
+.fy-apply-step[data-status="failed"] .fy-apply-icon,
+.fy-apply-icon[data-status="failed"] {
   color: var(--fy-danger-text);
+  background: currentColor;
 }
 
-.fy-apply-step[data-status="running"] .fy-apply-icon {
+.fy-apply-step[data-status="cancelled"] .fy-apply-icon,
+.fy-apply-icon[data-status="cancelled"] {
+  color: var(--fy-text-tertiary);
+  background: currentColor;
+}
+
+.fy-apply-step[data-status="running"] .fy-apply-icon,
+.fy-apply-icon[data-status="running"] {
   color: var(--fy-accent-text);
-}
-
-.fy-apply-spin {
+  border-top-color: transparent;
   animation: fy-apply-spin 900ms linear infinite;
 }
 

--- a/src/v2/pages/models/apply/apply-workspace.css
+++ b/src/v2/pages/models/apply/apply-workspace.css
@@ -1,0 +1,416 @@
+.fy-apply-workspace {
+  display: grid;
+  grid-template-rows: 116px minmax(0, 1fr);
+  width: 100%;
+  min-width: 0;
+  height: 100%;
+  min-height: 0;
+  padding: 0 31px 44px 26px;
+  color: var(--fy-text);
+}
+
+.fy-apply-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-width: 0;
+  padding: 0 14px 0 12px;
+}
+
+.fy-apply-title-group {
+  display: flex;
+  align-items: flex-start;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.fy-apply-title-group h1 {
+  margin: 0;
+  color: var(--fy-text);
+  font-size: clamp(30px, 2.35vw, 38px);
+  font-weight: 650;
+  line-height: 1.08;
+  letter-spacing: -0.02em;
+}
+
+.fy-apply-context-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  min-width: 0;
+}
+
+.fy-apply-prototype-status,
+.fy-apply-outbound-note {
+  flex: 0 0 auto;
+  padding: 3px 8px;
+  border: 1px solid var(--fy-border);
+  border-radius: 999px;
+  color: var(--fy-accent-text);
+  font-size: 11px;
+  font-weight: 550;
+  line-height: 1.35;
+  background: var(--fy-control);
+}
+
+.fy-apply-status-badge {
+  min-width: 88px;
+  padding: 8px 16px;
+  border: 1px solid var(--fy-border-strong);
+  border-radius: 999px;
+  color: var(--fy-text);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  background: var(--fy-surface-strong);
+}
+
+.fy-apply-status-badge[data-status="succeeded"] {
+  border-color: color-mix(in srgb, var(--fy-success) 46%, transparent);
+  color: var(--fy-success);
+}
+
+.fy-apply-status-badge[data-status="warning"] {
+  border-color: color-mix(in srgb, var(--fy-warning) 46%, transparent);
+  color: var(--fy-warning);
+}
+
+.fy-apply-status-badge[data-status="failed"] {
+  border-color: color-mix(in srgb, var(--fy-danger-text) 46%, transparent);
+  color: var(--fy-danger-text);
+  background: var(--fy-danger-soft);
+}
+
+.fy-apply-status-badge[data-status="running"] {
+  border-color: var(--fy-selected-border);
+  color: var(--fy-accent-text);
+}
+
+.fy-apply-status-badge[data-status="cancelled"] {
+  color: var(--fy-text-tertiary);
+}
+
+.fy-apply-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.45fr) minmax(0, 1.15fr);
+  gap: 13px;
+  min-width: 0;
+  min-height: 0;
+}
+
+.fy-apply-pane {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--fy-border-strong);
+  border-radius: 16px;
+  background:
+    linear-gradient(180deg, var(--fy-surface-soft), var(--fy-surface)),
+    var(--fy-surface);
+  box-shadow:
+    inset 0 1px 0 var(--fy-highlight),
+    var(--fy-shadow-control);
+  backdrop-filter: blur(18px) saturate(1.04);
+  -webkit-backdrop-filter: blur(18px) saturate(1.04);
+}
+
+.fy-apply-pane h2 {
+  margin: 0;
+  color: var(--fy-text);
+  font-size: clamp(18px, 1.45vw, 23px);
+  font-weight: 600;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+}
+
+.fy-apply-plan,
+.fy-apply-timeline,
+.fy-apply-outcome {
+  padding: 28px 22px 24px;
+}
+
+.fy-apply-plan-meta {
+  display: grid;
+  gap: 10px;
+  margin: 22px 0 0;
+}
+
+.fy-apply-plan-meta strong {
+  color: var(--fy-text);
+  font-size: clamp(16px, 1.2vw, 20px);
+}
+
+.fy-apply-plan-meta span,
+.fy-apply-plan-meta em {
+  color: var(--fy-text-secondary);
+  font-size: 14px;
+  font-style: normal;
+}
+
+.fy-apply-plan-meta em[data-valid="true"] {
+  color: var(--fy-success);
+}
+
+.fy-apply-step-list {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 0;
+  margin: 20px 0 0;
+  padding: 0;
+  overflow-y: auto;
+  list-style: none;
+}
+
+.fy-apply-step {
+  display: grid;
+  grid-template-columns: 22px minmax(0, 1fr) auto;
+  align-items: center;
+  min-height: 58px;
+  gap: 12px;
+  padding: 10px 14px;
+  border: 1px solid var(--fy-border);
+  border-radius: 10px;
+  background: var(--fy-control);
+}
+
+.fy-apply-step[aria-current="step"] {
+  border-color: var(--fy-selected-border);
+  background: var(--fy-selected-soft);
+  box-shadow: inset 0 1px 0 var(--fy-highlight);
+}
+
+.fy-apply-step-copy {
+  min-width: 0;
+  color: var(--fy-text);
+  font-size: clamp(14px, 1.1vw, 17px);
+  font-weight: 600;
+}
+
+.fy-apply-step > em {
+  color: var(--fy-text-tertiary);
+  font-size: 12px;
+  font-style: normal;
+}
+
+.fy-apply-step[data-status="succeeded"] > em {
+  color: var(--fy-success);
+}
+
+.fy-apply-step[data-status="warning"] > em {
+  color: var(--fy-warning);
+}
+
+.fy-apply-step[data-status="failed"] > em {
+  color: var(--fy-danger-text);
+}
+
+.fy-apply-step[data-status="running"] > em {
+  color: var(--fy-accent-text);
+}
+
+.fy-apply-icon {
+  color: var(--fy-text-tertiary);
+}
+
+.fy-apply-step[data-status="succeeded"] .fy-apply-icon {
+  color: var(--fy-success);
+}
+
+.fy-apply-step[data-status="warning"] .fy-apply-icon {
+  color: var(--fy-warning);
+}
+
+.fy-apply-step[data-status="failed"] .fy-apply-icon {
+  color: var(--fy-danger-text);
+}
+
+.fy-apply-step[data-status="running"] .fy-apply-icon {
+  color: var(--fy-accent-text);
+}
+
+.fy-apply-spin {
+  animation: fy-apply-spin 900ms linear infinite;
+}
+
+.fy-apply-outcome-title {
+  margin: 18px 0 0;
+  color: var(--fy-text);
+  font-size: clamp(20px, 1.55vw, 26px);
+  font-weight: 650;
+  line-height: 1.25;
+  letter-spacing: -0.02em;
+}
+
+.fy-apply-outcome-copy,
+.fy-apply-effect,
+.fy-apply-backup,
+.fy-apply-usage,
+.fy-apply-notice,
+.fy-apply-failure {
+  margin: 10px 0 0;
+  color: var(--fy-text-secondary);
+  font-size: clamp(13px, 1.02vw, 16px);
+}
+
+.fy-apply-effect {
+  color: var(--fy-text);
+  font-weight: 600;
+}
+
+.fy-apply-backup,
+.fy-apply-usage {
+  color: var(--fy-success);
+}
+
+.fy-apply-notice,
+.fy-apply-failure {
+  color: var(--fy-warning);
+}
+
+.fy-apply-failure {
+  color: var(--fy-danger-text);
+}
+
+.fy-apply-evidence {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 16px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.fy-apply-evidence li {
+  color: var(--fy-text-tertiary);
+  font-size: 13px;
+}
+
+.fy-apply-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: auto;
+  padding-top: 22px;
+}
+
+.fy-apply-action {
+  min-height: 48px;
+  padding: 0 22px;
+  border: 1px solid var(--fy-border-strong);
+  border-radius: 999px;
+  color: var(--fy-text);
+  font-size: clamp(14px, 1.1vw, 17px);
+  font-weight: 600;
+  background: var(--fy-control);
+  cursor: pointer;
+  transition:
+    border-color 160ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    background-color 160ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    transform 120ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.fy-apply-action:hover {
+  border-color: var(--fy-selected-border);
+  background: var(--fy-selected-soft);
+}
+
+.fy-apply-action:active {
+  transform: translateY(1px);
+}
+
+.fy-apply-action[data-primary="true"] {
+  border-color: color-mix(in srgb, var(--fy-accent-text) 38%, transparent);
+  color: var(--fy-text);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--fy-accent) 92%, white),
+    var(--fy-accent)
+  );
+  box-shadow:
+    inset 0 1px 0 var(--fy-highlight),
+    var(--fy-shadow-control);
+}
+
+.fy-apply-workspace button:focus-visible {
+  outline: 2px solid var(--fy-focus);
+  outline-offset: 2px;
+}
+
+.fy-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 1179px) {
+  .fy-apply-workspace {
+    grid-template-rows: 102px auto;
+    height: auto;
+    min-height: 100%;
+    padding: 0 20px 28px;
+  }
+
+  .fy-apply-grid {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1.1fr);
+    grid-template-rows: auto minmax(360px, auto);
+    gap: 12px;
+  }
+
+  .fy-apply-plan {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 760px) {
+  .fy-apply-workspace {
+    padding-right: 14px;
+    padding-left: 14px;
+  }
+
+  .fy-apply-header {
+    align-items: flex-start;
+    flex-direction: column;
+    justify-content: center;
+    gap: 10px;
+  }
+
+  .fy-apply-grid {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: auto;
+  }
+
+  .fy-apply-plan,
+  .fy-apply-timeline,
+  .fy-apply-outcome {
+    grid-column: 1;
+    min-height: 280px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fy-apply-spin {
+    animation: none;
+  }
+
+  .fy-apply-action {
+    transition-duration: 0.01ms;
+  }
+}
+
+@keyframes fy-apply-spin {
+  to {
+    transform: rotate(1turn);
+  }
+}

--- a/src/v2/pages/models/apply/fixtures.ts
+++ b/src/v2/pages/models/apply/fixtures.ts
@@ -1,0 +1,222 @@
+export const APPLY_STEP_IDS = [
+  "verify_plan",
+  "backup_resources",
+  "write_managed_config",
+  "readback_verify",
+  "refresh_local_state",
+] as const;
+
+export type ApplyStepId = (typeof APPLY_STEP_IDS)[number];
+export type ApplyJobStatus =
+  | "not_started"
+  | "planned"
+  | "running"
+  | "succeeded"
+  | "warning"
+  | "failed"
+  | "cancelled";
+export type ApplyStepStatus = ApplyJobStatus;
+export type ApplyEffect = "none" | "applied" | "partial" | "unknown";
+export type ApplyRecoveryAction =
+  | "retry_readback"
+  | "restore_backup"
+  | "retry_refresh"
+  | "regenerate_plan";
+export type ObservedUsageState = "not_observed" | "observed";
+
+export type ApplyEvidence = {
+  readonly kind:
+    | "plan_verified"
+    | "backup_ready"
+    | "managed_write_completed"
+    | "readback_matched"
+    | "local_state_refreshed";
+  readonly count: number;
+};
+
+export type ApplyStepSnapshot = {
+  readonly stepId: ApplyStepId;
+  readonly status: ApplyStepStatus;
+  readonly blocking: boolean;
+  readonly evidence: readonly ApplyEvidence[];
+};
+
+export type ApplySnapshot = {
+  readonly jobId: string;
+  readonly status: ApplyJobStatus;
+  readonly effect: ApplyEffect;
+  readonly canCancel: boolean;
+  readonly cancelRequested: boolean;
+  readonly backupAvailable: boolean;
+  readonly observedUsage: ObservedUsageState;
+  readonly steps: readonly ApplyStepSnapshot[];
+  readonly notices: readonly {
+    readonly code: "local_index_refresh_failed";
+    readonly stepId: ApplyStepId;
+  }[];
+  readonly failure: {
+    readonly code: "readback_mismatch";
+    readonly stepId: ApplyStepId;
+    readonly retryable: boolean;
+  } | null;
+  readonly recoveryActions: readonly ApplyRecoveryAction[];
+  readonly plan: {
+    readonly actionLabel: string;
+    readonly resourceCount: number;
+    readonly baselineValid: boolean;
+  };
+};
+
+export const APPLY_SCENARIOS = [
+  "running",
+  "succeeded",
+  "warning",
+  "failed",
+  "cancelled",
+] as const;
+
+export type ApplyScenario = (typeof APPLY_SCENARIOS)[number];
+
+const CODEX_PLAN = {
+  actionLabel: "Codex Provider 切换",
+  resourceCount: 2,
+  baselineValid: true,
+} as const;
+
+function evidence(
+  kind: ApplyEvidence["kind"],
+  count: number,
+): readonly ApplyEvidence[] {
+  return [{ kind, count }];
+}
+
+function step(
+  index: 0 | 1 | 2 | 3 | 4,
+  status: ApplyStepStatus,
+  items: readonly ApplyEvidence[] = [],
+): ApplyStepSnapshot {
+  const stepId = APPLY_STEP_IDS[index];
+  return {
+    stepId,
+    status,
+    blocking: stepId !== "refresh_local_state",
+    evidence: items,
+  };
+}
+
+const running: ApplySnapshot = {
+  jobId: "job-running",
+  status: "running",
+  effect: "none",
+  canCancel: true,
+  cancelRequested: false,
+  backupAvailable: false,
+  observedUsage: "not_observed",
+  notices: [],
+  failure: null,
+  recoveryActions: [],
+  plan: CODEX_PLAN,
+  steps: [
+    step(0, "succeeded", evidence("plan_verified", 2)),
+    step(1, "running"),
+    step(2, "not_started"),
+    step(3, "not_started"),
+    step(4, "not_started"),
+  ],
+};
+
+const succeeded: ApplySnapshot = {
+  jobId: "job-succeeded",
+  status: "succeeded",
+  effect: "applied",
+  canCancel: false,
+  cancelRequested: false,
+  backupAvailable: true,
+  observedUsage: "not_observed",
+  notices: [],
+  failure: null,
+  recoveryActions: [],
+  plan: CODEX_PLAN,
+  steps: [
+    step(0, "succeeded", evidence("plan_verified", 2)),
+    step(1, "succeeded", evidence("backup_ready", 2)),
+    step(2, "succeeded", evidence("managed_write_completed", 2)),
+    step(3, "succeeded", evidence("readback_matched", 2)),
+    step(4, "succeeded", evidence("local_state_refreshed", 3)),
+  ],
+};
+
+const warning: ApplySnapshot = {
+  jobId: "job-warning",
+  status: "warning",
+  effect: "applied",
+  canCancel: false,
+  cancelRequested: false,
+  backupAvailable: true,
+  observedUsage: "not_observed",
+  notices: [{ code: "local_index_refresh_failed", stepId: "refresh_local_state" }],
+  failure: null,
+  recoveryActions: ["retry_refresh"],
+  plan: CODEX_PLAN,
+  steps: [
+    step(0, "succeeded", evidence("plan_verified", 2)),
+    step(1, "succeeded", evidence("backup_ready", 2)),
+    step(2, "succeeded", evidence("managed_write_completed", 2)),
+    step(3, "succeeded", evidence("readback_matched", 2)),
+    step(4, "warning"),
+  ],
+};
+
+const failed: ApplySnapshot = {
+  jobId: "job-failed",
+  status: "failed",
+  effect: "unknown",
+  canCancel: false,
+  cancelRequested: false,
+  backupAvailable: true,
+  observedUsage: "not_observed",
+  notices: [],
+  failure: {
+    code: "readback_mismatch",
+    stepId: "readback_verify",
+    retryable: true,
+  },
+  recoveryActions: ["retry_readback", "restore_backup"],
+  plan: CODEX_PLAN,
+  steps: [
+    step(0, "succeeded", evidence("plan_verified", 2)),
+    step(1, "succeeded", evidence("backup_ready", 2)),
+    step(2, "succeeded", evidence("managed_write_completed", 2)),
+    step(3, "failed"),
+    step(4, "not_started"),
+  ],
+};
+
+const cancelled: ApplySnapshot = {
+  jobId: "job-cancelled",
+  status: "cancelled",
+  effect: "none",
+  canCancel: false,
+  cancelRequested: true,
+  backupAvailable: false,
+  observedUsage: "not_observed",
+  notices: [],
+  failure: null,
+  recoveryActions: [],
+  plan: CODEX_PLAN,
+  steps: [
+    step(0, "succeeded", evidence("plan_verified", 2)),
+    step(1, "cancelled"),
+    step(2, "not_started"),
+    step(3, "not_started"),
+    step(4, "not_started"),
+  ],
+};
+
+export const applyFixtures = {
+  running,
+  succeeded,
+  warning,
+  failed,
+  cancelled,
+} as const satisfies Record<ApplyScenario, ApplySnapshot>;

--- a/src/v2/pages/models/apply/fixtures.ts
+++ b/src/v2/pages/models/apply/fixtures.ts
@@ -154,7 +154,9 @@ const warning: ApplySnapshot = {
   cancelRequested: false,
   backupAvailable: true,
   observedUsage: "not_observed",
-  notices: [{ code: "local_index_refresh_failed", stepId: "refresh_local_state" }],
+  notices: [
+    { code: "local_index_refresh_failed", stepId: "refresh_local_state" },
+  ],
   failure: null,
   recoveryActions: ["retry_refresh"],
   plan: CODEX_PLAN,

--- a/src/v2/pages/models/apply/index.ts
+++ b/src/v2/pages/models/apply/index.ts
@@ -1,0 +1,8 @@
+export { ApplyWorkspace, type ApplyWorkspaceProps } from "./ApplyWorkspace";
+export {
+  APPLY_SCENARIOS,
+  applyFixtures,
+  type ApplyScenario,
+  type ApplySnapshot,
+} from "./fixtures";
+export { createApplyViewModel, type ApplyPresentation } from "./view-model";

--- a/src/v2/pages/models/apply/view-model.ts
+++ b/src/v2/pages/models/apply/view-model.ts
@@ -1,0 +1,235 @@
+import type {
+  ApplyEffect,
+  ApplyEvidence,
+  ApplyJobStatus,
+  ApplyRecoveryAction,
+  ApplySnapshot,
+  ApplyStepId,
+  ApplyStepStatus,
+} from "./fixtures";
+
+export type {
+  ApplyEffect,
+  ApplyJobStatus,
+  ApplySnapshot,
+  ApplyStepStatus,
+} from "./fixtures";
+
+export type ApplyActionKind =
+  | ApplyRecoveryAction
+  | "complete_and_use"
+  | "request_cancel"
+  | "return_to_plan";
+
+export type ApplyActionPresentation = {
+  readonly kind: ApplyActionKind;
+  readonly label: string;
+  readonly primary: boolean;
+};
+
+export type ApplyStepPresentation = {
+  readonly stepId: ApplyStepId;
+  readonly label: string;
+  readonly status: ApplyStepStatus;
+  readonly statusLabel: string;
+  readonly current: boolean;
+};
+
+export type ApplyPresentation = {
+  readonly status: ApplyJobStatus;
+  readonly statusLabel: string;
+  readonly effect: ApplyEffect;
+  readonly effectLabel: string;
+  readonly title: string;
+  readonly subtitle: string;
+  readonly observedUsageCopy: string | null;
+  readonly backupAvailable: boolean;
+  readonly steps: readonly ApplyStepPresentation[];
+  readonly evidence: readonly string[];
+  readonly notices: readonly string[];
+  readonly failureLabel: string | null;
+  readonly actions: readonly ApplyActionPresentation[];
+  readonly plan: ApplySnapshot["plan"];
+};
+
+const STEP_LABELS = {
+  verify_plan: "核对计划",
+  backup_resources: "备份资源",
+  write_managed_config: "写入受管配置",
+  readback_verify: "回读核对",
+  refresh_local_state: "刷新本机状态",
+} as const satisfies Record<ApplyStepId, string>;
+
+const STATUS_LABELS = {
+  not_started: "未开始",
+  planned: "已就绪",
+  running: "进行中",
+  succeeded: "已完成",
+  warning: "需留意",
+  failed: "失败",
+  cancelled: "已取消",
+} as const satisfies Record<ApplyJobStatus, string>;
+
+const EFFECT_LABELS = {
+  none: "无变更",
+  applied: "已应用",
+  partial: "部分变更",
+  unknown: "结果未确认",
+} as const satisfies Record<ApplyEffect, string>;
+
+const RECOVERY_LABELS = {
+  retry_readback: "重试回读",
+  restore_backup: "恢复备份",
+  retry_refresh: "重试辅助刷新",
+  regenerate_plan: "重新生成计划",
+} as const satisfies Record<ApplyRecoveryAction, string>;
+
+const EVIDENCE_COPY = {
+  plan_verified: "已核对",
+  backup_ready: "已备份",
+  managed_write_completed: "已写入",
+  readback_matched: "回读一致 ·",
+  local_state_refreshed: "已刷新",
+} as const satisfies Record<ApplyEvidence["kind"], string>;
+
+const EVIDENCE_UNIT = {
+  plan_verified: "项逻辑资源",
+  backup_ready: "项资源",
+  managed_write_completed: "项受管配置",
+  readback_matched: "项资源",
+  local_state_refreshed: "个本机组件",
+} as const satisfies Record<ApplyEvidence["kind"], string>;
+
+const OUTCOME_COPY = {
+  running_before_write: ["正在应用配置", "正在核对计划并保护可恢复性"],
+  running_after_write: ["正在确认配置结果", "配置写入已返回，正在进行本机回读"],
+  succeeded: ["配置已应用，可直接开始使用", "已完成本机写入与回读核对"],
+  warning: [
+    "配置已应用，可直接开始使用",
+    "核心配置已回读一致；仍有一项本机辅助状态待处理",
+  ],
+  failed_none: [
+    "配置尚未应用",
+    "写入前已安全停止；请按提示重新生成计划或修复条件",
+  ],
+  failed_partial: ["配置未能完整应用", "已检测到部分变更；请先查看恢复选项"],
+  failed_unknown: [
+    "无法确认配置结果",
+    "不会自动重复写入；请先重试回读或恢复备份",
+  ],
+  cancelled: ["已取消应用", "尚未开始受管配置写入"],
+  planned: ["准备应用配置", "任务已创建，尚未开始写入"],
+  not_started: ["尚未开始应用", "确认计划后开始本机写入"],
+} as const;
+
+type OutcomeKey = keyof typeof OUTCOME_COPY;
+
+export function assertNever(value: never): never {
+  throw new Error(`Unhandled apply presentation value: ${String(value)}`);
+}
+
+function resolveOutcome(snapshot: ApplySnapshot): OutcomeKey {
+  switch (snapshot.status) {
+    case "running":
+      return snapshot.effect === "unknown"
+        ? "running_after_write"
+        : "running_before_write";
+    case "succeeded":
+      return "succeeded";
+    case "warning":
+      return "warning";
+    case "failed":
+      switch (snapshot.effect) {
+        case "none":
+          return "failed_none";
+        case "partial":
+          return "failed_partial";
+        case "unknown":
+        case "applied":
+          return "failed_unknown";
+        default:
+          return assertNever(snapshot.effect);
+      }
+    case "cancelled":
+      return "cancelled";
+    case "planned":
+      return "planned";
+    case "not_started":
+      return "not_started";
+    default:
+      return assertNever(snapshot.status);
+  }
+}
+
+function presentActions(
+  snapshot: ApplySnapshot,
+): readonly ApplyActionPresentation[] {
+  switch (snapshot.status) {
+    case "running":
+    case "planned":
+      return snapshot.canCancel
+        ? [{ kind: "request_cancel", label: "请求取消", primary: false }]
+        : [];
+    case "succeeded":
+      return [{ kind: "complete_and_use", label: "完成并开始使用", primary: true }];
+    case "warning":
+      return [
+        { kind: "complete_and_use", label: "完成并开始使用", primary: true },
+        ...snapshot.recoveryActions.map((kind) => ({
+          kind,
+          label: RECOVERY_LABELS[kind],
+          primary: false,
+        })),
+      ];
+    case "failed":
+      return snapshot.recoveryActions.map((kind, index) => ({
+        kind,
+        label: RECOVERY_LABELS[kind],
+        primary: index === 0,
+      }));
+    case "cancelled":
+    case "not_started":
+      return [{ kind: "return_to_plan", label: "返回计划", primary: true }];
+    default:
+      return assertNever(snapshot.status);
+  }
+}
+
+export function createApplyViewModel(
+  snapshot: ApplySnapshot,
+): ApplyPresentation {
+  const [title, subtitle] = OUTCOME_COPY[resolveOutcome(snapshot)];
+  const runningStepId =
+    snapshot.steps.find((step) => step.status === "running")?.stepId ?? null;
+
+  return {
+    status: snapshot.status,
+    statusLabel: STATUS_LABELS[snapshot.status],
+    effect: snapshot.effect,
+    effectLabel: EFFECT_LABELS[snapshot.effect],
+    title,
+    subtitle,
+    observedUsageCopy:
+      snapshot.effect === "applied" && snapshot.observedUsage === "not_observed"
+        ? "配置已应用，尚无真实使用证据"
+        : null,
+    backupAvailable: snapshot.backupAvailable,
+    steps: snapshot.steps.map((item) => ({
+      stepId: item.stepId,
+      label: STEP_LABELS[item.stepId],
+      status: item.status,
+      statusLabel: STATUS_LABELS[item.status],
+      current: item.stepId === runningStepId,
+    })),
+    evidence: snapshot.steps.flatMap((item) =>
+      item.evidence.map(
+        (entry) =>
+          `${EVIDENCE_COPY[entry.kind]} ${String(entry.count)} ${EVIDENCE_UNIT[entry.kind]}`,
+      ),
+    ),
+    notices: snapshot.notices.map(() => "本机索引刷新未完成"),
+    failureLabel: snapshot.failure ? "回读不一致" : null,
+    actions: presentActions(snapshot),
+    plan: snapshot.plan,
+  };
+}

--- a/src/v2/pages/models/apply/view-model.ts
+++ b/src/v2/pages/models/apply/view-model.ts
@@ -171,7 +171,9 @@ function presentActions(
         ? [{ kind: "request_cancel", label: "请求取消", primary: false }]
         : [];
     case "succeeded":
-      return [{ kind: "complete_and_use", label: "完成并开始使用", primary: true }];
+      return [
+        { kind: "complete_and_use", label: "完成并开始使用", primary: true },
+      ];
     case "warning":
       return [
         { kind: "complete_and_use", label: "完成并开始使用", primary: true },

--- a/tests/v2/pages/models/apply/ApplyWorkspace.test.tsx
+++ b/tests/v2/pages/models/apply/ApplyWorkspace.test.tsx
@@ -1,0 +1,185 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ApplyWorkspace } from "@/v2/pages/models/apply/ApplyWorkspace";
+import {
+  APPLY_SCENARIOS,
+  applyFixtures,
+  type ApplyScenario,
+} from "@/v2/pages/models/apply/fixtures";
+
+const STEP_IDS = [
+  "verify_plan",
+  "backup_resources",
+  "write_managed_config",
+  "readback_verify",
+  "refresh_local_state",
+] as const;
+
+const STEP_LABELS = [
+  "核对计划",
+  "备份资源",
+  "写入受管配置",
+  "回读核对",
+  "刷新本机状态",
+] as const;
+
+const SUCCESS_TITLE = "配置已应用，可直接开始使用";
+const NO_USAGE_EVIDENCE = "配置已应用，尚无真实使用证据";
+const FORBIDDEN_FIELD = /sk-|\/Users\/|[A-Za-z]:\\|SecretRef|SecretBackend|secretValue|secretHash|planDigest|absolutePath|promptBody|memoryBody|configText|rawDiff|providerRequestId/;
+
+function renderApply(scenario: ApplyScenario) {
+  render(<ApplyWorkspace scenario={scenario} />);
+}
+
+function serializedFixtures(): string {
+  return JSON.stringify(applyFixtures);
+}
+
+describe("ApplyWorkspace presentation fixtures", () => {
+  it("exports running, succeeded, warning, failed, and cancelled snapshots", () => {
+    expect(APPLY_SCENARIOS).toEqual([
+      "running",
+      "succeeded",
+      "warning",
+      "failed",
+      "cancelled",
+    ]);
+    expect(Object.keys(applyFixtures).sort()).toEqual([...APPLY_SCENARIOS].sort());
+  });
+
+  it("keeps five fixed steps, at most one running step, and no forbidden fields", () => {
+    expect(serializedFixtures()).not.toMatch(FORBIDDEN_FIELD);
+
+    for (const scenario of APPLY_SCENARIOS) {
+      const snapshot = applyFixtures[scenario];
+      expect(snapshot.steps.map((step) => step.stepId)).toEqual([...STEP_IDS]);
+      expect(
+        snapshot.steps.filter((step) => step.status === "running"),
+      ).toHaveLength(scenario === "running" ? 1 : 0);
+    }
+  });
+});
+
+describe("ApplyWorkspace status, effect, copy, and actions", () => {
+  it("renders the three-pane prototype workspace without a new top-level nav", () => {
+    renderApply("succeeded");
+
+    expect(screen.getByRole("heading", { name: "应用配置" })).toBeVisible();
+    expect(screen.getByText("前端原型 · 模拟数据")).toBeVisible();
+    expect(screen.getByText("不发送测试请求")).toBeVisible();
+    expect(screen.getByTestId("apply-workspace")).toHaveAttribute(
+      "data-data-source",
+      "prototype",
+    );
+    expect(screen.getByTestId("apply-plan")).toBeVisible();
+    expect(screen.getByTestId("apply-timeline")).toBeVisible();
+    expect(screen.getByTestId("apply-outcome")).toBeVisible();
+    expect(screen.queryByRole("navigation")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "应用配置" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the frozen success title and no-usage evidence on succeeded", () => {
+    renderApply("succeeded");
+
+    const workspace = screen.getByTestId("apply-workspace");
+    expect(workspace).toHaveAttribute("data-status", "succeeded");
+    expect(workspace).toHaveAttribute("data-effect", "applied");
+    expect(
+      screen.getByRole("heading", { name: SUCCESS_TITLE }),
+    ).toBeVisible();
+    expect(screen.getByText("已完成本机写入与回读核对")).toBeVisible();
+    expect(screen.getByText(NO_USAGE_EVIDENCE)).toBeVisible();
+    expect(screen.getByText("效果：已应用")).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "完成并开始使用" }),
+    ).toBeVisible();
+  });
+
+  it("keeps the success title on warning and offers retry refresh", () => {
+    renderApply("warning");
+
+    const workspace = screen.getByTestId("apply-workspace");
+    expect(workspace).toHaveAttribute("data-status", "warning");
+    expect(workspace).toHaveAttribute("data-effect", "applied");
+    expect(
+      screen.getByRole("heading", { name: SUCCESS_TITLE }),
+    ).toBeVisible();
+    expect(
+      screen.getByText("核心配置已回读一致；仍有一项本机辅助状态待处理"),
+    ).toBeVisible();
+    expect(screen.getByText(NO_USAGE_EVIDENCE)).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "完成并开始使用" }),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "重试辅助刷新" }),
+    ).toBeVisible();
+  });
+
+  it("shows failed recovery without a green success title", () => {
+    renderApply("failed");
+
+    const workspace = screen.getByTestId("apply-workspace");
+    expect(workspace).toHaveAttribute("data-status", "failed");
+    expect(workspace).toHaveAttribute("data-effect", "unknown");
+    expect(
+      screen.getByRole("heading", { name: "无法确认配置结果" }),
+    ).toBeVisible();
+    expect(
+      screen.getByText("不会自动重复写入；请先重试回读或恢复备份"),
+    ).toBeVisible();
+    expect(screen.getByText("效果：结果未确认")).toBeVisible();
+    expect(screen.getByText("备份可用")).toBeVisible();
+    expect(screen.getByRole("button", { name: "重试回读" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "恢复备份" })).toBeVisible();
+    expect(
+      screen.queryByRole("heading", { name: SUCCESS_TITLE }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(NO_USAGE_EVIDENCE)).not.toBeInTheDocument();
+  });
+
+  it("shows cancelled with no write effect and a return-to-plan action", () => {
+    renderApply("cancelled");
+
+    const workspace = screen.getByTestId("apply-workspace");
+    expect(workspace).toHaveAttribute("data-status", "cancelled");
+    expect(workspace).toHaveAttribute("data-effect", "none");
+    expect(screen.getByRole("heading", { name: "已取消应用" })).toBeVisible();
+    expect(screen.getByText("尚未开始受管配置写入")).toBeVisible();
+    expect(screen.getByText("效果：无变更")).toBeVisible();
+    expect(screen.getByRole("button", { name: "返回计划" })).toBeVisible();
+    expect(
+      screen.queryByRole("heading", { name: SUCCESS_TITLE }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders running before write with one current step and a cancel action", () => {
+    renderApply("running");
+
+    const workspace = screen.getByTestId("apply-workspace");
+    expect(workspace).toHaveAttribute("data-status", "running");
+    expect(workspace).toHaveAttribute("data-effect", "none");
+    expect(screen.getByRole("heading", { name: "正在应用配置" })).toBeVisible();
+    expect(screen.getByText("正在核对计划并保护可恢复性")).toBeVisible();
+    expect(screen.getByRole("button", { name: "请求取消" })).toBeVisible();
+
+    const timeline = screen.getByTestId("apply-timeline");
+    expect(within(timeline).getAllByRole("listitem")).toHaveLength(5);
+    expect(within(timeline).getByRole("listitem", { current: "step" })).toHaveTextContent(
+      "备份资源",
+    );
+  });
+
+  it("labels every step in Chinese so status is not color-only", () => {
+    renderApply("succeeded");
+
+    const timeline = screen.getByTestId("apply-timeline");
+    for (const label of STEP_LABELS) {
+      expect(within(timeline).getByText(label)).toBeVisible();
+    }
+    expect(within(timeline).getAllByText("已完成")).toHaveLength(5);
+  });
+});


### PR DESCRIPTION
Refs #41

面向 `fy-agent/fyagent` `main` 的 **draft**。从 `origin/main` 干净摘出今晚增量，不含 Prompt/Memory 旧历史。不关票。

## 审什么
1. `src/v2/pages/models/apply/*`：展示层三栏工作台，四种失败/成功文案冻结。
2. `src-tauri/src/services/configuration_apply/*`：进程内 fake coordinator。
3. `ProviderWriteLease`：只是给现有 `lock_switch_for_app` 起名，不是 #35 activation lease。
4. `ModelsPage` 必须仍是 `return null`。

## 做什么
- 展示层 ApplyWorkspace：running / succeeded / warning / failed / cancelled
- 成功标题：`配置已应用，可直接开始使用`
- 无使用证据：`配置已应用，尚无真实使用证据`
- 取消在写之前 → `effect=none`，writer=0
- 写失败 → 非绿，要求恢复备份
- 出站 Provider HTTP spy = 0
- 状态点用 CSS，不引入 `@phosphor-icons/react`（main 没有这个包）

## 不做什么
- 不关 #41
- 不接线生产 `/models`
- 不解析 #35 secret
- 不新增第二套 job SQLite 表
- 不合并 #108 / #109 / #112

## 提交
1. `feat(apply): presentation ApplyWorkspace fixtures`
2. `feat(apply): fake coordinator and process-local apply runtime`
3. `refactor(provider): name existing switch write lock`
4. `fix(apply): drop phosphor csr imports for main CI` ← 补第一轮 Frontend Checks

## 验证
本地（摘出前原树）：
- `mise run test:v2 -- tests/v2/pages/models/apply/ApplyWorkspace.test.tsx` → 9/9
- `mise run typecheck:v2` → 0
- `mise run rust:test -- configuration_apply` → 3/3
- `mise run rust:test -- provider_service` → 15/15

CI：第一轮 Frontend Checks 红（Phosphor csr 导入 + prettier）。第 4 个提交已推，等新一轮 `CI / Required`。

独立审查：无 BLOCKER。证据级别 `local_runtime` + `code_audit`。不是 UAT。