### PR TITLE
Fit the macOS DMG window to the V2 background

### DIFF
--- a/.trellis/spec/backend/macos-dmg-layout.md
+++ b/.trellis/spec/backend/macos-dmg-layout.md
@@ -49,7 +49,14 @@ background file .background/background.png
 - `write-dmg-layout.py` uses `mac_alias.Alias.for_file` on the **mounted**
   background and `ds_store` for `bwsp` / `icvp` / `Iloc`. It must not call
   `hdiutil`, `osascript`, or Finder. Staging-directory aliases bind the runner
-  disk CNID and are invalid.
+  disk CNID and are invalid. `bwsp.WindowBounds` is an AppKit frame
+  `{{x, y}, {width, height}}` (660×400), not opposite-corner coordinates.
+  Do not write `vSrn`; that record means “opened in a new tab” and makes
+  Finder inherit another window’s size and chrome.
+- After writing `.DS_Store`, `create-macos-dmg.sh` deletes `.fseventsd`,
+  `.Trashes`, and `.Spotlight-V100` from the writable UDRW, `chflags hidden`
+  on `.background`, and parks those names at `Iloc` (10000, 10000) so they
+  stay outside the 660×400 window even if Finder shows hidden files.
 - AppleScript, `osascript`, `dmgbuild` CLI, `appdmg`, `pip3`, Homebrew
   `create-dmg`, `--skip-jenkins`, and `bless --openfolder` are forbidden.
   GitHub-hosted `macos-15` is Apple Silicon; `bless --openfolder` exits
@@ -73,6 +80,8 @@ background file .background/background.png
 | Condition | Required result |
 | --- | --- |
 | Missing FyAgent.app, background PNG, or Applications symlink | Fail before `hdiutil create` |
+| Opposite-corner `WindowBounds` or `vSrn = 1` | Oversized window, white gutter, or a Finder tab; write AppKit origin+size and omit `vSrn` |
+| `.fseventsd` visible in the Finder window | Delete it from the UDRW before convert; park leftover junk at `Iloc` (10000, 10000) |
 | `bless --openfolder` on Apple Silicon | Fail `build-macos`; do not call `bless` |
 | Layout writer not on Darwin, mount item missing, or alias failure | Non-zero; no osascript fallback |
 | `hdiutil create`/`convert` reports `Resource busy` / temporarily unavailable | Retry same argv, at most 5 attempts, 2/4/8/16s |
@@ -85,18 +94,21 @@ background file .background/background.png
 ## 5. Good / Base / Bad Cases
 
 - Good: mounted-volume `.DS_Store` with picture `icvp` and left/right `Iloc`;
-  double-click shows app on the left and Applications on the right.
+  double-click opens a 660×400 window, app on the left and Applications on the
+  right, with no `.fseventsd` icon in the content area.
 - Base: one `Resource busy` during convert, then UDZO verifies.
 - Bad: `create-dmg --skip-jenkins`; AppleScript `.DS_Store`; `bless --openfolder`;
-  `pip3 install dmgbuild`; a host-copied `.DS_Store` template; `uv add ds-store`
-  into the default group.
+  `WindowBounds` as opposite-corner `{860, 520}`; `vSrn = 1`; leaving
+  `.fseventsd` in the visible icon layout; `pip3 install dmgbuild`; a
+  host-copied `.DS_Store` template; `uv add ds-store` into the default group.
 
 ## 6. Tests Required
 
 - `tests/releaseWorkflow.test.ts`: script path, coordinates, `setup-uv`,
   `uv sync --locked --group dmg-layout`, Applications symlink, background and
-  `.DS_Store` attach checks, no `osascript` / `skip-jenkins` / `dmgbuild` /
-  `bless` / ZIP.
+  `.DS_Store` attach checks, AppKit `WindowBounds` origin+size, no `vSrn`,
+  `.fseventsd` removal / hidden `Iloc`, no `osascript` / `skip-jenkins` /
+  `dmgbuild` / `bless` / ZIP.
 - `tests/hdiutilRetry.test.ts`: convert destination deletion on busy.
 - `tests/dmgBackground.test.ts`: 1320×800, `pHYs` 5669, byte-stable PNG, empty
   wells, `--check` matches the checked-in file.

--- a/scripts/release/create-macos-dmg.sh
+++ b/scripts/release/create-macos-dmg.sh
@@ -132,6 +132,16 @@ uv run --locked --group dmg-layout python "$LAYOUT_WRITER" \
   --apps-xy 480,188
 
 [ -f "$mount_point/.DS_Store" ]
+rm -rf \
+  "$mount_point/.fseventsd" \
+  "$mount_point/.Trashes" \
+  "$mount_point/.Spotlight-V100"
+if [ -e "$mount_point/.background" ]; then
+  chflags hidden "$mount_point/.background"
+fi
+if [ -e "$mount_point/.fseventsd" ]; then
+  chflags hidden "$mount_point/.fseventsd"
+fi
 sync
 detach_mount
 

--- a/scripts/release/write-dmg-layout.py
+++ b/scripts/release/write-dmg-layout.py
@@ -16,6 +16,7 @@ DEFAULT_ICON_SIZE = 128
 DEFAULT_APP_XY = (180, 188)
 DEFAULT_APPLICATIONS_XY = (480, 188)
 HIDDEN_ILOC = (10000, 10000)
+JUNK_NAMES = (".background", ".fseventsd", ".Trashes", ".Spotlight-V100")
 
 
 def parse_pair(raw: str, label: str) -> tuple[int, int]:
@@ -70,11 +71,10 @@ def write_layout(
     background = require_mount_item(mount, background_relative, "file")
     alias = Alias.for_file(os.fspath(background))
     left, top = WINDOW_ORIGIN
-    right = left + window[0]
-    bottom = top + window[1]
     ds_store_path = mount / ".DS_Store"
+    visible = {app_name, applications_name}
     with DSStore.open(os.fspath(ds_store_path), "w+") as store:
-        store["."]["vSrn"] = ("long", 1)
+        store["."]["vstl"] = ("type", "icnv")
         store["."]["bwsp"] = {
             "ShowTabView": False,
             "ShowToolbar": False,
@@ -82,7 +82,11 @@ def write_layout(
             "ShowPathbar": False,
             "ShowStatusBar": False,
             "SidebarWidth": 0,
-            "WindowBounds": "{{%d, %d}, {%d, %d}}" % (left, top, right, bottom),
+            "ContainerShowSidebar": False,
+            "PreviewPaneVisibility": False,
+            # AppKit frame is {{x, y}, {width, height}}, not opposite-corner.
+            "WindowBounds": "{{%d, %d}, {%d, %d}}"
+            % (left, top, window[0], window[1]),
         }
         store["."]["icvp"] = {
             "viewOptionsVersion": 1,
@@ -105,7 +109,12 @@ def write_layout(
         }
         store[app_name]["Iloc"] = app_xy
         store[applications_name]["Iloc"] = applications_xy
-        store[".background"]["Iloc"] = HIDDEN_ILOC
+        for name in JUNK_NAMES:
+            store[name]["Iloc"] = HIDDEN_ILOC
+        for entry in mount.iterdir():
+            if entry.name in visible or entry.name == ".DS_Store":
+                continue
+            store[entry.name]["Iloc"] = HIDDEN_ILOC
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/scripts/tasks/supported-platform-structure-assets.json
+++ b/scripts/tasks/supported-platform-structure-assets.json
@@ -319,7 +319,7 @@
     ],
     [
       "tests/releaseWorkflow.test.ts",
-      "e35721b250f218dbe867c50190d13f163c9b723980cb0a080f28560dcf8cfa67"
+      "0c3e2a01197491d3aa88f5d6efb877e0b583481a057c2b7a91dfd46c9f9855b1"
     ],
     [
       "tests/remainingPlatformSurface.test.ts",

--- a/tests/releaseWorkflow.test.ts
+++ b/tests/releaseWorkflow.test.ts
@@ -2088,7 +2088,17 @@ jobs:
     expect(createDmg).not.toContain("hdiutil detach -force");
     expect(dmgLayout).toContain('store[app_name]["Iloc"] = app_xy');
     expect(dmgLayout).toContain('store[applications_name]["Iloc"] = applications_xy');
-    expect(dmgLayout).toContain('backgroundImageAlias');
+    expect(dmgLayout).toContain("backgroundImageAlias");
+    expect(dmgLayout).toContain(
+      '"{{%d, %d}, {%d, %d}}"\n            % (left, top, window[0], window[1])',
+    );
+    expect(dmgLayout).not.toContain("right = left + window[0]");
+    expect(dmgLayout).not.toContain('["vSrn"]');
+    expect(dmgLayout).toContain("ContainerShowSidebar");
+    expect(dmgLayout).toContain('".fseventsd"');
+    expect(dmgLayout).toContain("HIDDEN_ILOC");
+    expect(createDmg).toContain("$mount_point/.fseventsd");
+    expect(createDmg).toContain("chflags hidden");
     expect(dmgLayout).not.toContain("osascript");
     expect(dmgLayout).not.toContain("hdiutil");
     expect(dmgBackground).toContain("DMG_WINDOW_WIDTH_PT = 660");


### PR DESCRIPTION
## Summary
- Finder `WindowBounds` is an AppKit frame `{{x, y}, {width, height}}`. The layout writer had been storing the opposite corner, so the published window was 860×520 instead of 660×400 and left a white gutter.
- Drop `vSrn` (that record means “opened in a new tab”).
- Delete `.fseventsd` / `.Trashes` / `.Spotlight-V100` from the writable UDRW, hide `.background`, and park leftover junk at `Iloc (10000, 10000)`.

## Test plan
- [x] `mise run test:unit -- tests/releaseWorkflow.test.ts tests/developmentEnvironment.test.ts`
- [x] Local dummy DMG: `WindowBounds {{200, 120}, {660, 400}}`; volume listing has no `.fseventsd`
- [ ] `CI / Required`
- [ ] After the next signed DMG: no white gutter, no `.fseventsd` icon in the 660×400 window


Made with [Cursor](https://cursor.com)