### PR TITLE
ci: add fast-fail commit convention gate for all branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
   push:
-    branches: [main, dev/laiyongjie]
   merge_group:
     types: [checks_requested]
   workflow_dispatch:
@@ -17,8 +15,85 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 jobs:
+  commit-convention:
+    name: Commit Convention
+    runs-on: macos-15
+    timeout-minutes: 5
+    steps:
+      - name: Checkout complete comparison history
+        id: checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node.js
+        id: setup-node
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .node-version
+
+      - name: Verify commit messages
+        id: verify
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MERGE_GROUP_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
+          PUSH_BASE_SHA: ${{ github.event.before }}
+          PUSH_HEAD_SHA: ${{ github.sha }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          case "$EVENT_NAME" in
+            pull_request)
+              base_sha="$PR_BASE_SHA"
+              head_sha="$PR_HEAD_SHA"
+              ;;
+            merge_group)
+              base_sha="$MERGE_GROUP_BASE_SHA"
+              head_sha="$MERGE_GROUP_HEAD_SHA"
+              ;;
+            push|workflow_dispatch)
+              base_sha="$PUSH_BASE_SHA"
+              head_sha="$PUSH_HEAD_SHA"
+              ;;
+            *)
+              echo "Unsupported CI event: $EVENT_NAME" >&2
+              exit 1
+              ;;
+          esac
+          if [[ "$base_sha" =~ ^0{40}$ ]]; then
+            base_sha="$head_sha"
+          fi
+          if [ "$EVENT_NAME" = push ] &&
+            ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null; then
+            echo "Push before SHA is not a commit in this clone; using head as an empty comparison" >&2
+            base_sha="$head_sha"
+          fi
+          args=(
+            --base "$base_sha"
+            --head "$head_sha"
+          )
+          if [ "$EVENT_NAME" = pull_request ] && [ -n "${PR_TITLE:-}" ]; then
+            args+=(--pr-title "$PR_TITLE")
+          fi
+          node scripts/ci/verify-commit-messages.mjs "${args[@]}"
+
+      - name: Evaluate collected diagnostics
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
+        env:
+          CI_REQUIRED_STEPS: setup-node,verify
+          CI_STEP_RESULTS: ${{ toJSON(steps) }}
+        run: node scripts/ci/evaluate-step-outcomes.mjs
+
   changes:
     name: Classify Changes
+    needs: commit-convention
     runs-on: macos-15
     outputs:
       plan: ${{ steps.plan.outputs.plan }}
@@ -700,6 +775,7 @@ jobs:
     name: CI / Required
     if: always()
     needs:
+      - commit-convention
       - changes
       - contracts
       - frontend

--- a/.trellis/spec/backend/github-ci-workflow.md
+++ b/.trellis/spec/backend/github-ci-workflow.md
@@ -159,6 +159,9 @@ changes
 only, validates every commit subject in the explicit base/head comparison, and
 validates the pull request title on `pull_request` events. When it fails, every
 downstream job is skipped so the workflow stops before expensive domain work.
+Empty-comparison coverage must use an isolated git fixture, not the Actions
+checkout HEAD: `pull_request` checkouts are merge commits whose subject is
+`Merge <sha> into <sha>`, while this job compares `PR_BASE_SHA`..`PR_HEAD_SHA`.
 
 The requested job mapping is exact:
 
@@ -436,6 +439,7 @@ never src-tauri/target, never RUSTC_WRAPPER / sccache
 ## Scenario: Push before SHA missing after history rewrite
 
 ### 1. Scope / Trigger
+
 - Trigger: CI classification is an infra contract. Force-updating
   `dev/laiyongjie` onto a squash `main` SHA sets `github.event.before` to a
   commit that `actions/checkout` `fetch-depth: 0` does not clone once no ref
@@ -444,10 +448,12 @@ never src-tauri/target, never RUSTC_WRAPPER / sccache
   `scripts/ci/classify-changes.mjs`.
 
 ### 2. Signatures
+
 - Workflow resolves `base_sha` / `head_sha`, then
   `node scripts/ci/classify-changes.mjs --base <sha> --head <sha> --json`
 
 ### 3. Contracts
+
 - `push` event `before` that is forty zeroes -> `base_sha = head_sha`.
 - `push` event `before` that is not `${base_sha}^{commit}` in the clone ->
   `base_sha = head_sha` (empty comparison). Event policy still sets every
@@ -456,6 +462,7 @@ never src-tauri/target, never RUSTC_WRAPPER / sccache
   classifier still fail-closes.
 
 ### 4. Validation & Error Matrix
+
 - Forty-zero or unreachable push `before` -> empty comparison, full push CI.
 - Missing PR/merge-group SHA -> classifier job failure -> failed
   `CI / Required`.
@@ -463,6 +470,7 @@ never src-tauri/target, never RUSTC_WRAPPER / sccache
   event forcing does not convert that error to success.
 
 ### 5. Good / Base / Bad Cases
+
 - Good: ordinary push; `before` is an ancestor still fetched by complete
   history; classifier runs, then event policy forces every domain.
 - Base: force-update drops the previous tip; workflow logs that `before` is
@@ -471,17 +479,22 @@ never src-tauri/target, never RUSTC_WRAPPER / sccache
   `Classify Changes` while domain jobs already ran as fail-closed full CI.
 
 ### 6. Tests Required
+
 - `tests/ciWorkflow.test.ts` asserts the push-only `git cat-file -e` fallback
   and the empty-comparison diagnostic string.
 - Local tests do not clone GitHub's unreachable `before` objects.
 
 ### 7. Wrong vs Correct
+
 #### Wrong
+
 ```bash
 node scripts/ci/classify-changes.mjs --base "$PUSH_BASE_SHA" --head "$head_sha" --json
 # git cat-file: before SHA does not identify a commit object
 ```
+
 #### Correct
+
 ```bash
 if [ "$EVENT_NAME" = push ] &&
   ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null; then

--- a/.trellis/spec/backend/github-ci-workflow.md
+++ b/.trellis/spec/backend/github-ci-workflow.md
@@ -3,9 +3,10 @@
 ## 1. Scope and stable public result
 
 This contract owns `.github/workflows/ci.yml`,
-`scripts/ci/classify-changes.mjs`, `scripts/ci/required-gate.mjs`, and their
-fixture suites. It applies to pull requests, merge queue candidates, pushes to
-`main` and `dev/laiyongjie`, and manual diagnostics.
+`scripts/ci/classify-changes.mjs`, `scripts/ci/required-gate.mjs`,
+`scripts/ci/verify-commit-messages.mjs`, and their fixture suites. It applies to
+pull requests, merge queue candidates, pushes on every branch, and manual
+diagnostics.
 
 This workflow owns scheduling and aggregation, not the underlying product
 behavior. Windows installer/runtime review guidance is recorded in
@@ -27,17 +28,16 @@ The workflow triggers are:
 
 ```yaml
 pull_request:
-  branches: [main]
 push:
-  branches: [main, dev/laiyongjie]
 merge_group:
   types: [checks_requested]
 workflow_dispatch:
 ```
 
-- every `main` push remains a full CI run for that SHA; it is not a formal
-  Release eligibility gate;
-- every `dev/laiyongjie` push is a full CI run for that SHA; preflight still
+- every branch push remains subject to commit-convention and event policy;
+- every `main` push remains a full CI run for that SHA when event policy forces
+  full domains; it is not a formal Release eligibility gate;
+- every `dev/laiyongjie` push remains a full CI run for that SHA; preflight still
   binds the live remote `dev/laiyongjie` HEAD;
 - PR and `merge_group` runs execute only affected domains;
 - `workflow_dispatch` is a full diagnostic run and is never release evidence
@@ -142,6 +142,8 @@ must not pass an unresolvable push `before` SHA into the classifier.
 ## 4. Domain-to-job topology
 
 ```text
+commit-convention
+  ↓
 changes
   ├─ contracts
   ├─ frontend
@@ -152,6 +154,11 @@ changes
          ↓
     CI / Required
 ```
+
+`commit-convention` is the fast-fail gate. It runs with checkout plus Node.js
+only, validates every commit subject in the explicit base/head comparison, and
+validates the pull request title on `pull_request` events. When it fails, every
+downstream job is skipped so the workflow stops before expensive domain work.
 
 The requested job mapping is exact:
 
@@ -165,22 +172,25 @@ The requested job mapping is exact:
 | `backend-macos`               | `backend`                    |
 
 Every domain job needs `changes` and may run only after classifier success.
-Docs/spec-only changes therefore execute the repository contracts gate but do
-not start frontend, Rust, macOS, or Windows-heavy jobs. The contracts job runs
-the task, docs, Python lock, version, and release contract suite; it does not
-require Trellis task state, overlay reconciliation, or hook execution.
+`changes` needs `commit-convention` and may run only after commit validation
+success. Docs/spec-only changes therefore execute the repository contracts gate
+but do not start frontend, Rust, macOS, or Windows-heavy jobs. The contracts
+job runs the task, docs, Python lock, version, and release contract suite; it
+does not require Trellis task state, overlay reconciliation, or hook execution.
 
 ## 5. Required aggregation and timeout evidence
 
 `scripts/ci/required-gate.mjs` is the pure evaluator for the stable aggregate.
 It receives:
 
-1. exact `toJSON(needs)` results for `changes` plus the six domain job IDs;
+1. exact `toJSON(needs)` results for `commit-convention`, `changes`, plus the
+   six domain job IDs;
 2. the exact classifier/event plan emitted by `changes`;
 3. the current workflow run-attempt Jobs REST response.
 
 The evaluator requires exact keys and booleans. Its result rules are:
 
+- `commit-convention` must be successful;
 - `changes` must be successful;
 - a requested job must be successful;
 - a non-requested job must be skipped;

--- a/scripts/ci/classify-changes.mjs
+++ b/scripts/ci/classify-changes.mjs
@@ -56,7 +56,7 @@ const CONTROL_PLANE_FILES = new Set([
 ]);
 
 const RELEASE_AND_CI_CONTRACT_TEST =
-  /^tests\/(?:ci|classifyChanges|githubWorkflow|localBuildBoundary|miseTaskContract|requiredCiGate|release|systemCheck|taskDocs|version|windowsSigningAdapter|writePlatformMetadata|downloadManifest)/u;
+  /^tests\/(?:ci|classifyChanges|githubWorkflow|localBuildBoundary|miseTaskContract|requiredCiGate|release|systemCheck|taskDocs|verifyCommitMessages|version|windowsSigningAdapter|writePlatformMetadata|downloadManifest)/u;
 
 const WINDOWS_NATIVE_TEST =
   /^tests\/(?:codexDesktopDtoContract|codexUserHelperContract|codexWindowsUserScopeContract|desktopSecurityBoundary|windowsNsisContract|fixtures\/windows-nsis)/u;

--- a/scripts/ci/required-gate.mjs
+++ b/scripts/ci/required-gate.mjs
@@ -22,6 +22,7 @@ export const REQUIRED_CI_JOBS = Object.freeze([
 ]);
 
 export const REQUIRED_CI_DEPENDENCIES = Object.freeze([
+  "commit-convention",
   "changes",
   ...REQUIRED_CI_JOBS,
 ]);
@@ -45,6 +46,7 @@ const KNOWN_JOB_CONCLUSIONS = new Set([
 ]);
 
 const DISPLAY_NAME_MATCHERS = Object.freeze({
+  "commit-convention": (name) => name === "Commit Convention",
   changes: (name) => name === "Classify Changes",
   contracts: (name) => name === "Repository Contracts",
   frontend: (name) => name === "Frontend Checks",
@@ -254,6 +256,19 @@ export function evaluateRequiredCiResults(
   const attemptConclusions = normalizeAttemptJobs(attemptJobsValue, errors);
   for (const job of REQUIRED_CI_DEPENDENCIES) {
     conclusions[job] = aggregateConclusions(attemptConclusions[job] ?? []);
+  }
+
+  if (results["commit-convention"] && results["commit-convention"] !== "success") {
+    const observed =
+      conclusions["commit-convention"] ?? results["commit-convention"];
+    errors.push(`commit convention finished with ${observed}`);
+  } else if (
+    results["commit-convention"] === "success" &&
+    conclusions["commit-convention"] === null
+  ) {
+    errors.push(
+      "commit convention is missing from current run-attempt jobs",
+    );
   }
 
   if (results.changes && results.changes !== "success") {

--- a/scripts/ci/verify-commit-messages.mjs
+++ b/scripts/ci/verify-commit-messages.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+export const CONVENTIONAL_COMMIT_TYPES = Object.freeze([
+  "feat",
+  "fix",
+  "docs",
+  "style",
+  "refactor",
+  "test",
+  "ci",
+  "chore",
+]);
+
+export const CONVENTIONAL_SUBJECT_PATTERN =
+  /^(feat|fix|docs|style|refactor|test|ci|chore)(\([a-z0-9./-]+\))?: .+$/u;
+
+export const MERGE_COMMIT_SUBJECT_PATTERNS = Object.freeze([
+  /^Merge pull request #\d+ from /u,
+  /^Merge branch /u,
+  /^Merge remote-tracking branch /u,
+]);
+
+export const REVERT_COMMIT_SUBJECT_PATTERN = /^Revert "/u;
+
+export const GITHUB_SQUASH_PR_SUFFIX_PATTERN = /\s\(#\d+\)$/u;
+
+const SUBJECT_MAX_LENGTH = 72;
+
+function git(args) {
+  const result = spawnSync("git", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status !== 0) {
+    const detail = (result.stderr || result.stdout || "").trim();
+    throw new Error(
+      detail ? `git ${args.join(" ")} failed: ${detail}` : `git ${args.join(" ")} failed`,
+    );
+  }
+  return result.stdout;
+}
+
+function assertCommitSha(value, label) {
+  if (typeof value !== "string" || !/^[0-9a-f]{40}$/u.test(value)) {
+    throw new Error(`${label} must be a full 40-character commit SHA`);
+  }
+  git(["cat-file", "-e", `${value}^{commit}`]);
+  return value;
+}
+
+export function stripGithubSquashSuffix(subject) {
+  return subject.replace(GITHUB_SQUASH_PR_SUFFIX_PATTERN, "");
+}
+
+export function isMergeCommitSubject(subject) {
+  return MERGE_COMMIT_SUBJECT_PATTERNS.some((pattern) => pattern.test(subject));
+}
+
+export function isRevertCommitSubject(subject) {
+  return REVERT_COMMIT_SUBJECT_PATTERN.test(subject);
+}
+
+export function isConventionalCommitSubject(subject) {
+  const trimmed = subject.trim();
+  if (trimmed.length === 0 || trimmed.length > SUBJECT_MAX_LENGTH) {
+    return false;
+  }
+  if (isMergeCommitSubject(trimmed) || isRevertCommitSubject(trimmed)) {
+    return true;
+  }
+  const normalized = stripGithubSquashSuffix(trimmed);
+  if (normalized.length === 0 || normalized.length > SUBJECT_MAX_LENGTH) {
+    return false;
+  }
+  return CONVENTIONAL_SUBJECT_PATTERN.test(normalized);
+}
+
+export function validateCommitSubject(subject) {
+  const trimmed = subject.trim();
+  if (trimmed.length === 0) {
+    return "commit subject must not be empty";
+  }
+  if (trimmed.length > SUBJECT_MAX_LENGTH) {
+    return `commit subject exceeds ${SUBJECT_MAX_LENGTH} characters`;
+  }
+  if (isMergeCommitSubject(trimmed) || isRevertCommitSubject(trimmed)) {
+    return null;
+  }
+  const normalized = stripGithubSquashSuffix(trimmed);
+  if (normalized.length === 0) {
+    return "commit subject must not be empty after removing GitHub PR suffix";
+  }
+  if (normalized.length > SUBJECT_MAX_LENGTH) {
+    return `commit subject exceeds ${SUBJECT_MAX_LENGTH} characters after removing GitHub PR suffix`;
+  }
+  if (!CONVENTIONAL_SUBJECT_PATTERN.test(normalized)) {
+    return [
+      "commit subject must follow Conventional Commits:",
+      "  type(scope): description",
+      `  allowed types: ${CONVENTIONAL_COMMIT_TYPES.join(", ")}`,
+      "  examples: fix(ci): align contracts, chore(deps): update dependencies",
+    ].join("\n");
+  }
+  return null;
+}
+
+export function listCommitSubjectsInRange(baseSha, headSha) {
+  assertCommitSha(baseSha, "base");
+  assertCommitSha(headSha, "head");
+  if (baseSha === headSha) {
+    return [{ sha: headSha, subject: git(["show", "-s", "--format=%s", headSha]).trim() }];
+  }
+  const output = git([
+    "log",
+    "--format=%H%x09%s",
+    `${baseSha}..${headSha}`,
+  ]).trim();
+  if (output.length === 0) {
+    return [];
+  }
+  return output.split("\n").map((line) => {
+    const separator = line.indexOf("\t");
+    if (separator <= 0) {
+      throw new Error(`malformed git log output: ${line}`);
+    }
+    return {
+      sha: line.slice(0, separator),
+      subject: line.slice(separator + 1),
+    };
+  });
+}
+
+export function verifyCommitMessages({
+  baseSha,
+  headSha,
+  prTitle = null,
+}) {
+  const errors = [];
+  const commits = listCommitSubjectsInRange(baseSha, headSha);
+  for (const commit of commits) {
+    const violation = validateCommitSubject(commit.subject);
+    if (violation) {
+      errors.push(`${commit.sha.slice(0, 12)} ${commit.subject}\n  ${violation}`);
+    }
+  }
+  if (typeof prTitle === "string" && prTitle.trim().length > 0) {
+    const violation = validateCommitSubject(prTitle);
+    if (violation) {
+      errors.push(`pull request title ${JSON.stringify(prTitle)}\n  ${violation}`);
+    }
+  }
+  return {
+    ok: errors.length === 0,
+    commitCount: commits.length,
+    errors,
+  };
+}
+
+function argumentValue(argv, name) {
+  const index = argv.indexOf(name);
+  if (index === -1) return null;
+  const value = argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${name} requires a value`);
+  }
+  return value;
+}
+
+export function runVerifyCommitMessagesCli(argv = process.argv.slice(2)) {
+  try {
+    const baseSha = argumentValue(argv, "--base");
+    const headSha = argumentValue(argv, "--head");
+    if (!baseSha || !headSha) {
+      throw new Error("--base and --head are required");
+    }
+    const prTitle = argumentValue(argv, "--pr-title");
+    const report = verifyCommitMessages({ baseSha, headSha, prTitle });
+    console.log(JSON.stringify(report, null, 2));
+    if (!report.ok) {
+      for (const error of report.errors) {
+        console.error(`Commit convention failed:\n${error}`);
+      }
+      process.exitCode = 1;
+    }
+    return report;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+    return {
+      ok: false,
+      commitCount: 0,
+      errors: [error instanceof Error ? error.message : String(error)],
+    };
+  }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  runVerifyCommitMessagesCli();
+}

--- a/tests/ciWorkflow.test.ts
+++ b/tests/ciWorkflow.test.ts
@@ -16,7 +16,7 @@ const REQUIRED_JOBS = [
   "backend-macos",
 ] as const;
 
-const DEPENDENCY_JOBS = ["changes", ...REQUIRED_JOBS] as const;
+const DEPENDENCY_JOBS = ["commit-convention", "changes", ...REQUIRED_JOBS] as const;
 
 const LOCAL_MISE_TESTS = [
   "tests/developmentEnvironment.test.ts",
@@ -86,9 +86,25 @@ describe("automatic CI workflow", () => {
     const jobIds = [...jobsSection.matchAll(/^  ([a-z][a-z0-9-]*):\s*$/gm)].map(
       (match) => match[1],
     );
-    expect(jobIds).toEqual(["changes", ...REQUIRED_JOBS, "required"]);
+    expect(jobIds).toEqual([
+      "commit-convention",
+      "changes",
+      ...REQUIRED_JOBS,
+      "required",
+    ]);
+
+    const commitConvention = jobBlock("commit-convention");
+    expect(commitConvention).toContain("name: Commit Convention");
+    expect(commitConvention).toContain("timeout-minutes: 5");
+    expect(commitConvention).toContain("fetch-depth: 0");
+    expect(commitConvention).toContain(
+      "node scripts/ci/verify-commit-messages.mjs",
+    );
+    expect(commitConvention).toContain("PR_TITLE:");
+    expect(commitConvention).not.toContain("pnpm install");
 
     const changes = jobBlock("changes");
+    expect(changes).toContain("needs: commit-convention");
     expect(changes).toContain("name: Classify Changes");
     expect(changes).toContain("fetch-depth: 0");
     expect(changes).toContain(
@@ -158,6 +174,7 @@ describe("automatic CI workflow", () => {
       "runs-on: macos-15",
     );
     expect(jobBlock("changes")).toContain("runs-on: macos-15");
+    expect(jobBlock("commit-convention")).toContain("runs-on: macos-15");
     expect(jobBlock("backend-windows")).toContain("runs-on: windows-2025");
     expect(jobBlock("windows-native-contracts")).toContain(
       "runs-on: ${{ matrix.runner }}",
@@ -190,7 +207,7 @@ describe("automatic CI workflow", () => {
     }
 
     const checkoutSteps = actionSteps("actions/checkout");
-    expect(checkoutSteps).toHaveLength(8);
+    expect(checkoutSteps).toHaveLength(9);
     for (const step of checkoutSteps) {
       expect(step).toContain("persist-credentials: false");
     }
@@ -205,7 +222,7 @@ describe("automatic CI workflow", () => {
     expect(source).not.toContain("3.14.7");
 
     const nodeSteps = actionSteps("actions/setup-node");
-    expect(nodeSteps).toHaveLength(7);
+    expect(nodeSteps).toHaveLength(8);
     for (const step of nodeSteps) {
       expect(step).toContain("node-version-file: .node-version");
       expect(step).not.toMatch(/^\s+node-version:/m);
@@ -369,6 +386,7 @@ describe("automatic CI workflow", () => {
 
   it("collects every CI diagnostic before each job restores its failure", () => {
     const collectedSteps = {
+      "commit-convention": ["Setup Node.js", "Verify commit messages"],
       changes: [
         "Setup Node.js",
         "Classify explicit base and head commits",

--- a/tests/githubWorkflowTriggers.test.ts
+++ b/tests/githubWorkflowTriggers.test.ts
@@ -17,7 +17,7 @@ function readHeaderBefore(source: string, marker: string): string {
 }
 
 describe("GitHub workflow trigger policy", () => {
-  it("keeps one required CI surface for PRs, merge queue, dev/main pushes, and diagnostics", () => {
+  it("keeps one required CI surface for every branch, merge queue, push, and diagnostics", () => {
     const source = readWorkflow("ci.yml");
     const triggerSection = readHeaderBefore(source, "\npermissions:");
 
@@ -27,9 +27,7 @@ describe("GitHub workflow trigger policy", () => {
         "",
         "on:",
         "  pull_request:",
-        "    branches: [main]",
         "  push:",
-        "    branches: [main, dev/laiyongjie]",
         "  merge_group:",
         "    types: [checks_requested]",
         "  workflow_dispatch:",
@@ -49,6 +47,10 @@ describe("GitHub workflow trigger policy", () => {
   it("keeps desktop acceptance in the automatic CI path and mock-only boundary", () => {
     const source = readWorkflow("ci.yml");
 
+    expect(source).toContain("commit-convention:");
+    expect(source).toContain("name: Commit Convention");
+    expect(source).toContain("node scripts/ci/verify-commit-messages.mjs");
+    expect(source).toContain("needs: commit-convention");
     expect(source).toContain("desktop-acceptance-contract:");
     expect(source).toContain(
       "run: node --throw-deprecation ./node_modules/vitest/vitest.mjs run tests/desktop-acceptance",

--- a/tests/requiredCiGate.test.ts
+++ b/tests/requiredCiGate.test.ts
@@ -29,6 +29,7 @@ const evaluateRequiredCiResults =
   };
 
 const DISPLAY_NAMES: Record<string, string[]> = {
+  "commit-convention": ["Commit Convention"],
   changes: ["Classify Changes"],
   contracts: ["Repository Contracts"],
   frontend: ["Frontend Checks"],
@@ -83,7 +84,12 @@ function needs(plan: Plan): Record<string, { result: string }> {
   return Object.fromEntries(
     DEPENDENCY_JOB_IDS.map((job) => [
       job,
-      { result: job === "changes" || requested[job] ? "success" : "skipped" },
+      {
+        result:
+          job === "commit-convention" || job === "changes" || requested[job]
+            ? "success"
+            : "skipped",
+      },
     ]),
   );
 }
@@ -183,6 +189,19 @@ describe("CI / Required gate", () => {
     expect(
       evaluateRequiredCiResults(docsNeeds, docs, docsJobs).errors,
     ).toContain("non-requested job frontend finished with success");
+  });
+
+  it("fails closed when commit convention does not succeed", () => {
+    const plan = fullPlan();
+    const input = needs(plan);
+    input["commit-convention"].result = "failure";
+    const jobs = attemptJobs(plan);
+    setConclusion(jobs, "Commit Convention", "failure");
+    const report = evaluateRequiredCiResults(input, plan, jobs);
+    expect(report.ok).toBe(false);
+    expect(report.errors).toContain(
+      "commit convention finished with failure",
+    );
   });
 
   it("fails closed for unknown paths, malformed force-full plans, and classifier failure", () => {

--- a/tests/verifyCommitMessages.test.ts
+++ b/tests/verifyCommitMessages.test.ts
@@ -1,16 +1,33 @@
 import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 // @ts-expect-error The workflow executes this dependency-free JavaScript helper directly.
 import * as commitMessages from "../scripts/ci/verify-commit-messages.mjs";
 
 const ROOT = path.resolve(__dirname, "..");
+const VERIFY_COMMIT_MESSAGES = path.join(
+  ROOT,
+  "scripts",
+  "ci",
+  "verify-commit-messages.mjs",
+);
+const temporaryRoots: string[] = [];
+
+function git(cwd: string, ...args: string[]): string {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(result.stderr || `git ${args.join(" ")} failed`);
+  }
+  return result.stdout.trim();
+}
+
 const {
   CONVENTIONAL_COMMIT_TYPES,
   isConventionalCommitSubject,
   stripGithubSquashSuffix,
   validateCommitSubject,
-  verifyCommitMessages,
 } = commitMessages;
 
 describe("commit message convention", () => {
@@ -32,15 +49,15 @@ describe("commit message convention", () => {
   it("accepts merge, revert, and GitHub squash suffix subjects", () => {
     expect(
       isConventionalCommitSubject(
-        'Merge pull request #19 from fy-agent/codex/fix-v0.3.4-release',
+        "Merge pull request #19 from fy-agent/codex/fix-v0.3.4-release",
       ),
     ).toBe(true);
-    expect(isConventionalCommitSubject('Revert "fix(ci): align contracts"')).toBe(
+    expect(
+      isConventionalCommitSubject('Revert "fix(ci): align contracts"'),
+    ).toBe(true);
+    expect(isConventionalCommitSubject("fix(ci): align contracts (#120)")).toBe(
       true,
     );
-    expect(
-      isConventionalCommitSubject("fix(ci): align contracts (#120)"),
-    ).toBe(true);
     expect(stripGithubSquashSuffix("fix(ci): align contracts (#120)")).toBe(
       "fix(ci): align contracts",
     );
@@ -52,9 +69,9 @@ describe("commit message convention", () => {
       "Conventional Commits",
     );
     expect(validateCommitSubject("feat: ")).toContain("Conventional Commits");
-    expect(
-      validateCommitSubject(`fix(ci): ${"x".repeat(80)}`),
-    ).toContain("exceeds 72");
+    expect(validateCommitSubject(`fix(ci): ${"x".repeat(80)}`)).toContain(
+      "exceeds 72",
+    );
   });
 
   it("documents the allowed Conventional Commit types", () => {
@@ -82,12 +99,34 @@ describe("commit message convention", () => {
 });
 
 describe("commit message range verification", () => {
-  it("validates the current HEAD subject in an empty comparison", () => {
-    const head = spawnSync("git", ["rev-parse", "HEAD"], {
-      cwd: ROOT,
-      encoding: "utf8",
-    }).stdout.trim();
-    const report = verifyCommitMessages({ baseSha: head, headSha: head });
+  afterAll(() => {
+    for (const root of temporaryRoots) {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("validates a conventional HEAD subject in an empty comparison", () => {
+    const root = fs.mkdtempSync(
+      path.join(os.tmpdir(), "fyagent-commit-messages-"),
+    );
+    temporaryRoots.push(root);
+    git(root, "init", "--quiet");
+    git(root, "config", "user.name", "FyAgent Tests");
+    git(root, "config", "user.email", "tests@fyagent.invalid");
+    fs.writeFileSync(path.join(root, "README"), "fixture\n");
+    git(root, "add", "README");
+    git(root, "commit", "-m", "ci: empty comparison fixture");
+    const head = git(root, "rev-parse", "HEAD");
+    const result = spawnSync(
+      process.execPath,
+      [VERIFY_COMMIT_MESSAGES, "--base", head, "--head", head],
+      { cwd: root, encoding: "utf8" },
+    );
+    expect(result.status).toBe(0);
+    const report = JSON.parse(result.stdout) as {
+      ok: boolean;
+      commitCount: number;
+    };
     expect(report.ok).toBe(true);
     expect(report.commitCount).toBe(1);
   });

--- a/tests/verifyCommitMessages.test.ts
+++ b/tests/verifyCommitMessages.test.ts
@@ -1,0 +1,94 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+// @ts-expect-error The workflow executes this dependency-free JavaScript helper directly.
+import * as commitMessages from "../scripts/ci/verify-commit-messages.mjs";
+
+const ROOT = path.resolve(__dirname, "..");
+const {
+  CONVENTIONAL_COMMIT_TYPES,
+  isConventionalCommitSubject,
+  stripGithubSquashSuffix,
+  validateCommitSubject,
+  verifyCommitMessages,
+} = commitMessages;
+
+describe("commit message convention", () => {
+  it("accepts repository Conventional Commit examples", () => {
+    for (const subject of [
+      "feat(provider): add support for new provider",
+      "fix(tray): resolve menu not updating after switch",
+      "docs(readme): update installation instructions",
+      "ci: add format check workflow",
+      "chore(deps): update dependencies",
+      "chore(task): archive 08-21-v2-model-probe",
+      "style(v2): format model probe frontend files for Prettier",
+    ]) {
+      expect(isConventionalCommitSubject(subject), subject).toBe(true);
+      expect(validateCommitSubject(subject), subject).toBeNull();
+    }
+  });
+
+  it("accepts merge, revert, and GitHub squash suffix subjects", () => {
+    expect(
+      isConventionalCommitSubject(
+        'Merge pull request #19 from fy-agent/codex/fix-v0.3.4-release',
+      ),
+    ).toBe(true);
+    expect(isConventionalCommitSubject('Revert "fix(ci): align contracts"')).toBe(
+      true,
+    );
+    expect(
+      isConventionalCommitSubject("fix(ci): align contracts (#120)"),
+    ).toBe(true);
+    expect(stripGithubSquashSuffix("fix(ci): align contracts (#120)")).toBe(
+      "fix(ci): align contracts",
+    );
+  });
+
+  it("rejects empty, overlong, and non-conventional subjects", () => {
+    expect(validateCommitSubject("")).toContain("must not be empty");
+    expect(validateCommitSubject("Update files")).toContain(
+      "Conventional Commits",
+    );
+    expect(validateCommitSubject("feat: ")).toContain("Conventional Commits");
+    expect(
+      validateCommitSubject(`fix(ci): ${"x".repeat(80)}`),
+    ).toContain("exceeds 72");
+  });
+
+  it("documents the allowed Conventional Commit types", () => {
+    expect(CONVENTIONAL_COMMIT_TYPES).toEqual([
+      "feat",
+      "fix",
+      "docs",
+      "style",
+      "refactor",
+      "test",
+      "ci",
+      "chore",
+    ]);
+  });
+
+  it("fails closed on malformed CLI input", () => {
+    const result = spawnSync(
+      process.execPath,
+      ["scripts/ci/verify-commit-messages.mjs", "--base", "abc"],
+      { cwd: ROOT, encoding: "utf8" },
+    );
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("--head are required");
+  });
+});
+
+describe("commit message range verification", () => {
+  it("validates the current HEAD subject in an empty comparison", () => {
+    const head = spawnSync("git", ["rev-parse", "HEAD"], {
+      cwd: ROOT,
+      encoding: "utf8",
+    }).stdout.trim();
+    const report = verifyCommitMessages({ baseSha: head, headSha: head });
+    expect(report.ok).toBe(true);
+    expect(report.commitCount).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a lightweight `Commit Convention` CI job that validates Conventional Commits before change classification.
- Expand CI triggers to all branches and PRs so every push is covered.
- Fail fast by skipping expensive domain jobs when commit messages or PR titles are invalid.

## Test plan
- [x] `tests/verifyCommitMessages.test.ts`
- [x] `tests/ciWorkflow.test.ts`
- [x] `tests/requiredCiGate.test.ts`
- [x] `tests/githubWorkflowTriggers.test.ts`

Made with [Cursor](https://cursor.com)