### PR TITLE
Release 0.4.2: ship Applications-only DMG and Agent directory home

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1204,26 +1204,25 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p release-assets
-          zip_path="release-assets/FyAgent-${APP_VERSION}-macOS.zip"
           dmg_path="release-assets/FyAgent-${APP_VERSION}-macOS.dmg"
           stage="$RUNNER_TEMP/fyagent-dmg-stage"
           mount_point="$RUNNER_TEMP/fyagent-dmg-mount"
-          unzip_root="$RUNNER_TEMP/fyagent-zip-verify"
-          rm -rf "$stage" "$mount_point" "$unzip_root"
-          mkdir -p "$stage" "$mount_point" "$unzip_root"
+          rm -rf "$stage" "$mount_point"
+          mkdir -p "$stage" "$mount_point"
           mounted=false
           cleanup() {
             status=$?
             trap - EXIT
             set +e
             if [ "$mounted" = true ]; then hdiutil detach "$mount_point"; fi
-            rm -rf "$stage" "$mount_point" "$unzip_root"
+            rm -rf "$stage" "$mount_point"
             exit "$status"
           }
           trap cleanup EXIT
 
           source_digest="$(shasum -a 256 "$APP_PATH/Contents/MacOS/$APP_EXECUTABLE" | awk '{print $1}')"
           ditto "$APP_PATH" "$stage/FyAgent.app"
+          ln -s /Applications "$stage/Applications"
           scripts/release/retry-hdiutil.sh \
             "$dmg_path" \
             -- \
@@ -1235,18 +1234,14 @@ jobs:
           scripts/release/macos-developer-id.sh sign-dmg "$dmg_path"
           scripts/release/macos-developer-id.sh notarize-dmg "$dmg_path"
           scripts/release/macos-developer-id.sh staple-app "$APP_PATH"
+          scripts/release/verify-macos-signed-app.sh "$APP_PATH"
           scripts/release/verify-macos-signed-dmg.sh "$dmg_path"
-
-          ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" "$zip_path"
-          ditto -x -k "$zip_path" "$unzip_root"
-          [ -d "$unzip_root/FyAgent.app" ]
-          [ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$unzip_root/FyAgent.app/Contents/Info.plist")" = "$APP_VERSION" ]
-          [ "$(shasum -a 256 "$unzip_root/FyAgent.app/Contents/MacOS/$APP_EXECUTABLE" | awk '{print $1}')" = "$source_digest" ]
-          scripts/release/verify-macos-signed-app.sh "$unzip_root/FyAgent.app"
 
           mounted=true
           hdiutil attach "$dmg_path" -readonly -nobrowse -noautoopen -mountpoint "$mount_point"
           [ -d "$mount_point/FyAgent.app" ]
+          [ -L "$mount_point/Applications" ]
+          [ "$(readlink "$mount_point/Applications")" = "/Applications" ]
           [ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$mount_point/FyAgent.app/Contents/Info.plist")" = "$APP_VERSION" ]
           [ "$(shasum -a 256 "$mount_point/FyAgent.app/Contents/MacOS/$APP_EXECUTABLE" | awk '{print $1}')" = "$source_digest" ]
           scripts/release/verify-macos-signed-app.sh --signature-only "$mount_point/FyAgent.app"
@@ -1417,7 +1412,7 @@ jobs:
           pattern: signing-*
           path: downloaded-signing
 
-      - name: Verify exact four and generate three machine-readable subjects
+      - name: Verify exact three installers and generate three machine-readable subjects
         shell: bash
         run: |
           set -euo pipefail
@@ -1452,7 +1447,7 @@ jobs:
             verified-subjects/build-metadata.json
           node scripts/release/verify-release-files.mjs subjects verified-subjects "$APP_VERSION"
 
-      - name: Upload the exact seven attestation subjects
+      - name: Upload the exact six attestation subjects
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: verified-attestation-subjects
@@ -1461,7 +1456,7 @@ jobs:
           retention-days: 7
 
   attest:
-    name: Attest four installers and three evidence files
+    name: Attest three installers and three evidence files
     if: ${{ !cancelled() }}
     needs: [eligibility, verify-assets]
     runs-on: macos-15
@@ -1502,7 +1497,7 @@ jobs:
           name: verified-attestation-subjects
           path: verified-subjects
 
-      - name: Recheck the exact seven subjects
+      - name: Recheck the exact six subjects
         run: node scripts/release/verify-release-files.mjs subjects verified-subjects "$APP_VERSION"
 
       - name: Generate mandatory GitHub artifact attestation
@@ -1511,7 +1506,7 @@ jobs:
         with:
           subject-path: verified-subjects/*
 
-      - name: Assemble and verify exact eight Release attachments
+      - name: Assemble and verify exact seven Release attachments
         shell: bash
         env:
           BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
@@ -1795,9 +1790,9 @@ jobs:
             "$api_root/repos/$repository/releases/$draft_id/assets?per_page=100")"
           [ "$assets_status" = 200 ]
           jq -e '
-            length == 8 and
-            (map(.id) | unique | length) == 8 and
-            (map(.name) | unique | length) == 8 and
+            length == 7 and
+            (map(.id) | unique | length) == 7 and
+            (map(.name) | unique | length) == 7 and
             all(.state == "uploaded" and .size > 0)
           ' "$assets_json" >/dev/null
 
@@ -1866,7 +1861,7 @@ jobs:
             '.id == $id and .draft == false and .prerelease == false and
              .tag_name == $tag and
              .name == ("FyAgent " + $tag) and .body == $body and
-             (.published_at | type) == "string" and (.assets | length) == 8' \
+             (.published_at | type) == "string" and (.assets | length) == 7' \
             "$published_json" >/dev/null
 
           published_confirm_json="$transaction_root/published-confirmed.json"

--- a/.trellis/spec/backend/fyagent-version-contract.md
+++ b/.trellis/spec/backend/fyagent-version-contract.md
@@ -115,17 +115,17 @@ push CI. The eligibility engine and
 [GitHub Release Workflow](./github-release-workflow.md) own the branch split;
 do not treat `main` as the preflight authority.
 
-The installer allowlist contains exactly four versioned files:
+The installer allowlist contains exactly three versioned files:
 
 ```text
 FyAgent-X.Y.Z-macOS.dmg
-FyAgent-X.Y.Z-macOS.zip
 FyAgent-X.Y.Z-Windows-x64-setup.exe
 FyAgent-X.Y.Z-Windows-arm64-setup.exe
 ```
 
 Only the two versioned NSIS setup executables are accepted for Windows.
-Non-allowlisted Windows package formats, portable archives, v-prefixed names,
+The only accepted macOS installer is the versioned DMG. Non-allowlisted
+Windows package formats, portable archives, macOS ZIP archives, v-prefixed names,
 architecture aliases, and unversioned installer names are rejected.
 
 `download-manifest.json` schema `fyagent-download-manifest/v3` binds product,
@@ -148,9 +148,9 @@ Authenticode state. It is a release attachment and attestation subject; native
 per-architecture signing fragments are private workflow inputs and are never
 published.
 
-The attestation subject set contains exactly seven files: the four installers,
+The attestation subject set contains exactly six files: the three installers,
 download manifest, build metadata, and signing status. The Sigstore bundle is
-the eighth and final Release attachment and does not attest itself.
+the seventh and final Release attachment and does not attest itself.
 
 ## 5. Change and Failure Rules
 
@@ -177,9 +177,10 @@ the eighth and final Release attachment and does not attest itself.
   byte-identical.
 - `tests/versionConsistency.test.ts` delegates to the canonical script rather
   than implementing another version parser.
-- Download/release asset tests assert all four exact names, the two Windows NSIS
-  setup executables and architecture mapping, URL shape, and
-  missing/extra/non-allowlisted/symlink rejection.
+- Download/release asset tests assert all three exact names, the two Windows NSIS
+  setup executables and architecture mapping, URL shape,
+  missing/extra/non-allowlisted/symlink rejection, six attestation subjects,
+  and seven Release attachments.
 - Release tests assert frozen output consumption and that the download,
   build, signing, attestation, and publication stages use the same version,
   source SHA, CI run, and attempt. They cover `dev/laiyongjie` preflight and

--- a/.trellis/spec/backend/github-release-workflow.md
+++ b/.trellis/spec/backend/github-release-workflow.md
@@ -239,7 +239,7 @@ sccache.
 | --------------- | -------------------------------- | ---------------------------------- |
 | Windows x64     | `windows-2025`, native `X64`     | x64 NSIS setup EXE                 |
 | Windows ARM64   | `windows-11-arm`, native `ARM64` | ARM64 NSIS setup EXE               |
-| macOS universal | `macos-15`, both Apple targets   | DMG and ZIP from one universal app |
+| macOS universal | `macos-15`, both Apple targets   | one UDZO DMG from the universal app |
 
 Each target verifies documented `runner.os`/`runner.arch`, the requested
 runner label, source HEAD, Node 24.19.0, pnpm 10.12.3, and Rust 1.97.1. There is
@@ -293,16 +293,23 @@ unavailability blocks acceptance.
   `notarytool info` until `Accepted` / `Invalid` or a multi-hour budget;
   `notarytool wait --timeout` is not used because it exits 124 with JSON on
   stderr while Apple may still be In Progress. After Apple accepts that one
-  submission, it staples the DMG and the original app from the same ticket,
-  then zips the stapled app. It does not notarize an app zip as a second serial
+  submission, it staples the DMG and the original app from the same ticket.
+  It does not emit a ZIP or notarize an app zip as a second serial
   wait. The `build-macos` job sets `timeout-minutes: 360` so the poll can use
   the GitHub-hosted maximum. Strict deep verification must
   report the exact identity, `runtime` flags, a timestamp, and sealed
-  resources. The ZIP app and the DMG container must carry stapled tickets. The
+  resources. The published DMG container must carry a stapled ticket. The
+  workflow also staples the original app for ticket proof. The
   app copy inside the already-built DMG is the pre-staple Developer ID binary
   and is checked for signature identity, not a nested ticket. An ad-hoc
   signature, missing team, missing timestamp, or missing required ticket is
   rejected;
+- the DMG source folder contains `FyAgent.app` and a symlink named
+  `Applications` whose target is `/Applications`. After `hdiutil attach`, the
+  workflow requires that symlink (`-L` and `readlink` equals `/Applications`)
+  plus the signed app. The volume stays UDZO/read-only; Finder drag-install
+  uses the in-image Applications alias. No `FyAgent-X.Y.Z-macOS.zip` is
+  produced;
 - DMG creation removes its explicit output before the first attempt and after
   every failed attempt. DMG verification preserves the completed input across
   attempts. Both operations retry the same arguments only when the captured
@@ -315,16 +322,16 @@ unavailability blocks acceptance.
 
 ## 7. Assets, metadata, signing disclosure, and attestation
 
-The installer allowlist contains exactly four versioned files:
+The installer allowlist contains exactly three versioned files:
 
 ```text
 FyAgent-X.Y.Z-macOS.dmg
-FyAgent-X.Y.Z-macOS.zip
 FyAgent-X.Y.Z-Windows-x64-setup.exe
 FyAgent-X.Y.Z-Windows-arm64-setup.exe
 ```
 
-Any Windows format other than the two NSIS setup executables, plus v-prefixed
+Any Windows format other than the two NSIS setup executables, any macOS
+format other than the versioned DMG, plus v-prefixed
 filenames, unversioned names, architecture aliases, missing files, extras,
 directories, symlinks, empty files, or overwrites is forbidden.
 
@@ -348,10 +355,10 @@ are not Authenticode signed and still list SHA-256, source SHA, and
 attestation. Signed mode reports the verified public certificate policy; no
 credential or adapter secret is included.
 
-Attestation subjects are the four installers plus `download-manifest.json`,
-`build-metadata.json`, and `signing-status.json` (seven subjects). The
+Attestation subjects are the three installers plus `download-manifest.json`,
+`build-metadata.json`, and `signing-status.json` (six subjects). The
 Sigstore bundle is copied to `artifact-attestation.sigstore.json`; it is the
-eighth Release attachment and does not attest itself.
+seventh Release attachment and does not attest itself.
 
 ## 8. Permissions and publication transaction
 
@@ -372,7 +379,7 @@ The publish job has an explicit formal tag-push condition; dispatch evaluates
 to false. It performs this transaction:
 
 1. re-evaluate live remote eligibility against the frozen identity;
-2. require the exact eight attachments and dynamic English notes file
+2. require the exact seven attachments and dynamic English notes file
    `docs/release-notes/${RELEASE_TAG}-en.md`;
 3. generate the signing disclosure from verified metadata;
 4. list all Releases, including drafts, and refuse any existing release with
@@ -419,7 +426,7 @@ never called private or successful.
 | Apple status is still non-terminal after `FYAGENT_NOTARY_WAIT_SECONDS` (default 18000)                 | Fail with the submission id and last status; do not start a second Apple upload. |
 | Windows proof/sealed binding or macOS identity fails                                                                                    | Stop aggregation and publication.                            |
 | An intentional producer skip propagates past successful asset verification                                                              | Attestation still runs; abnormal direct needs fail visibly.  |
-| Four/seven/eight file allowlist or digest differs                                                                                       | Stop verification, attestation, or publication.              |
+| Three/six/seven file allowlist or digest differs                                                                                      | Stop verification, attestation, or publication.              |
 | Live main identity changes during the transaction                                                                                       | Continue; tag target SHA remains the frozen source.          |
 | A draft/published Release already exists                                                                                                | Refuse update, replacement, or deletion.                     |
 | Upload/re-download/pre-PATCH verification fails                                                                                         | Leave draft untouched and report it.                         |
@@ -438,8 +445,9 @@ dispatch publication, both preflight/formal tail-job truth tables, mutation of
 explicit status conditions or direct-need assertions, asset loss/extra, signer
 policy, transaction failure, a single `notarytool submit`, `notarytool info`
 polling, no `xcrun notarytool wait` invocation, `notarytool log` on a denied
-submission, `FYAGENT_NOTARY_WAIT_SECONDS`, and `build-macos`
-`timeout-minutes: 360`.
+submission, `FYAGENT_NOTARY_WAIT_SECONDS`, `build-macos`
+`timeout-minutes: 360`, the Applications symlink inside the DMG, and the
+absence of a macOS ZIP installer.
 
 Local execution cannot establish another platform's PowerShell/NSIS/
 Authenticode, native build/package output, macOS bundle, GitHub attestation, or
@@ -491,8 +499,8 @@ lightweight tags are both valid. Missing exact-source push CI is not a gate.
 Operators may force-update `vX.Y.Z` only when no GitHub Release exists.
 Cache `~/.cargo/registry` and `~/.cargo/git` from `Cargo.lock`. Submit the
 signed DMG once without `--wait`, poll `notarytool info` on that submission
-id until `Accepted` / `Invalid` or the wait budget, then staple the app from
-that ticket.
+id until `Accepted` / `Invalid` or the wait budget, then staple the DMG and
+the original app from that ticket. Do not emit a ZIP.
 
 ## Scenario: Single DMG notarization poll
 
@@ -531,11 +539,11 @@ that ticket.
 - `Invalid` / `Rejected` -> print `notarytool log`, fail, do not staple.
 - Non-terminal after wait budget -> fail with id and last status; do not
   upload a second Apple job.
-- `Accepted` -> staple DMG and app; ZIP is built from the stapled app.
+- `Accepted` -> staple DMG and the original app; do not emit a ZIP.
 
 ### 5. Good / Base / Bad Cases
-- Good: `info` returns `Accepted` inside the budget; DMG and ZIP app have
-  stapled tickets.
+- Good: `info` returns `Accepted` inside the budget; the DMG has a stapled
+  ticket and the original app is stapled from the same ticket.
 - Base: `info` stays `In Progress` for more than 60 minutes, then `Accepted`;
   the same submission id is reused.
 - Bad: two serial Apple uploads; `wait --timeout 1800` twice; treating 124 as
@@ -547,7 +555,8 @@ that ticket.
   presence of `notarytool info` and `notarytool log`, no `xcrun notarytool wait`
   invocation, `FYAGENT_NOTARY_WAIT_SECONDS`,
   `scripts/release/macos-developer-id.sh notarize-dmg`,
-  `staple-app`, and `timeout-minutes: 360` on `build-macos`.
+  `staple-app`, `timeout-minutes: 360` on `build-macos`, the DMG Applications
+  symlink, and the absence of `macOS.zip`.
 - Local tests do not call Apple; a successful unit run is not notarization
   evidence.
 

--- a/.trellis/spec/frontend/v2-agent-models.md
+++ b/.trellis/spec/frontend/v2-agent-models.md
@@ -28,8 +28,11 @@ its own capability workflow:
   unsupported-capability lists, support counts, usage notes, Qoder Hooks
   editors, or MCP validation panels. Non-Codex details mount a page-local
   「产品介绍」 section from `src/v2/pages/agents/intros.ts` (hardcoded Chinese,
-  not the catalog `description` and not 「使用说明」). Codex keeps the desktop
-  installer as its substantial body and does not require that intro.
+  not the catalog `description` and not 「使用说明」). That copy describes the
+  third-party product only and must not mention FyAgent. Codex keeps the desktop
+  installer as its substantial body and does not require that intro. The
+  installer heading explains install/update/launch of Codex Desktop and must
+  not mention FyAgent.
 - WorkBuddy and OpenCode each use a dedicated revision-checked
   model-configuration domain. WorkBuddy additionally exposes direct Skills
   copy and MCP `mcp.json` assignment. Grok Build Models uses the same Provider
@@ -231,6 +234,8 @@ and a revision, never `ak` / `sk` / `apiKey`.
   TRAE `displayName` is `TRAE Work CN`; its product URL is exactly
   `https://www.trae.cn/sem-work`.   Catalog descriptions use 支持 / 不支持
   wording and must not contain `可在 FyAgent` or `可通过 FyAgent`.
+  QoderWork CN catalog `description` and Agent intro copy must not mention
+  Hooks.
   QoderWork CN and TRAE Work CN describe MCP as 直接分配; their `mcp.write`
   mode is `direct` with `dedicated_native_contract`.
 - The v4 link matrix is exact: QoderWork CN, TRAE Work CN, WorkBuddy, and
@@ -514,6 +519,8 @@ fetch/save controls.
 | Runtime value is unknown                                                                   | Preserve `null`/`unverified`; never display "not installed"                                            |
 | Agent directory mounts Hooks editor, MCP validation, observation, or unsupported lists     | Page test fails; those surfaces stay off the Agent directory                                            |
 | Non-Codex Agent detail omits 「产品介绍」 or Codex detail shows that region                 | Page test fails; intros are page-local copy, never catalog `description`                                |
+| Agent directory intro or Codex installer copy names FyAgent                                | Intro/page/installer test fails; Agent directory copy describes the third-party product only            |
+| QoderWork CN catalog description or Agent intro mentions Hooks                             | Catalog/intro test fails; Qoder user-facing copy must not name Hooks                                    |
 | TRAE Models attempts sqlite save or fetch-and-apply                                        | Forbidden; GET observation and catalog guidance only, never 请回 TRAE 保存                              |
 | TRAE/OpenCode GET snapshot or Debug/log contains `ak`/`sk`/`apiKey`                        | Security regression test fails                                                                          |
 | External MCP result contains an original env/header value                                  | Reject the result and expose no copy action                                                             |
@@ -632,7 +639,7 @@ Required focused coverage includes:
   Agent directory tests prove only `direct` capability jumps, no capability-item
   grid or catalog description, shared official
   primary buttons, page-local 「产品介绍」 on non-Codex details, Codex without
-  that region, and the absence of observation/Hooks/MCP panels. Product
+  that region, no FyAgent host copy on Agent directory surfaces, and the absence of observation/Hooks/MCP panels. Product
   pages have no outer h1/subtitle.
 
 Browser tests prove renderer/IPC wiring only. Rust tests prove service/command

--- a/.trellis/spec/frontend/v2-shell.md
+++ b/.trellis/spec/frontend/v2-shell.md
@@ -199,7 +199,7 @@ The navigation source contains exactly these entries in this order:
 | `memory`  | `/memory`  | `记忆`       |
 
 - Use a hash data router. The index route and every unknown route redirect to
-  `/models`; the stable default URL is `#/models`.
+  `/agents`; the stable default URL is `#/agents`.
 - Derive selected state only from router location. The active link has
   `aria-current="page"`; do not maintain a second `currentView` state.
 - After a primary route is first visited, keep that page mounted for the rest of
@@ -370,7 +370,7 @@ Agent/Models, Skills, and MCP ports do not by themselves make it Release-ready.
 
 | Condition                                                              | Required result                                                                    |
 | ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| Empty hash, root route, or unknown route                               | Redirect to `#/models`; Models alone has `aria-current="page"`                     |
+| Empty hash, root route, or unknown route                               | Redirect to `#/agents`; Agent directory alone has `aria-current="page"`            |
 | A `layoutId` pill uses non-uniform scale with `backdrop-filter`            | Architecture test fails; overlay must spring `left`/`top`/`width`/`height` and must not animate `transform: scale` |
 | Changing the active option remounts the overlay or restarts from `{width:0}` | Unit test fails; the same overlay node must keep identity and retarget from current geometry |
 | First show or show-after-`hidden` collapses to the track origin (`inset`, `inset`) | Unit and architecture tests fail; appear must use `selectionLensCollapsedOrigin` of the active host |
@@ -378,7 +378,7 @@ Agent/Models, Skills, and MCP ports do not by themselves make it Release-ready.
 | UI Lab development route                                               | No primary link active; the lab may render one isolated lens specimen              |
 | SVG/backdrop filter unavailable                                        | CSS tint, edge, shadow, focus, and selected state remain readable                  |
 | React StrictMode or repeated ready calls                               | One native `frontend-deeplink-ready` emission per renderer lifetime                |
-| Production requests the UI Lab path                                    | Route is absent and wildcard fallback selects `#/models`                           |
+| Production requests the UI Lab path                                    | Route is absent and wildcard fallback selects `#/agents`                           |
 | Custom caption buttons or `setDecorations(false)` appear                | Unit, architecture, or browser negative assertion fails                            |
 | A drag region appears outside the V2 `TopBar` Overlay chrome            | Architecture test fails; browser preview still has no drag strip                   |
 | Drag strip is gated on userAgent instead of `detectRuntime()`           | Mac-host Playwright/jsdom can show a false strip; runtime tests must fail          |
@@ -407,7 +407,7 @@ Agent/Models, Skills, and MCP ports do not by themselves make it Release-ready.
   Agent directory renders its approved master/detail UI with its own catalog
   pill. Models, Skills, MCP, Prompts, and Memory render only their approved
   bounded feature surfaces.
-- **Base:** Opening without a route lands on `#/models`, with six links and
+- **Base:** Opening without a route lands on `#/agents`, with six links and
   three tools visible. Browser preview has no system or simulated controls.
 - **Fallback:** If refraction cannot render, the selected item remains visibly
   distinct through its CSS material, text, border, shadow, and focus ring.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,17 @@ V2 desktop shell as the shipped product.
 ### Changed
 
 - Notarized exactly one submission per release: the workflow submits only the
-  signed DMG, polls `notarytool info` until Apple accepts or rejects it,
-  staples the DMG and the app from the same ticket, and zips the stapled app.
-  This replaces the serial app-then-DMG waits and stops treating
+  signed DMG, polls `notarytool info` until Apple accepts or rejects it, and
+  staples the DMG and the original app from the same ticket. The published
+  macOS installer is a UDZO DMG that contains `FyAgent.app` and an
+  `Applications` symlink for drag-install. This replaces the serial
+  app-then-DMG waits, the macOS ZIP attachment, and treating
   `notarytool wait --timeout` exit 124 as a rejection.
 - Refined the V2 setup experience: Skill and MCP actions stay on the header
-  row, Agent details show product intros, Models warn on explicit Claude
-  `/v1` paths, and draft service URLs are probed before save.
+  row, opening the app lands on the Agent directory, Agent details show
+  product intros without naming FyAgent, Qoder copy no longer mentions
+  Hooks, Models warn on explicit Claude `/v1` paths, and draft service URLs
+  are probed before save.
 - Codex Desktop skips redundant package-hash rereads during installation.
 
 ### CI and release contract
@@ -31,8 +35,8 @@ V2 desktop shell as the shipped product.
 - Formal `sourceSha` is now the annotated tag's target commit instead of the
   live `main` HEAD, and CI/Release cache `~/.cargo/registry` and
   `~/.cargo/git` keyed by `Cargo.lock`.
-- The publication contract requires exactly eight non-empty attachments: four
-  installers (Windows x64/ARM64 NSIS, macOS Universal DMG/ZIP), three
+- The publication contract requires exactly seven non-empty attachments: three
+  installers (Windows x64/ARM64 NSIS, macOS Universal DMG), three
   release-evidence JSON files, and one Sigstore bundle. The v0.4.1 run that
   failed during serial notarization was never published; earlier v0.3.x tags
   remain unmoved.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ FyAgent 的工作数据默认保存在本机 `~/.fyagent`。配置更新使用 S
 
 发布文件名如下：
 
-- macOS：`FyAgent-X.Y.Z-macOS.dmg`、`FyAgent-X.Y.Z-macOS.zip`
+- macOS：`FyAgent-X.Y.Z-macOS.dmg`
 - Windows：`FyAgent-X.Y.Z-Windows-x64-setup.exe`、`FyAgent-X.Y.Z-Windows-arm64-setup.exe`
 
 Windows 当前只提供 NSIS 安装程序，不提供 MSI 或便携 ZIP。macOS 构建使用 Apple Developer ID 签名，并经过 Apple 公证。

--- a/README_EN.md
+++ b/README_EN.md
@@ -96,7 +96,7 @@ See the full [English manual](docs/user-manual/en/README.md), or switch to [ç®€ä
 
 Release files follow these names:
 
-- macOS: `FyAgent-X.Y.Z-macOS.dmg`, `FyAgent-X.Y.Z-macOS.zip`
+- macOS: `FyAgent-X.Y.Z-macOS.dmg`
 - Windows: `FyAgent-X.Y.Z-Windows-x64-setup.exe`, `FyAgent-X.Y.Z-Windows-arm64-setup.exe`
 
 Windows releases use an NSIS setup program; MSI and portable ZIP packages are not part of the current release surface. macOS builds are signed with an Apple Developer ID and notarized.

--- a/README_JA.md
+++ b/README_JA.md
@@ -96,7 +96,7 @@ AI が賢くなるほど、権限を誰に渡したのか、なぜ設定が壊�
 
 ファイル名は次の形式です。
 
-- macOS: `FyAgent-X.Y.Z-macOS.dmg`、`FyAgent-X.Y.Z-macOS.zip`
+- macOS: `FyAgent-X.Y.Z-macOS.dmg`
 - Windows: `FyAgent-X.Y.Z-Windows-x64-setup.exe`、`FyAgent-X.Y.Z-Windows-arm64-setup.exe`
 
 Windows 版は NSIS セットアップのみで、MSI とポータブル ZIP は現在の配布対象ではありません。macOS 版は Apple Developer ID で署名され、公証を受けています。

--- a/docs/fyagent/development/ci-release/release.md
+++ b/docs/fyagent/development/ci-release/release.md
@@ -31,8 +31,10 @@ Platform acceptance is successful build and packaging on each matching native
 runner. Windows additionally requires strict unsigned/signing proof and the
 fresh formal sealing boundary before exact-asset verification. macOS
 additionally requires Developer ID signing, one Apple notarization of the
-signed DMG, a stapled DMG ticket, and a stapled ticket on the ZIP's app.
-The notarization helper submits the DMG once, then polls `notarytool info`
+signed DMG, a stapled DMG ticket, and a stapled ticket on the original app.
+The published macOS installer is that DMG, with `FyAgent.app` and an
+`Applications` symlink so Finder can drag-install. The notarization helper
+submits the DMG once, then polls `notarytool info`
 until Apple returns a terminal status, instead of treating a
 `notarytool wait` timeout as rejection. The
 Release workflow does not launch the setup

--- a/docs/release-notes/v0.4.2-en.md
+++ b/docs/release-notes/v0.4.2-en.md
@@ -5,8 +5,8 @@
 > before upgrading, and review the trust and verification boundaries below
 > before installing.
 >
-> The v0.4.2 publication contract requires exactly eight non-empty attachments:
-> four installers, three release-evidence JSON files, and one Sigstore bundle.
+> The v0.4.2 publication contract requires exactly seven non-empty attachments:
+> three installers, three release-evidence JSON files, and one Sigstore bundle.
 > The workflow verifies that exact set before publication. This document does
 > not by itself claim that an independent post-publication re-download review
 > has been completed.
@@ -29,19 +29,21 @@
   universal app with `Developer ID Application: William Wang (HY446996QX)`,
   then notarizes only the signed DMG. The helper submits without `--wait` and
   polls `notarytool info` until Apple accepts or rejects that one submission,
-  then staples the DMG and the app from the same ticket. The ZIP contains that
-  stapled app. This avoids two serial Apple notarization waits and does not
+  then staples the DMG and the app from the same ticket. The published macOS
+  installer is a DMG with an Applications symlink; there is no ZIP. This avoids
+  two serial Apple notarization waits and does not
   treat `notarytool wait --timeout` exit 124 as rejection.
-- **V2 setup UX:** Skill and MCP actions stay on the header row. Agent details
-  show product intros. Models warn on explicit Claude `/v1` paths and probe
-  draft service URLs before save.
+- **V2 setup UX:** Skill and MCP actions stay on the header row. Opening the
+  app lands on the Agent directory. Agent details show product intros without
+  naming FyAgent. Qoder copy no longer mentions Hooks. Models warn on
+  explicit Claude `/v1` paths and probe draft service URLs before save.
 - **Installer and CI:** Codex Desktop skips extra package-hash rereads. Formal
   `sourceSha` is the tag target commit, not live `main` HEAD. CI/Release cache
   `~/.cargo/registry` and `~/.cargo/git` from `Cargo.lock`.
 - **V2 desktop shell and catalogs** from 0.4.0 remain the shipped product:
   Agent directory, Models, Skills, MCP, Prompts, and Memory.
 - **Shipped platforms:** formal installers are Windows (x64 and ARM64 NSIS)
-  and macOS Universal (DMG and ZIP). Current-host development checks are not a
+  and macOS Universal DMG. Current-host development checks are not a
   substitute for those installers.
 
 ## Download and trust guidance
@@ -61,11 +63,11 @@ attestation before installing.
 
 ### macOS
 
-Choose the DMG or ZIP; both contain the Universal application:
+Choose `FyAgent-0.4.2-macOS.dmg`. Open it, then drag `FyAgent.app` onto
+**Applications** in the same window.
 
 ```text
 FyAgent-0.4.2-macOS.dmg
-FyAgent-0.4.2-macOS.zip
 ```
 
 The universal app is signed with an Apple Developer ID and notarized by Apple.
@@ -77,11 +79,10 @@ remove quarantine metadata.
 
 ## Exact Release attachment contract
 
-The formal Release must contain exactly these four installer assets:
+The formal Release must contain exactly these three installer assets:
 
 ```text
 FyAgent-0.4.2-macOS.dmg
-FyAgent-0.4.2-macOS.zip
 FyAgent-0.4.2-Windows-x64-setup.exe
 FyAgent-0.4.2-Windows-arm64-setup.exe
 ```
@@ -95,9 +96,9 @@ signing-status.json
 artifact-attestation.sigstore.json
 ```
 
-That is eight attachments total. The attestation has seven subjects: the four
+That is seven attachments total. The attestation has six subjects: the three
 installers plus `download-manifest.json`, `build-metadata.json`, and
-`signing-status.json`. The copied Sigstore bundle is the eighth attachment and
+`signing-status.json`. The copied Sigstore bundle is the seventh attachment and
 does not attest itself. A missing, duplicate, renamed, empty, stale, or extra
 attachment blocks publication.
 

--- a/docs/release-notes/v0.4.2-zh.md
+++ b/docs/release-notes/v0.4.2-zh.md
@@ -3,7 +3,7 @@
 > [!IMPORTANT]
 > FyAgent 仍在积极开发中。升级前请备份重要配置，并先阅读下方的信任与校验边界。
 >
-> v0.4.2 的发布合同要求恰好 8 个非空附件：4 个安装包、3 份发布证据 JSON，以及
+> v0.4.2 的发布合同要求恰好 7 个非空附件：3 个安装包、3 份发布证据 JSON，以及
 > 1 个 Sigstore bundle。工作流会在发布前校验该集合。本文本身不声称已经完成
 > 独立的发布后再下载复核。
 
@@ -23,9 +23,11 @@
   `Developer ID Application: William Wang (HY446996QX)` 签署 Universal 应用，
   然后只把已签名的 DMG 提交 Apple 公证。助手不带 `--wait` 提交，并轮询
   `notarytool info`，直到 Apple 接受或拒绝这一次提交，再用同一张票据装订 DMG
-  和应用；ZIP 内含该已装订应用。这样不再串行等待两次公证，也不会把
+  和应用。发布的 macOS 安装包是带 `Applications` 符号链接的 DMG，不再附带 ZIP。
+  这样不再串行等待两次公证，也不会把
   `notarytool wait --timeout` 的退出码 124 当成拒绝。
-- **V2 设置体验：** Skill 与 MCP 操作保留在标题行；Agent 详情展示产品简介；
+- **V2 设置体验：** Skill 与 MCP 操作保留在标题行；打开应用后进入 Agent 目录；
+  Agent 详情展示产品简介，且不再出现 FyAgent 字样；Qoder 文案不再提及 Hooks；
   Models 会对显式 Claude `/v1` 路径发出警告，并在保存前探测草稿服务 URL。
 - **安装器与 CI：** Codex Desktop 不再额外重读 package hash。正式 `sourceSha`
   是标签指向的提交，而不是当时的 `main` HEAD。CI/Release 按 `Cargo.lock` 缓存
@@ -33,7 +35,7 @@
 - **0.4.0 的 V2 桌面壳与目录** 仍是当前交付：Agent 目录、Models、Skills、MCP、
   Prompts 和 Memory。
 - **已交付平台：** 正式安装包为 Windows（x64 与 ARM64 NSIS）和 macOS Universal
-  （DMG 与 ZIP）。本机开发检查不能替代这些安装包。
+  DMG。本机开发检查不能替代这些安装包。
 
 ## 下载与信任说明
 
@@ -51,11 +53,11 @@ FyAgent-0.4.2-Windows-arm64-setup.exe
 
 ### macOS
 
-选择 DMG 或 ZIP；两者都包含 Universal 应用：
+选择 `FyAgent-0.4.2-macOS.dmg`。双击打开后，将 `FyAgent.app` 拖到同一窗口中的
+「应用程序」。
 
 ```text
 FyAgent-0.4.2-macOS.dmg
-FyAgent-0.4.2-macOS.zip
 ```
 
 该 Universal 应用使用 Apple Developer ID 签名，并经过 Apple 公证。DMG 容器
@@ -66,11 +68,10 @@ quarantine 元数据。
 
 ## 精确的 Release 附件合同
 
-正式 Release 必须恰好包含以下 4 个安装包：
+正式 Release 必须恰好包含以下 3 个安装包：
 
 ```text
 FyAgent-0.4.2-macOS.dmg
-FyAgent-0.4.2-macOS.zip
 FyAgent-0.4.2-Windows-x64-setup.exe
 FyAgent-0.4.2-Windows-arm64-setup.exe
 ```
@@ -84,9 +85,9 @@ signing-status.json
 artifact-attestation.sigstore.json
 ```
 
-合计 8 个附件。attestation 有 7 个 subject：4 个安装包以及
+合计 7 个附件。attestation 有 6 个 subject：3 个安装包以及
 `download-manifest.json`、`build-metadata.json` 和 `signing-status.json`。
-复制出的 Sigstore bundle 是第 8 个附件，且不对自己做 attestation。缺失、
+复制出的 Sigstore bundle 是第 7 个附件，且不对自己做 attestation。缺失、
 重复、改名、空文件、过期或多余附件都会阻止发布。
 
 ## 兼容性与升级说明

--- a/docs/user-manual/en/1-getting-started/1.2-installation.md
+++ b/docs/user-manual/en/1-getting-started/1.2-installation.md
@@ -108,14 +108,15 @@ trigger Windows trust warnings.
 
 ### Download from GitHub Releases
 
-1. Download `FyAgent-X.Y.Z-macOS.dmg` (recommended) or `FyAgent-X.Y.Z-macOS.zip`
-2. Open the DMG, or extract the zip to get `FyAgent.app`
-3. Drag it to the Applications folder
+1. Download `FyAgent-X.Y.Z-macOS.dmg`
+2. Double-click the DMG to open it
+3. Drag `FyAgent.app` onto **Applications** in the same window
 
 ### Current Signing and Notarization Status
 
 The complete universal app is **signed with an Apple Developer ID** and
-**notarized by Apple**. The ZIP and DMG contain that same app. The **DMG
+**notarized by Apple**. The installer is a DMG that contains `FyAgent.app` and
+an Applications symlink. The **DMG
 container is signed, notarized, and stapled**. Before opening it, verify the
 exact Release's SHA-256, source SHA, and attestation.
 

--- a/docs/user-manual/ja/1-getting-started/1.2-installation.md
+++ b/docs/user-manual/ja/1-getting-started/1.2-installation.md
@@ -108,17 +108,17 @@ attestation を確認してください。明示的に `NotSigned` の setup で
 
 ### GitHub Releases からダウンロード
 
-1. `FyAgent-X.Y.Z-macOS.dmg`（推奨）または `FyAgent-X.Y.Z-macOS.zip` をダウンロード
-2. DMG を開く、または zip を展開して `FyAgent.app` を取得
-3. 「アプリケーション」フォルダにドラッグ
+1. `FyAgent-X.Y.Z-macOS.dmg` をダウンロード
+2. DMG をダブルクリックして開く
+3. 同じウィンドウの「アプリケーション」へ `FyAgent.app` をドラッグ
 
 ### 現在の署名と公証の状態
 
 現在の正式な macOS リリースワークフローは、完全なユニバーサル app が
 **Apple Developer ID で署名され**、パッケージ化前に **Apple の公証を受けています**。
-ZIP と DMG には同じ app が含まれ、DMG container 自体も署名・公証され、ticket が
-staple されます。開く前に、対象 Release の SHA-256、source SHA、attestation を確認して
-ください。
+インストーラーは `FyAgent.app` と Applications シンボリックリンクを含む DMG です。
+DMG container 自体も署名・公証され、ticket が staple されます。開く前に、対象
+Release の SHA-256、source SHA、attestation を確認してください。
 
 ### Gatekeeper が初回起動をブロックした場合
 

--- a/docs/user-manual/zh/1-getting-started/1.2-installation.md
+++ b/docs/user-manual/zh/1-getting-started/1.2-installation.md
@@ -123,15 +123,15 @@ npm install -g @google/gemini-cli --registry=https://registry.npmmirror.com
 
 ### 从 GitHub Releases 下载
 
-1. 下载 `FyAgent-X.Y.Z-macOS.dmg`（推荐）或 `FyAgent-X.Y.Z-macOS.zip`
-2. 打开 DMG，或解压 zip 得到 `FyAgent.app`
-3. 拖动到「应用程序」文件夹
+1. 下载 `FyAgent-X.Y.Z-macOS.dmg`
+2. 双击打开 DMG
+3. 将 `FyAgent.app` 拖到同一窗口中的「应用程序」
 
 ### 当前签名与公证状态
 
 当前正式 macOS 发布工作流使用 **Apple Developer ID 签名** 封装完整的通用应用，
-并在打包前完成 **Apple 公证** 和票据装订。ZIP 和 DMG 内含同一应用，DMG 容器
-本身也经过签名、公证和装订。打开前请核对具体 Release 的 SHA-256、源码 SHA
+并在打包前完成 **Apple 公证** 和票据装订。安装包是带 `Applications` 符号链接的
+DMG；容器本身也经过签名、公证和装订。打开前请核对具体 Release 的 SHA-256、源码 SHA
 和 attestation。
 
 ### Gatekeeper 拦截首次启动时

--- a/playwright.v2.config.ts
+++ b/playwright.v2.config.ts
@@ -41,7 +41,7 @@ export default defineConfig({
   })),
   webServer: {
     command: "pnpm dev:renderer --host 127.0.0.1 --port 4173 --strictPort",
-    url: "http://127.0.0.1:4173/#/models",
+    url: "http://127.0.0.1:4173/#/agents",
     reuseExistingServer: false,
     timeout: 120_000,
   },

--- a/scripts/release/release-contract.d.mts
+++ b/scripts/release/release-contract.d.mts
@@ -10,7 +10,7 @@ export type GitHubRunnerArch = "X86" | "X64" | "ARM" | "ARM64";
 export interface InstallerRule {
   readonly suffix: string;
   readonly platform: ReleasePlatform;
-  readonly kind: "dmg" | "zip" | "exe";
+  readonly kind: "dmg" | "exe";
   readonly architecture: ReleaseArchitecture;
 }
 

--- a/scripts/release/release-contract.mjs
+++ b/scripts/release/release-contract.mjs
@@ -39,12 +39,6 @@ export const INSTALLER_RULES = Object.freeze([
     architecture: "universal",
   },
   {
-    suffix: "-macOS.zip",
-    platform: "macos",
-    kind: "zip",
-    architecture: "universal",
-  },
-  {
     suffix: "-Windows-x64-setup.exe",
     platform: "windows",
     kind: "exe",
@@ -86,9 +80,9 @@ export const EXPECTED_TARGETS = Object.freeze([
 ]);
 
 export const EXPECTED_INSTALLERS_BY_TARGET = Object.freeze({
-  "macos-universal": Object.freeze([0, 1]),
-  "windows-x64": Object.freeze([2]),
-  "windows-arm64": Object.freeze([3]),
+  "macos-universal": Object.freeze([0]),
+  "windows-x64": Object.freeze([1]),
+  "windows-arm64": Object.freeze([2]),
 });
 
 export const WINDOWS_SIGNING_FRAGMENTS_BY_TARGET = Object.freeze({

--- a/scripts/tasks/supported-platform-structure-assets.json
+++ b/scripts/tasks/supported-platform-structure-assets.json
@@ -319,7 +319,7 @@
     ],
     [
       "tests/releaseWorkflow.test.ts",
-      "a31829d104127922600b4e35d4330cade01842d3e44d7a2e8e63bbc6f1f65d3a"
+      "da0edb65c0712b7bc32849e7a3a233bd6c6cf8ab776d316e0c4cbc9caa741e09"
     ],
     [
       "tests/remainingPlatformSurface.test.ts",

--- a/src-tauri/src/commands/agent_catalog.rs
+++ b/src-tauri/src/commands/agent_catalog.rs
@@ -7,7 +7,7 @@ use crate::services::external_agents::{
 };
 
 const AGENT_CATALOG_CONTRACT_VERSION: u16 = 4;
-const AGENT_CATALOG_REVIEWED_AT: &str = "2026-08-20";
+const AGENT_CATALOG_REVIEWED_AT: &str = "2026-08-21";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -652,7 +652,7 @@ const AGENT_CATALOG: [AgentCatalogEntry; 7] = [
         variant_id: AgentVariantId::QoderWorkCn,
         display_name: "QoderWork CN",
         description:
-            "支持 Skills 同步、Hooks 配置与 MCP 直接分配；不支持第三方模型配置。本机识别和启动暂无法确认。",
+            "支持 Skills 同步与 MCP 直接分配；不支持第三方模型配置。本机识别和启动暂无法确认。",
         official_links: &QODERWORK_OFFICIAL_LINKS,
         capabilities: &QODERWORK_CAPABILITIES,
     },
@@ -771,7 +771,7 @@ mod tests {
         let catalog = get_agent_catalog();
 
         assert_eq!(catalog.contract_version, 4);
-        assert_eq!(catalog.reviewed_at, "2026-08-20");
+        assert_eq!(catalog.reviewed_at, "2026-08-21");
         assert_eq!(
             catalog
                 .agents
@@ -1009,6 +1009,10 @@ mod tests {
         assert_eq!(trae.official_links[0].url, "https://www.trae.cn/sem-work");
         assert!(qoder.description.contains("不支持第三方模型配置"));
         assert!(qoder.description.contains("MCP 直接分配"));
+        assert!(
+            !qoder.description.contains("Hooks") && !qoder.description.contains("hooks"),
+            "QoderWork CN description must not mention Hooks"
+        );
         assert!(trae.description.contains("MCP 直接分配"));
         assert!(trae
             .description
@@ -1083,7 +1087,7 @@ mod tests {
         let value = serde_json::to_value(get_agent_catalog()).expect("catalog serializes");
 
         assert_eq!(value["contractVersion"], 4);
-        assert_eq!(value["reviewedAt"], "2026-08-20");
+        assert_eq!(value["reviewedAt"], "2026-08-21");
         assert_eq!(
             sorted_object_keys(&value),
             ["agents", "contractVersion", "reviewedAt"]

--- a/src/v2/app/router.tsx
+++ b/src/v2/app/router.tsx
@@ -30,7 +30,7 @@ export const appRoutes: RouteObject[] = [
       {
         errorElement: <RootError />,
         children: [
-          { index: true, element: <Navigate to="/models" replace /> },
+          { index: true, element: <Navigate to="/agents" replace /> },
           {
             element: <PersistentPrimaryOutlet />,
             children: [
@@ -41,7 +41,7 @@ export const appRoutes: RouteObject[] = [
               { path: "prompts", element: null },
               { path: "memory", element: null },
               ...developmentRoutes,
-              { path: "*", element: <Navigate to="/models" replace /> },
+              { path: "*", element: <Navigate to="/agents" replace /> },
             ],
           },
         ],

--- a/src/v2/pages/agents/intros.ts
+++ b/src/v2/pages/agents/intros.ts
@@ -10,15 +10,13 @@ const INTROS: Partial<Record<AgentCatalogId, AgentIntro>> = {
       "QoderWork CN 是阿里云 Qoder CN 系列里的桌面端智能工作助手。它把 Agent 能力从写代码扩展到日常办公：用自然语言交代任务，由它在本机整理文件、处理数据、撰写文档，并直接操作表格、演示文稿和 PDF。",
       "和只负责问答的聊天工具不同，QoderWork CN 强调把结果交付出来。它可以读取你授权的本地目录，自动浏览网页、填写表单、提取数据，也能点击、输入、滚动，与屏幕上的桌面应用协作。还可以设置一次性或周期性任务，并把钉钉、飞书等即时通讯接到工作流里。",
       "扩展方式包括社区技能、自定义 Skill、MCP 服务器和第三方连接器。文件处理在本地完成，访问目录前需要授权；高风险操作会再确认。它使用 Qoder CN 账号，并与系列内其他产品共享 Credits。",
-      "在 FyAgent 里可以为它同步 Skills、配置 Hooks 并直接分配 MCP。官方不支持在第三方工具里改模型，因此模型页不会提供第三方模型编辑器。本机识别和一键启动目前仍无法确认。",
     ],
   },
   "trae-work": {
     paragraphs: [
       "TRAE Work CN（TraeWork）是字节跳动推出的 AI 原生工作台，覆盖文档撰写、数据分析、深度调研、PPT 生成和代码开发。产品提供网页版、桌面版和移动端，桌面端不依赖 TraeCode IDE 也能独立运行。",
       "同一工作台里可以切换 Work、Code、Design 三种模式。Work 面向产品、运营和分析等岗位，处理文档、数据和演示稿；Code 面向开发，覆盖编码、调试、代码库和 Git 工作流；Design 用 AI 走完设计、修改到交付。你提出任务后，TraeWork 会自动拆解并调用 Skills 与工具，项目文件集中在 Workspace 里验收。",
-      "桌面版同时支持本地与云端运行环境，网页版以云端为主；多任务可以并行。外部能力可通过 GitHub、飞书、MCP、技能、斜杠命令和规则扩展。自定义模型需要在 TRAE Work CN 自己的界面里添加，FyAgent 不会写入它的 sqlite。",
-      "在 FyAgent 里可以为它同步 Skills 并直接分配 MCP。本机识别和一键启动目前仍无法确认。",
+      "桌面版同时支持本地与云端运行环境，网页版以云端为主；多任务可以并行。外部能力可通过 GitHub、飞书、MCP、技能、斜杠命令和规则扩展。自定义模型需要在 TRAE Work CN 自己的界面里添加。",
     ],
   },
   workbuddy: {
@@ -26,7 +24,6 @@ const INTROS: Partial<Record<AgentCatalogId, AgentIntro>> = {
       "WorkBuddy 是 workbuddy.cn 上的 AI 编程助手产品线（官方文档中也以 CodeBuddy 形态出现），由腾讯云提供，目标是把产品构思、设计、研发到部署放进同一条协作链路。",
       "常见形态包括 IDE、编辑器插件和 CLI。IDE 主打「对话即编程」，可以从自然语言需求生成结构化说明、把设计稿转成可维护代码，并覆盖补全、多文件改写、审查和测试。插件装进 VS Code 或 JetBrains，让开发者继续主导、AI 做辅助。CLI 面向命令行和自动化，适合脚本、运维和流水线里的批量任务。",
       "文档还提到需求分析转 PRD、Figma 转代码、CloudBase / Supabase 等云服务集成，以及混元、DeepSeek 等多模型切换。Ask / Craft / Plan 等模式用来区分问答、局部改写和跨文件执行。",
-      "在 FyAgent 里可以为它配置第三方模型、同步 Skills 并直接分配 MCP。本机识别和一键启动目前仍无法确认。",
     ],
   },
   grokbuild: {
@@ -34,7 +31,6 @@ const INTROS: Partial<Record<AgentCatalogId, AgentIntro>> = {
       "Grok Build 是 xAI 的终端编码 Agent，命令行里通常以 grok 启动。它提供全屏 TUI，能阅读代码库、编辑文件、执行 shell、搜索网页，并管理较长时间的任务；也可以无头运行，或通过 Agent Client Protocol 嵌进其他编辑器。",
       "官方定位是覆盖计划、构建、测试到部署的开发工作流。当前由 Grok 4.6 驱动。安装脚本为 curl -fsSL https://x.ai/cli/install.sh | bash。首次启动会走浏览器登录。",
       "它可以按项目发现 rules、skills、plugins、hooks 和 MCP。子命令覆盖登录、模型列表、MCP 与插件市场、会话导入导出（含从 Claude Code 导入）、worktree 和仪表盘。headless / ACP 适合脚本和 CI。",
-      "在 FyAgent 里可以为它做 Provider 快速配置、同步 Skills 并直接分配 MCP。本机识别和一键启动目前仍无法确认。",
     ],
   },
   "claude-code": {
@@ -42,7 +38,6 @@ const INTROS: Partial<Record<AgentCatalogId, AgentIntro>> = {
       "Claude Code 是 Anthropic 的 agentic 编码工具，可以在终端、IDE、桌面应用和浏览器里使用。它直接读取代码库、编辑文件、运行命令，并接入 Git 与常见开发工具，用自然语言完成例行改动、解释复杂代码和提交工作流。",
       "终端 CLI 是完整功能面。官方安装不再推荐 npm：macOS 使用官方 install.sh 脚本，Windows 使用官方 PowerShell 安装命令。装好后在项目目录运行 claude 即可开会话。多数表面需要 Claude 订阅或 Anthropic Console 账号；终端和 VS Code 也支持第三方供应商。",
       "它能做代码库导览、多文件编辑、测试与 PR。除 CLI 外还有 VS Code / JetBrains 扩展、GitHub 集成、网页和移动入口。第三方网关应把 ANTHROPIC_BASE_URL 写成主机和前缀，不要再叠一层 /v1，否则 Anthropic SDK 拼接后会变成 /v1/v1/…。",
-      "在 FyAgent 里可以为它做 Provider 快速配置、同步 Skills 并直接分配 MCP。本机识别和一键启动目前仍无法确认。",
     ],
   },
   opencode: {
@@ -50,7 +45,6 @@ const INTROS: Partial<Record<AgentCatalogId, AgentIntro>> = {
       "OpenCode 是开源 AI 编码 Agent，可在终端 TUI、桌面应用和 IDE 扩展里使用。它把模型接到你的仓库、终端和开发工具：修复缺陷时可以自己找文件、拟定计划、改代码、跑测试并处理报错。",
       "官方强调隐私：不把你的代码或上下文存到他们那边，方便在对数据敏感的环境使用。它按 MIT 许可发布，模型无关，可用任意 LLM 供应商；模型费用与软件本身分开。推荐安装：curl -fsSL https://opencode.ai/install | bash。",
       "架构上是本地客户端加本地 server。TUI、桌面、IDE 和 SDK 都通过 HTTP 连这台 server，也支持 opencode attach 远程接入和 opencode serve 无头运行。权限提示用于确认写文件和跑命令，但官方说明它不是安全沙箱；需要隔离时应放进容器或虚拟机。",
-      "在 FyAgent 里使用专用的 OpenCode 模型端口写入 opencode.json，同时同步 Skills 并直接分配 MCP。不要走 Claude/Codex 那套 Provider 快配。本机识别和一键启动目前仍无法确认。",
     ],
   },
 };

--- a/src/v2/shared/codex-desktop/CodexDesktopInstallerPanel.tsx
+++ b/src/v2/shared/codex-desktop/CodexDesktopInstallerPanel.tsx
@@ -136,7 +136,7 @@ export function CodexDesktopInstallerPanel() {
       <div className="fy-codex-installer-heading">
         <div>
           <h3>Codex Desktop</h3>
-          <p>在 FyAgent 中安装、更新或启动桌面应用。</p>
+          <p>安装、更新或启动 Codex Desktop。</p>
         </div>
         {(installer.state === "checking" || installer.isRefreshing) && (
           <Spinner label="正在读取 Codex Desktop 状态" />

--- a/tests/downloadManifest.test.ts
+++ b/tests/downloadManifest.test.ts
@@ -63,7 +63,7 @@ afterEach(() => {
 });
 
 describe("release download manifest", () => {
-  it("records the exact four installers with frozen identity and streaming digests", () => {
+  it("records the exact three installers with frozen identity and streaming digests", () => {
     const assetsDirectory = createAssetsDirectory();
     populateExactInstallers(assetsDirectory);
     const manifestPath = runGenerator(assetsDirectory);
@@ -95,7 +95,7 @@ describe("release download manifest", () => {
     expect(manifest.assets.map(({ name }) => name)).toEqual(
       expectedInstallerNames(version),
     );
-    expect(manifest.assets).toHaveLength(4);
+    expect(manifest.assets).toHaveLength(3);
     const windowsArm64 = manifest.assets.find(
       ({ name }) => name === "FyAgent-0.3.0-Windows-arm64-setup.exe",
     );
@@ -125,7 +125,7 @@ describe("release download manifest", () => {
     populateExactInstallers(assetsDirectory);
     mutate(assetsDirectory);
     expect(() => runGenerator(assetsDirectory)).toThrow(
-      /installer directory must contain exactly 4 files/,
+      /installer directory must contain exactly 3 files/,
     );
   });
 
@@ -133,7 +133,7 @@ describe("release download manifest", () => {
     const assetsDirectory = createAssetsDirectory();
     populateExactInstallers(assetsDirectory);
     writeFileSync(
-      path.join(assetsDirectory, expectedInstallerNames(version)[3]),
+      path.join(assetsDirectory, expectedInstallerNames(version)[2]),
       "",
     );
     expect(() => runGenerator(assetsDirectory)).toThrow(

--- a/tests/releaseAssets.test.ts
+++ b/tests/releaseAssets.test.ts
@@ -207,13 +207,12 @@ describe("release asset and metadata contract", () => {
     ]);
   });
 
-  it("freezes four installers, seven subjects, and eight attachments", () => {
+  it("freezes three installers, six subjects, and seven attachments", () => {
     const installers = expectedInstallerNames("0.3.0");
     expect(PREFLIGHT_BRANCH).toBe("dev/laiyongjie");
     expect(RELEASE_BRANCH).toBe("main");
     expect(installers).toEqual([
       "FyAgent-0.3.0-macOS.dmg",
-      "FyAgent-0.3.0-macOS.zip",
       "FyAgent-0.3.0-Windows-x64-setup.exe",
       "FyAgent-0.3.0-Windows-arm64-setup.exe",
     ]);
@@ -223,12 +222,12 @@ describe("release asset and metadata contract", () => {
       BUILD_METADATA_NAME,
       WINDOWS_SIGNING_STATUS_NAME,
     ]);
-    expect(expectedAttestationSubjectNames("0.3.0")).toHaveLength(7);
+    expect(expectedAttestationSubjectNames("0.3.0")).toHaveLength(6);
     expect(expectedReleaseAttachmentNames("0.3.0")).toEqual([
       ...expectedAttestationSubjectNames("0.3.0"),
       ATTESTATION_BUNDLE_NAME,
     ]);
-    expect(expectedReleaseAttachmentNames("0.3.0")).toHaveLength(8);
+    expect(expectedReleaseAttachmentNames("0.3.0")).toHaveLength(7);
   });
 
   it("fails closed when a canonical version cannot fit NSIS fixed-file fields", () => {
@@ -469,7 +468,7 @@ describe("release asset and metadata contract", () => {
     });
     expect(metadata.version).toBe("12.34.56");
     expect(metadata.tag).toBe("v12.34.56");
-    expect(expectedInstallerNames(metadata.version)).toHaveLength(4);
+    expect(expectedInstallerNames(metadata.version)).toHaveLength(3);
   });
 
   it.each([
@@ -592,7 +591,7 @@ describe("release asset and metadata contract", () => {
     ).toThrow(error);
   });
 
-  it("assembles exactly eight attachments and verifies re-downloaded bytes", async () => {
+  it("assembles exactly seven attachments and verifies re-downloaded bytes", async () => {
     const root = temporaryDirectory();
     const subjects = path.join(root, "subjects");
     const attachments = path.join(root, "attachments");
@@ -614,7 +613,7 @@ describe("release asset and metadata contract", () => {
     expect(described.map(({ name }) => name)).toEqual(
       expectedReleaseAttachmentNames("0.3.0"),
     );
-    expect(described).toHaveLength(8);
+    expect(described).toHaveLength(7);
 
     for (const name of expectedReleaseAttachmentNames("0.3.0")) {
       copyFileSync(path.join(attachments, name), path.join(downloaded, name));
@@ -625,7 +624,7 @@ describe("release asset and metadata contract", () => {
         downloadedDirectory: downloaded,
         version: "0.3.0",
       }),
-    ).resolves.toHaveLength(8);
+    ).resolves.toHaveLength(7);
 
     writeFileSync(
       path.join(downloaded, expectedInstallerNames("0.3.0")[0]),

--- a/tests/releaseWorkflow.test.ts
+++ b/tests/releaseWorkflow.test.ts
@@ -467,7 +467,7 @@ function assertWindowsSetupIconGates(workflow: string) {
   const verify = workflowJobBlock(workflow, "verify-assets", "attest");
   const aggregate = namedStepBlock(
     verify,
-    "Verify exact four and generate three machine-readable subjects",
+    "Verify exact three installers and generate three machine-readable subjects",
   );
   const aggregateLines = aggregate.split("\n");
   if (
@@ -920,7 +920,7 @@ describe("FyAgent release workflow", () => {
     const rawPath = path.join(
       outputRoot,
       "raw-windows-x64",
-      expectedInstallerNames(version)[2],
+      expectedInstallerNames(version)[1],
     );
     const rawBytes = fs.readFileSync(rawPath);
     fs.appendFileSync(rawPath, "tampered");
@@ -1952,7 +1952,7 @@ jobs:
     expect(formal).toContain("pin-release-build-inputs");
   });
 
-  it("aggregates signing evidence and attests seven subjects into eight attachments", () => {
+  it("aggregates signing evidence and attests six subjects into seven attachments", () => {
     const verify = workflowJobBlock(source, "verify-assets", "attest");
     expect(verify).toContain(
       "artifact-ids: ${{ needs['pin-release-build-inputs'].outputs.artifact_id }}",
@@ -1972,7 +1972,7 @@ jobs:
       "--arm64-status signing-fragments/windows-signing-arm64.json",
     );
     expect(verify).toContain("--output verified-subjects/signing-status.json");
-    expect(verify).toContain("Upload the exact seven attestation subjects");
+    expect(verify).toContain("Upload the exact six attestation subjects");
 
     const attest = workflowJobBlock(source, "attest", "publish");
     expectExactLine(attest, "    needs: [eligibility, verify-assets]");
@@ -1981,8 +1981,8 @@ jobs:
       "actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6",
     );
     expect(attest).toContain("subject-path: verified-subjects/*");
-    expect(attest).toContain("Recheck the exact seven subjects");
-    expect(attest).toContain("exact eight Release attachments");
+    expect(attest).toContain("Recheck the exact six subjects");
+    expect(attest).toContain("exact seven Release attachments");
     expect(attest).toContain("prepare-release-publication.mjs assemble");
 
     const publish = source.slice(source.indexOf("\n  publish:\n"));
@@ -1997,8 +1997,8 @@ jobs:
     expect(publish).toContain(".attestation.subjectName");
     expect(publish).toContain(".attestation.subjectDigest");
     expect(publish).toContain("signing-status.json");
-    expect(publish).toContain("length == 8");
-    expect(publish).toContain("(.assets | length) == 8");
+    expect(publish).toContain("length == 7");
+    expect(publish).toContain("(.assets | length) == 7");
   });
 
   it("seals the universal macOS app with Developer ID and notarizes the DMG", () => {
@@ -2037,6 +2037,17 @@ jobs:
       "scripts/release/macos-developer-id.sh notarize-dmg",
     );
     expect(macJob).toContain("scripts/release/macos-developer-id.sh staple-app");
+    expect(macJob).toContain('ln -s /Applications "$stage/Applications"');
+    expect(macJob).toContain('[ -L "$mount_point/Applications" ]');
+    expect(macJob).toContain(
+      '[ "$(readlink "$mount_point/Applications")" = "/Applications" ]',
+    );
+    expect(macJob).toContain(
+      'scripts/release/verify-macos-signed-app.sh "$APP_PATH"',
+    );
+    expect(macJob).not.toContain("macOS.zip");
+    expect(macJob).not.toContain("ditto -c -k");
+    expect(macJob).not.toContain("unzip_root");
     expect(macJob).toContain("scripts/release/macos-developer-id.sh teardown");
     expect(macJob).toContain("secrets.FYAGENT_APPLE_CERTIFICATE_P12_BASE64");
     expect(macJob).toContain("secrets.FYAGENT_APPLE_CERTIFICATE_PASSWORD");
@@ -2123,6 +2134,7 @@ jobs:
     expect(macJob).not.toContain("unexpectedly has a code signature");
     expect(macJob).not.toContain("code object is not signed at all");
     expect(source).toContain("FyAgent-${APP_VERSION}-macOS.dmg");
+    expect(source).not.toContain("FyAgent-${APP_VERSION}-macOS.zip");
   });
 
   it("executes the Developer ID verifiers for both slices and fails closed on trust drift", () => {

--- a/tests/v2-browser/shell.spec.ts
+++ b/tests/v2-browser/shell.spec.ts
@@ -50,7 +50,7 @@ test("keeps the complete shell visible, separate, and overflow-free", async ({
   page,
 }) => {
   const health = monitorPageHealth(page);
-  await openV2Page(page, "/models");
+  await openV2Page(page, "/agents");
 
   await expectNoHorizontalOverflow(page);
 
@@ -152,7 +152,7 @@ test("keeps hash, selected link, and aria-current aligned for every route", asyn
   page,
 }) => {
   const health = monitorPageHealth(page);
-  await openV2Page(page, "/models");
+  await openV2Page(page, "/agents");
 
   const navigation = page.getByRole("navigation", { name: "主导航" });
   for (const { path, label } of navigationContract) {
@@ -212,7 +212,7 @@ test("reaches every primary control with the keyboard in document order", async 
   page,
 }) => {
   const health = monitorPageHealth(page);
-  await openV2Page(page, "/models");
+  await openV2Page(page, "/agents");
 
   expect(
     await page

--- a/tests/v2/app/router-shell.test.tsx
+++ b/tests/v2/app/router-shell.test.tsx
@@ -82,15 +82,15 @@ function expectSystemOwnedChrome(): void {
 
 describe("FyAgent V2 routing", () => {
   it.each(["/", "/route-that-does-not-exist"])(
-    "redirects %s to the models route",
+    "redirects %s to the agents route",
     async (initialEntry) => {
       const router = renderRoute(initialEntry);
 
-      await expectPath(router, "/models");
+      await expectPath(router, "/agents");
       const navigation = screen.getByRole("navigation", { name: "主导航" });
       expect(
-        screen.getByRole("link", { name: "模型", current: "page" }),
-      ).toHaveAttribute("href", "/models");
+        screen.getByRole("link", { name: "Agent 目录", current: "page" }),
+      ).toHaveAttribute("href", "/agents");
       expect(screen.getAllByTestId("liquid-glass-lens")).toHaveLength(1);
       expect(within(navigation).getAllByTestId("selection-lens")).toHaveLength(
         1,

--- a/tests/v2/pages/agents/CodexDesktopInstallerPanel.test.tsx
+++ b/tests/v2/pages/agents/CodexDesktopInstallerPanel.test.tsx
@@ -118,6 +118,11 @@ describe("V2 Codex Desktop installer panel", () => {
     });
     renderPanel(port);
 
+    expect(
+      await screen.findByText("安装、更新或启动 Codex Desktop。"),
+    ).toBeVisible();
+    expect(screen.queryByText(/FyAgent/iu)).not.toBeInTheDocument();
+
     const install = await screen.findByRole("button", {
       name: "安装 Codex Desktop",
     });

--- a/tests/v2/pages/agents/Page.test.tsx
+++ b/tests/v2/pages/agents/Page.test.tsx
@@ -388,6 +388,8 @@ describe("V2 Agent directory", () => {
     expect(
       within(qoderDetail).getByRole("region", { name: "产品介绍" }),
     ).toHaveTextContent("QoderWork CN 是阿里云");
+    expect(qoderDetail).not.toHaveTextContent("FyAgent");
+    expect(qoderDetail).not.toHaveTextContent("Hooks");
     expect(qoderDetail).not.toHaveTextContent("应用识别");
     expect(qoderDetail).not.toHaveTextContent("查看 Skills");
     expect(qoderDetail).not.toHaveTextContent("的目录说明");
@@ -434,6 +436,7 @@ describe("V2 Agent directory", () => {
     expect(
       within(codexDetail).queryByRole("region", { name: "产品介绍" }),
     ).not.toBeInTheDocument();
+    expect(codexDetail).not.toHaveTextContent("FyAgent");
     expect(codexDetail).not.toHaveTextContent("不适用的功能");
     expect(codexDetail).not.toHaveTextContent("项支持");
   });

--- a/tests/v2/pages/agents/intros.test.ts
+++ b/tests/v2/pages/agents/intros.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { getAgentIntro } from "@/v2/pages/agents/intros";
+import { AGENT_CATALOG_IDS } from "@/v2/shared/features/types";
+
+describe("Agent directory product intros", () => {
+  it("describes each product without naming FyAgent", () => {
+    for (const id of AGENT_CATALOG_IDS) {
+      const intro = getAgentIntro(id);
+      if (intro === null) continue;
+      expect(intro.paragraphs.length).toBeGreaterThan(0);
+      for (const paragraph of intro.paragraphs) {
+        expect(paragraph, id).not.toMatch(/FyAgent/iu);
+      }
+    }
+  });
+
+  it("keeps Qoder product copy free of Hooks", () => {
+    const intro = getAgentIntro("qoderwork");
+    expect(intro).not.toBeNull();
+    for (const paragraph of intro!.paragraphs) {
+      expect(paragraph).not.toMatch(/hooks/iu);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Publish macOS as a UDZO DMG that contains `FyAgent.app` plus an `Applications` symlink for drag-install, and stop attaching the macOS ZIP. The Release contract is three installers, six attestation subjects, and seven attachments.
- Open the app on the Agent directory (`#/agents`) instead of Models, and remove FyAgent host copy from Agent intros and the Codex installer heading.
- Drop Hooks from the QoderWork CN catalog description so Agent-facing Qoder copy no longer names Hooks.

## Test plan
- [x] `mise run release:check`
- [x] Focused V2 tests for router, Agent directory, intros, and Codex installer
- [x] `cargo test --lib commands::agent_catalog::tests`
- [ ] CI on this PR
- [ ] After merge: retag unpublished `v0.4.2` onto `main` HEAD and confirm the formal Release publishes seven attachments with no ZIP


Made with [Cursor](https://cursor.com)