### PR TITLE
Skip bless --openfolder on Apple Silicon DMG packaging

### DIFF
--- a/.trellis/spec/backend/macos-dmg-layout.md
+++ b/.trellis/spec/backend/macos-dmg-layout.md
@@ -51,7 +51,10 @@ background file .background/background.png
   `hdiutil`, `osascript`, or Finder. Staging-directory aliases bind the runner
   disk CNID and are invalid.
 - AppleScript, `osascript`, `dmgbuild` CLI, `appdmg`, `pip3`, Homebrew
-  `create-dmg`, and `--skip-jenkins` are forbidden. Layout failure is
+  `create-dmg`, `--skip-jenkins`, and `bless --openfolder` are forbidden.
+  GitHub-hosted `macos-15` is Apple Silicon; `bless --openfolder` exits
+  with "not supported on Apple Silicon devices". Finder uses `.DS_Store`
+  `bwsp`/`icvp`/`Iloc` when the user opens the volume. Layout failure is
   non-zero; there is no unstyled fallback.
 - `retry-hdiutil.sh` allows `create`, `convert`, and `verify`. `create` and
   `convert` delete only their destination on failure. Convert must not delete
@@ -70,6 +73,7 @@ background file .background/background.png
 | Condition | Required result |
 | --- | --- |
 | Missing FyAgent.app, background PNG, or Applications symlink | Fail before `hdiutil create` |
+| `bless --openfolder` on Apple Silicon | Fail `build-macos`; do not call `bless` |
 | Layout writer not on Darwin, mount item missing, or alias failure | Non-zero; no osascript fallback |
 | `hdiutil create`/`convert` reports `Resource busy` / temporarily unavailable | Retry same argv, at most 5 attempts, 2/4/8/16s |
 | Other `hdiutil` diagnostic or retry budget exhausted | Return original status; delete only convert/create destination |
@@ -83,15 +87,16 @@ background file .background/background.png
 - Good: mounted-volume `.DS_Store` with picture `icvp` and left/right `Iloc`;
   double-click shows app on the left and Applications on the right.
 - Base: one `Resource busy` during convert, then UDZO verifies.
-- Bad: `create-dmg --skip-jenkins`; AppleScript `.DS_Store`; `pip3 install
-  dmgbuild`; a host-copied `.DS_Store` template; `uv add ds-store` into the
-  default group.
+- Bad: `create-dmg --skip-jenkins`; AppleScript `.DS_Store`; `bless --openfolder`;
+  `pip3 install dmgbuild`; a host-copied `.DS_Store` template; `uv add ds-store`
+  into the default group.
 
 ## 6. Tests Required
 
 - `tests/releaseWorkflow.test.ts`: script path, coordinates, `setup-uv`,
   `uv sync --locked --group dmg-layout`, Applications symlink, background and
-  `.DS_Store` attach checks, no `osascript` / `skip-jenkins` / `dmgbuild` / ZIP.
+  `.DS_Store` attach checks, no `osascript` / `skip-jenkins` / `dmgbuild` /
+  `bless` / ZIP.
 - `tests/hdiutilRetry.test.ts`: convert destination deletion on busy.
 - `tests/dmgBackground.test.ts`: 1320×800, `pHYs` 5669, byte-stable PNG, empty
   wells, `--check` matches the checked-in file.

--- a/scripts/release/create-macos-dmg.sh
+++ b/scripts/release/create-macos-dmg.sh
@@ -132,7 +132,6 @@ uv run --locked --group dmg-layout python "$LAYOUT_WRITER" \
   --apps-xy 480,188
 
 [ -f "$mount_point/.DS_Store" ]
-bless --folder "$mount_point" --openfolder "$mount_point"
 sync
 detach_mount
 

--- a/scripts/tasks/supported-platform-structure-assets.json
+++ b/scripts/tasks/supported-platform-structure-assets.json
@@ -319,7 +319,7 @@
     ],
     [
       "tests/releaseWorkflow.test.ts",
-      "4ae184691a20a1bda6427e766fdc7a8ae2e1d5def9578a7b49b983d177e916d3"
+      "e35721b250f218dbe867c50190d13f163c9b723980cb0a080f28560dcf8cfa67"
     ],
     [
       "tests/remainingPlatformSurface.test.ts",

--- a/tests/releaseWorkflow.test.ts
+++ b/tests/releaseWorkflow.test.ts
@@ -2082,6 +2082,7 @@ jobs:
       'convert "$udrw_path" -format UDZO -imagekey zlib-level=9 -ov -o "$output_path"',
     );
     expect(createDmg).not.toContain("osascript");
+    expect(createDmg).not.toContain("bless");
     expect(createDmg).not.toContain("skip-jenkins");
     expect(createDmg).not.toContain("dmgbuild");
     expect(createDmg).not.toContain("hdiutil detach -force");


### PR DESCRIPTION
## Summary
- Remove `bless --openfolder` from `create-macos-dmg.sh`. GitHub-hosted `macos-15` is Apple Silicon and exits with `The 'openfolder' is not supported on Apple Silicon devices.`, which aborted the 0.4.2 Release after `.DS_Store` was already written.
- Finder still uses `bwsp` / `icvp` / `Iloc` from the mounted-volume `.DS_Store`.
- Regression test: the packager must not call `bless`. Spec updated to forbid that flag.

## Test plan
- [x] `mise run test:unit -- tests/releaseWorkflow.test.ts tests/developmentEnvironment.test.ts`
- [ ] `CI / Required` on this PR
- [ ] After merge, retag unpublished `v0.4.2` and confirm the Release workflow produces the seven artifacts


Made with [Cursor](https://cursor.com)