### PR TITLE
Feature the Models screenshot in the README preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,18 +37,18 @@ WorkBuddy 另有独立的顶层配置入口；它不属于上述目标工具或 
 <table>
   <tr>
     <td align="center" width="50%">
-      <img src="assets/screenshots/main-zh-1.png" alt="FyAgent 模型页：在 WorkBuddy 中管理第三方模型">
-      <br><em>模型</em>
-    </td>
-    <td align="center" width="50%">
       <img src="assets/screenshots/main-zh-2.png" alt="FyAgent Skill 市场">
       <br><em>Skills</em>
+    </td>
+    <td align="center" width="50%">
+      <img src="assets/screenshots/main-zh-3.png" alt="FyAgent MCP 发现页">
+      <br><em>MCP</em>
     </td>
   </tr>
   <tr>
     <td align="center" colspan="2">
-      <img src="assets/screenshots/main-zh-3.png" alt="FyAgent MCP 发现页">
-      <br><em>MCP</em>
+      <img src="assets/screenshots/main-zh-1.png" alt="FyAgent 模型页：在 WorkBuddy 中管理第三方模型">
+      <br><em>模型</em>
     </td>
   </tr>
 </table>

--- a/README_EN.md
+++ b/README_EN.md
@@ -37,18 +37,18 @@ The current desktop UI, captured in Simplified Chinese. The top bar switches amo
 <table>
   <tr>
     <td align="center" width="50%">
-      <img src="assets/screenshots/main-zh-1.png" alt="FyAgent Models page: manage third-party models for WorkBuddy">
-      <br><em>Models</em>
-    </td>
-    <td align="center" width="50%">
       <img src="assets/screenshots/main-zh-2.png" alt="FyAgent Skill marketplace">
       <br><em>Skills</em>
+    </td>
+    <td align="center" width="50%">
+      <img src="assets/screenshots/main-zh-3.png" alt="FyAgent MCP discovery page">
+      <br><em>MCP</em>
     </td>
   </tr>
   <tr>
     <td align="center" colspan="2">
-      <img src="assets/screenshots/main-zh-3.png" alt="FyAgent MCP discovery page">
-      <br><em>MCP</em>
+      <img src="assets/screenshots/main-zh-1.png" alt="FyAgent Models page: manage third-party models for WorkBuddy">
+      <br><em>Models</em>
     </td>
   </tr>
 </table>

--- a/README_JA.md
+++ b/README_JA.md
@@ -37,18 +37,18 @@ WorkBuddy には独立したトップレベルの設定入口があります。�
 <table>
   <tr>
     <td align="center" width="50%">
-      <img src="assets/screenshots/main-zh-1.png" alt="FyAgent のモデル画面：WorkBuddy のサードパーティモデルを管理">
-      <br><em>モデル</em>
-    </td>
-    <td align="center" width="50%">
       <img src="assets/screenshots/main-zh-2.png" alt="FyAgent の Skill マーケット">
       <br><em>Skills</em>
+    </td>
+    <td align="center" width="50%">
+      <img src="assets/screenshots/main-zh-3.png" alt="FyAgent の MCP 発見画面">
+      <br><em>MCP</em>
     </td>
   </tr>
   <tr>
     <td align="center" colspan="2">
-      <img src="assets/screenshots/main-zh-3.png" alt="FyAgent の MCP 発見画面">
-      <br><em>MCP</em>
+      <img src="assets/screenshots/main-zh-1.png" alt="FyAgent のモデル画面：WorkBuddy のサードパーティモデルを管理">
+      <br><em>モデル</em>
     </td>
   </tr>
 </table>


### PR DESCRIPTION
## Summary
- Reorder the three-language README preview from Models | Skills + large MCP to Skills | MCP + large Models.
- Image files are unchanged; only table order and the full-width slot move.

## Test plan
- [x] `node scripts/tasks/docs-contract-check.mjs`
- [ ] Confirm GitHub README preview: first row Skills then MCP, second row Models full width
- [ ] `CI / Required` on this PR


Made with [Cursor](https://cursor.com)