### PR TITLE
fix(v2): align model probe with client wire contracts

### DIFF
--- a/.trellis/spec/frontend/v2-agent-models.md
+++ b/.trellis/spec/frontend/v2-agent-models.md
@@ -248,15 +248,28 @@ must not use it for 「测试连通」.
 `checkModel({ app, baseUrl, apiKey, modelId, codexImageExtension? })` is available on the same three
 ports and invokes `stream_check_model`. It sends one authenticated streaming
 request for the selected model (first SSE chunk = success) and never looks up
-a saved Provider or touches the failover circuit breaker. Protocol is
-Anthropic Messages for Claude, OpenAI Responses for Codex and Grok Build, and
-OpenAI Chat Completions for WorkBuddy / OpenCode. Codex Responses does not add
-an output-token limit merely for the probe. `codexImageExtension` is the only
-renderer-controlled header intent: when true on Codex, Rust adds the same
-managed actor header as Quick Setup; the renderer cannot submit arbitrary
-headers. Empty `apiKey` omits the auth header. Failure `message` is
-`HTTP {status}: {truncated body}` or the
-transport error, with the API key redacted. Browser adapters reject both
+a saved Provider or touches the failover circuit breaker. Protocol projection
+is per-app and must match the client Quick Setup writes: Anthropic Messages
+plus `Authorization: Bearer` for Claude (`ANTHROPIC_AUTH_TOKEN`; not
+`x-api-key`), OpenAI Responses for Codex and Grok Build, and OpenAI Chat
+Completions for WorkBuddy / OpenCode. Each app emits one determined URL with
+no 404/400 fallback: Claude Code `{ANTHROPIC_BASE_URL}/v1/messages` (do not
+collapse `/v1/v1`), Codex/Grok `{base}/responses`, OpenCode
+`{base}/chat/completions`, WorkBuddy the same Chat path after its URL
+normalizer. Every probe sets `stream: true` and reads the first stream chunk.
+Claude Messages keeps `max_tokens: 1` and `Accept: text/event-stream`.
+Codex/Grok Responses use `Accept: text/event-stream`. WorkBuddy/OpenCode Chat
+keep `stream: true` and `Accept: application/json`. Transport must send a
+single `Content-Type: application/json` header (do not combine reqwest
+`.json()` with a second Content-Type append). Every app pads the user content
+to at least 1024 estimated input tokens so short-prompt interceptors do not
+drop the request; they omit a probe-only `max_tokens`.
+`codexImageExtension` is the only renderer-controlled header intent: when true
+on Codex, Rust adds the same managed actor header as Quick Setup; the renderer
+cannot submit arbitrary headers. Empty `apiKey` omits the auth header. Failure
+`message` is `HTTP {status}: {truncated body}` or the
+transport error, with the API key redacted. HTTP 400 is a real failure and
+must not trigger another URL. Browser adapters reject both
 methods as native-only. Qoder and TRAE Models ports must not expose
 `checkModel`.
 
@@ -709,6 +722,9 @@ fetch/save controls.
 | Writer failed and the original baseline is authoritatively restored                                                          | Render failed/danger with confirmed-baseline copy; target mismatches are expected, not unknown authority   |
 | Codex `imageExtension: true` omits `experimental_bearer_token` while `requires_openai_auth` is false                         | Host derivation/test fails; current Codex would not send `auth.json`'s key                                 |
 | Codex model probe adds an output-token limit solely for connectivity                                                         | Wire test fails; send the bounded Responses probe without that compatibility-breaking field                |
+| WorkBuddy/OpenCode Chat probe adds `max_tokens` solely for connectivity                                                      | Wire test fails; o-series and strict gateways reject that deprecated field                                 |
+| Claude model probe sends `x-api-key` while Quick Setup writes `ANTHROPIC_AUTH_TOKEN`                                         | Wire/contract test fails; Claude Code sends `Authorization: Bearer`                                        |
+| Model probe guesses a second URL after HTTP 400/404                                                                          | Wire test fails; each app has one determined client URL and returns the truncated body                     |
 | Grok Build probe uses Chat Completions while Quick Setup writes `api_backend = "responses"`                                  | Wire test fails; use the Responses endpoint                                                                |
 | Concurrent Provider/live writer                                                                                              | Serialize or detect conflict; never return a split DB/current/live state                                   |
 | Required atomic step fails and compensation succeeds                                                                         | Return `APPLY_FAILED_ROLLED_BACK`; UI may say rollback confirmed                                           |
@@ -749,10 +765,13 @@ fetch/save controls.
   saves revision N, and becomes clean only if no N+1 edit happened while the
   request was pending. A successful save also invalidates probe feedback from
   the old revision.
-- Good: Codex/Grok Build probes use Responses, Claude uses Messages, and
-  WorkBuddy/OpenCode use Chat Completions. Codex may project only the bounded
-  image-extension actor intent; it does not add an output-token limit for a
-  one-shot connectivity probe.
+- Good: Codex/Grok Build probes use Responses, Claude uses Messages with
+  Bearer (Quick Setup `ANTHROPIC_AUTH_TOKEN`) and `{base}/v1/messages`, and
+  WorkBuddy/OpenCode use streaming Chat Completions (`stream: true`) with
+  `Accept: application/json` rather than `text/event-stream`. Codex may
+  project only the bounded image-extension actor intent; it does not add an
+  output-token limit for a one-shot connectivity probe. HTTP 400 returns the
+  truncated upstream body and does not retry another path.
 - Base: browser preview renders the pages but authoritative panels report that
   desktop state is unavailable; test-only fixtures may exercise UI branches.
 - Bad: hard-code a second capability matrix, treat `null` runtime as absence,
@@ -847,8 +866,14 @@ Required focused coverage includes:
   backend `message`. `stream_check_model` validates the draft HTTP(S) URL the
   same way as `validate_probe_url` and never resets the circuit breaker. Wire
   tests prove Codex/Grok Build use Responses, the Codex probe omits the
-  connectivity-only output limit, and only bounded image-extension intent can
-  add the managed actor header.
+  connectivity-only output limit, WorkBuddy/OpenCode Chat omit `max_tokens`
+  and send `stream: true` with `Accept: application/json` (not
+  `text/event-stream`), every app pads user content to at least 1024 estimated
+  input tokens,
+  Claude Quick Setup AUTH_TOKEN projects `Authorization: Bearer` onto
+  `{base}/v1/messages` with no URL fallback, HTTP 400 returns the truncated
+  body, and only bounded image-extension intent can add the managed actor
+  header.
   Claude, Codex, and Grok Build all expose 「拉取模型」.
   Claude shows a warn-only explicit `/v1` pathname notice and a placeholder
   without `/v1`.

--- a/scripts/tasks/supported-platform-structure-assets.json
+++ b/scripts/tasks/supported-platform-structure-assets.json
@@ -175,7 +175,7 @@
     ],
     [
       "src-tauri/src/services/model_probe.rs",
-      "88a795f114a5ee81f75448668dd471f13c78027619372187f8f1caaacec53305"
+      "f5c87f86e62c5738d3c345e191960d02100b3df8b79f74ec9e1909428f0e0578"
     ],
     [
       "src-tauri/src/services/provider/mod.rs",

--- a/src-tauri/src/services/model_probe.rs
+++ b/src-tauri/src/services/model_probe.rs
@@ -1,11 +1,12 @@
 //! Draft-model connectivity probe.
 //!
-//! Recovers the real streaming request from the pre-`a5903d86` Stream Check
-//! path, but only for V2 Models draft URLs. This is not URL reachability:
-//! it sends an authenticated one-token stream and treats the first SSE chunk
-//! as success. It never looks up a saved Provider and never touches the
-//! failover circuit breaker.
+//! Projects one request per app onto the same wire contract the target client
+//! will use after Quick Setup (`ProbeRequestSpec`), then sends that single
+//! streaming request. This is not URL reachability: the first SSE chunk is
+//! success. It never looks up a saved Provider, never guesses a second URL,
+//! and never touches the failover circuit breaker.
 
+use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
 use futures::StreamExt;
@@ -16,7 +17,7 @@ use serde_json::{json, Value};
 use crate::error::AppError;
 use crate::services::stream_check::{HealthStatus, StreamCheckService};
 
-const TEST_PROMPT: &str = "ping";
+const MIN_PROBE_INPUT_TOKENS: usize = 1024;
 const TIMEOUT: Duration = Duration::from_secs(30);
 const MAX_RETRIES: u32 = 1;
 const DEGRADED_THRESHOLD_MS: u64 = 6000;
@@ -37,6 +38,14 @@ enum ProbeProtocol {
     AnthropicMessages,
     OpenAiChat,
     OpenAiResponses,
+}
+
+/// App-specific request projection. Transport only sends this object.
+#[derive(Debug, Clone, PartialEq)]
+struct ProbeRequestSpec {
+    url: String,
+    headers: Vec<(String, String)>,
+    body: Value,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -131,28 +140,10 @@ async fn probe_once(
     model_id: &str,
     codex_image_extension: bool,
 ) -> Result<(u16, String), AppError> {
-    let protocol = protocol_for_app(app);
-    let (actual_model, reasoning_effort) = parse_model_with_effort(model_id);
-    let urls = resolve_probe_urls(base_url, endpoint_for(protocol));
-    let body = request_body(protocol, &actual_model, reasoning_effort.as_deref());
-
-    for (index, url) in urls.iter().enumerate() {
-        match send_stream_request(client, protocol, url, api_key, &body, codex_image_extension)
-            .await
-        {
-            Ok(status) => return Ok((status, actual_model)),
-            Err(error) => {
-                if index == 0
-                    && urls.len() > 1
-                    && matches!(&error, AppError::HttpStatus { status: 404, .. })
-                {
-                    continue;
-                }
-                return Err(error);
-            }
-        }
-    }
-    Err(AppError::Message("没有可用的模型探测端点".to_string()))
+    let (spec, actual_model) =
+        build_probe_spec(app, base_url, api_key, model_id, codex_image_extension)?;
+    let status = send_stream_request(client, &spec).await?;
+    Ok((status, actual_model))
 }
 
 fn protocol_for_app(app: ModelProbeApp) -> ProbeProtocol {
@@ -163,12 +154,60 @@ fn protocol_for_app(app: ModelProbeApp) -> ProbeProtocol {
     }
 }
 
-fn endpoint_for(protocol: ProbeProtocol) -> &'static str {
-    match protocol {
-        ProbeProtocol::AnthropicMessages => "messages",
-        ProbeProtocol::OpenAiChat => "chat/completions",
-        ProbeProtocol::OpenAiResponses => "responses",
+fn build_probe_spec(
+    app: ModelProbeApp,
+    base_url: &str,
+    api_key: &str,
+    model_id: &str,
+    codex_image_extension: bool,
+) -> Result<(ProbeRequestSpec, String), AppError> {
+    let protocol = protocol_for_app(app);
+    let (actual_model, reasoning_effort) = parse_model_with_effort(model_id);
+    let url = probe_url(app, base_url)?;
+    let body = request_body(protocol, &actual_model, reasoning_effort.as_deref());
+    let headers = probe_headers(app, api_key, codex_image_extension);
+    Ok((ProbeRequestSpec { url, headers, body }, actual_model))
+}
+
+fn probe_url(app: ModelProbeApp, base_url: &str) -> Result<String, AppError> {
+    match app {
+        ModelProbeApp::Claude => Ok(claude_code_messages_url(base_url)),
+        ModelProbeApp::Codex | ModelProbeApp::GrokBuild => {
+            Ok(openai_compatible_url(base_url, "responses"))
+        }
+        ModelProbeApp::OpenCode => Ok(openai_compatible_url(base_url, "chat/completions")),
+        ModelProbeApp::WorkBuddy => workbuddy_chat_completions_url(base_url),
     }
+}
+
+/// Claude Code / Anthropic SDK join: `{ANTHROPIC_BASE_URL}/v1/messages`.
+/// Do not collapse `/v1/v1` and do not retry an alternate path.
+fn claude_code_messages_url(base_url: &str) -> String {
+    format!("{}/v1/messages", base_url.trim().trim_end_matches('/'))
+}
+
+/// Codex CLI / OpenCode openai-compatible join: `{base}/{endpoint}`.
+/// `base` is used as-is (typically already includes `/v1`). Terminal
+/// `/messages` `/responses` `/chat/completions` `/models` suffixes are
+/// stripped so a pasted full endpoint still maps to one determined URL.
+fn openai_compatible_url(base_url: &str, endpoint: &str) -> String {
+    format!(
+        "{}/{}",
+        strip_known_endpoints(base_url),
+        endpoint.trim_start_matches('/')
+    )
+}
+
+fn workbuddy_chat_completions_url(base_url: &str) -> Result<String, AppError> {
+    let normalized = crate::services::workbuddy::url::normalize_workbuddy_base_url(base_url)
+        .map_err(|_| AppError::Message("服务地址无效".to_string()))?;
+    let mut url = normalized.base_url;
+    let path = match url.path().trim_end_matches('/') {
+        "" | "/" => "/chat/completions".to_string(),
+        path => format!("{path}/chat/completions"),
+    };
+    url.set_path(&path);
+    Ok(url.to_string())
 }
 
 fn strip_known_endpoints(base: &str) -> String {
@@ -183,34 +222,75 @@ fn strip_known_endpoints(base: &str) -> String {
     base.trim_end_matches('/').to_string()
 }
 
-fn is_origin_only_url(value: &str) -> bool {
-    let trimmed = value.trim_end_matches('/');
-    match trimmed.split_once("://") {
-        Some((_scheme, rest)) => !rest.contains('/'),
-        None => !trimmed.contains('/'),
+fn probe_headers(
+    app: ModelProbeApp,
+    api_key: &str,
+    codex_image_extension: bool,
+) -> Vec<(String, String)> {
+    let mut headers = match app {
+        ModelProbeApp::Claude => claude_headers(api_key),
+        ModelProbeApp::Codex | ModelProbeApp::GrokBuild => openai_headers(api_key, true),
+        ModelProbeApp::WorkBuddy | ModelProbeApp::OpenCode => openai_headers(api_key, false),
+    };
+    if app == ModelProbeApp::Codex && codex_image_extension {
+        headers.push((
+            crate::codex_config::CODEX_IMAGE_EXTENSION_HEADER.to_string(),
+            crate::codex_config::CODEX_IMAGE_EXTENSION_VALUE.to_string(),
+        ));
     }
+    headers
 }
 
-fn resolve_probe_urls(base_url: &str, endpoint: &str) -> Vec<String> {
-    let base = strip_known_endpoints(base_url);
-    let endpoint_suffix = format!("/{endpoint}");
-    if base.to_ascii_lowercase().ends_with(&endpoint_suffix) {
-        return vec![base];
+fn claude_headers(api_key: &str) -> Vec<(String, String)> {
+    let mut headers = vec![
+        header("anthropic-version", "2023-06-01"),
+        header("content-type", "application/json"),
+        header("accept", "text/event-stream"),
+        header("accept-encoding", "identity"),
+        header("user-agent", "claude-cli/2.1.2 (external, cli)"),
+        header("x-app", "cli"),
+        header("x-stainless-lang", "js"),
+        header("x-stainless-os", os_name()),
+        header("x-stainless-arch", arch_name()),
+    ];
+    // V2 Quick Setup writes ANTHROPIC_AUTH_TOKEN. Claude Code and ClaudeAdapter
+    // send that as Authorization: Bearer. Do not send x-api-key here; if Quick
+    // Setup later exposes ANTHROPIC_API_KEY, add an explicit auth-mode enum.
+    if !api_key.is_empty() {
+        headers.push(header("authorization", format!("Bearer {api_key}")));
     }
-    if base.ends_with("/v1") {
-        return vec![format!("{base}{endpoint_suffix}")];
-    }
-    if is_origin_only_url(&base) {
-        vec![
-            format!("{base}/v1{endpoint_suffix}"),
-            format!("{base}{endpoint_suffix}"),
-        ]
+    headers
+}
+
+fn openai_headers(api_key: &str, event_stream_accept: bool) -> Vec<(String, String)> {
+    let mut headers = vec![header("content-type", "application/json")];
+    if event_stream_accept {
+        headers.push(header("accept", "text/event-stream"));
+        headers.push(header("accept-encoding", "identity"));
+        headers.push(header(
+            "user-agent",
+            format!("codex_cli_rs/0.80.0 ({}; {})", os_name(), arch_name()),
+        ));
+        headers.push(header("originator", "codex_cli_rs"));
     } else {
-        vec![
-            format!("{base}{endpoint_suffix}"),
-            format!("{base}/v1{endpoint_suffix}"),
-        ]
+        headers.push(header("accept", "application/json"));
     }
+    if !api_key.is_empty() {
+        headers.push(header("authorization", format!("Bearer {api_key}")));
+    }
+    headers
+}
+
+fn header(name: &str, value: impl Into<String>) -> (String, String) {
+    (name.to_string(), value.into())
+}
+
+#[cfg(test)]
+fn spec_header<'a>(spec: &'a ProbeRequestSpec, name: &str) -> Option<&'a str> {
+    spec.headers
+        .iter()
+        .find(|(key, _)| key.eq_ignore_ascii_case(name))
+        .map(|(_, value)| value.as_str())
 }
 
 fn parse_model_with_effort(model: &str) -> (String, Option<String>) {
@@ -224,19 +304,44 @@ fn parse_model_with_effort(model: &str) -> (String, Option<String>) {
     (model.to_string(), None)
 }
 
+/// Lower bound for unique Latin text on cl100k-class tokenizers.
+fn estimate_input_tokens(text: &str) -> usize {
+    text.len().div_ceil(4)
+}
+
+/// Shared user content for every app probe. Numbered unique lines keep the
+/// tokenizer from collapsing repetition, so short-prompt interceptors that
+/// require ~1K input tokens still see a real-looking request.
+fn probe_user_content() -> &'static str {
+    static CONTENT: OnceLock<String> = OnceLock::new();
+    CONTENT.get_or_init(|| {
+        let mut text = String::from(
+            "Reply with a single letter. Numbered lines below fill the input window so short-prompt filters do not reject this connectivity check.\n",
+        );
+        let mut index = 1_u32;
+        while estimate_input_tokens(&text) < MIN_PROBE_INPUT_TOKENS {
+            text.push_str(&format!(
+                "{index:04}. Distinct connectivity-check context for model probe input accounting.\n"
+            ));
+            index += 1;
+        }
+        text
+    })
+}
+
 fn request_body(protocol: ProbeProtocol, model: &str, reasoning_effort: Option<&str>) -> Value {
+    let content = probe_user_content();
     match protocol {
         ProbeProtocol::AnthropicMessages => json!({
             "model": model,
             "max_tokens": 1,
-            "messages": [{ "role": "user", "content": TEST_PROMPT }],
+            "messages": [{ "role": "user", "content": content }],
             "stream": true
         }),
         ProbeProtocol::OpenAiChat => {
             let mut body = json!({
                 "model": model,
-                "messages": [{ "role": "user", "content": TEST_PROMPT }],
-                "max_tokens": 1,
+                "messages": [{ "role": "user", "content": content }],
                 "stream": true
             });
             if let Some(effort) = reasoning_effort {
@@ -249,7 +354,7 @@ fn request_body(protocol: ProbeProtocol, model: &str, reasoning_effort: Option<&
         ProbeProtocol::OpenAiResponses => {
             let mut body = json!({
                 "model": model,
-                "input": [{ "role": "user", "content": TEST_PROMPT }],
+                "input": [{ "role": "user", "content": content }],
                 "stream": true
             });
             if let Some(effort) = reasoning_effort {
@@ -260,56 +365,18 @@ fn request_body(protocol: ProbeProtocol, model: &str, reasoning_effort: Option<&
     }
 }
 
-async fn send_stream_request(
-    client: &Client,
-    protocol: ProbeProtocol,
-    url: &str,
-    api_key: &str,
-    body: &Value,
-    codex_image_extension: bool,
-) -> Result<u16, AppError> {
-    let mut request = client.post(url).timeout(TIMEOUT).json(body);
-    request = match protocol {
-        ProbeProtocol::AnthropicMessages => {
-            let os_name = os_name();
-            let arch_name = arch_name();
-            let mut builder = request
-                .header("anthropic-version", "2023-06-01")
-                .header("content-type", "application/json")
-                .header("accept", "text/event-stream")
-                .header("accept-encoding", "identity")
-                .header("user-agent", "claude-cli/2.1.2 (external, cli)")
-                .header("x-app", "cli")
-                .header("x-stainless-lang", "js")
-                .header("x-stainless-os", os_name)
-                .header("x-stainless-arch", arch_name);
-            if !api_key.is_empty() {
-                builder = builder.header("x-api-key", api_key);
-            }
-            builder
-        }
-        ProbeProtocol::OpenAiChat | ProbeProtocol::OpenAiResponses => {
-            let mut builder = request
-                .header("content-type", "application/json")
-                .header("accept", "text/event-stream")
-                .header("accept-encoding", "identity")
-                .header(
-                    "user-agent",
-                    format!("codex_cli_rs/0.80.0 ({}; {})", os_name(), arch_name()),
-                )
-                .header("originator", "codex_cli_rs");
-            if !api_key.is_empty() {
-                builder = builder.header("authorization", format!("Bearer {api_key}"));
-            }
-            if protocol == ProbeProtocol::OpenAiResponses && codex_image_extension {
-                builder = builder.header(
-                    crate::codex_config::CODEX_IMAGE_EXTENSION_HEADER,
-                    crate::codex_config::CODEX_IMAGE_EXTENSION_VALUE,
-                );
-            }
-            builder
-        }
-    };
+async fn send_stream_request(client: &Client, spec: &ProbeRequestSpec) -> Result<u16, AppError> {
+    let body = serde_json::to_vec(&spec.body)
+        .map_err(|error| AppError::Message(format!("序列化探测请求失败: {error}")))?;
+    // Use `.body()` rather than `.json()`: reqwest's `.json()` already inserts
+    // Content-Type, and `.header()` appends, producing two identical
+    // `Content-Type: application/json` lines. Node-style gateways join those
+    // into `application/json, application/json` and return 400
+    // `Unsupported content type`.
+    let mut request = client.post(&spec.url).timeout(TIMEOUT).body(body);
+    for (name, value) in &spec.headers {
+        request = request.header(name.as_str(), value);
+    }
 
     let response = request.send().await.map_err(map_request_error)?;
     let status = response.status().as_u16();
@@ -506,6 +573,8 @@ mod tests {
         time::Duration as StdDuration,
     };
 
+    use crate::provider::Provider;
+    use crate::proxy::providers::{ClaudeAdapter, ProviderAdapter};
     use reqwest::{redirect::Policy, Client};
 
     fn loopback_client() -> Client {
@@ -528,6 +597,41 @@ mod tests {
         .into_bytes()
     }
 
+    fn read_http_request(stream: &mut impl Read) -> String {
+        let mut data = Vec::new();
+        let mut chunk = [0_u8; 2048];
+        loop {
+            match stream.read(&mut chunk) {
+                Ok(0) => break,
+                Ok(n) => {
+                    data.extend_from_slice(&chunk[..n]);
+                    if let Some((header_end, body_len)) = http_body_target(&data) {
+                        if data.len() >= header_end + body_len {
+                            break;
+                        }
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+        String::from_utf8_lossy(&data).into_owned()
+    }
+
+    fn http_body_target(data: &[u8]) -> Option<(usize, usize)> {
+        let header_end = data.windows(4).position(|window| window == b"\r\n\r\n")? + 4;
+        let headers = std::str::from_utf8(&data[..header_end]).ok()?;
+        let body_len = headers
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                name.eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse::<usize>().ok())
+                    .flatten()
+            })
+            .unwrap_or(0);
+        Some((header_end, body_len))
+    }
+
     fn spawn_server(responses: Vec<Vec<u8>>) -> (String, Arc<Mutex<Vec<String>>>) {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
         let port = listener.local_addr().expect("addr").port();
@@ -538,13 +642,10 @@ mod tests {
             for response in responses {
                 if let Ok((mut stream, _)) = listener.accept() {
                     let _ = stream.set_read_timeout(Some(StdDuration::from_secs(3)));
-                    let mut buf = [0_u8; 4096];
-                    if let Ok(read) = stream.read(&mut buf) {
-                        captured
-                            .lock()
-                            .expect("requests")
-                            .push(String::from_utf8_lossy(&buf[..read]).into_owned());
-                    }
+                    captured
+                        .lock()
+                        .expect("requests")
+                        .push(read_http_request(&mut stream));
                     let _ = stream.write_all(&response);
                     let _ = stream.flush();
                 }
@@ -553,26 +654,150 @@ mod tests {
         (format!("http://127.0.0.1:{port}"), requests)
     }
 
+    fn spec_user_content(spec: &ProbeRequestSpec) -> &str {
+        spec.body
+            .pointer("/messages/0/content")
+            .or_else(|| spec.body.pointer("/input/0/content"))
+            .and_then(Value::as_str)
+            .unwrap_or("")
+    }
+
+    fn spec_for(app: ModelProbeApp, base_url: &str, model_id: &str) -> ProbeRequestSpec {
+        build_probe_spec(app, base_url, "sk-test", model_id, false)
+            .expect("spec")
+            .0
+    }
+
     #[test]
-    fn origin_only_urls_prefer_v1_then_bare_path() {
+    fn each_app_projects_one_determined_url() {
         assert_eq!(
-            resolve_probe_urls("https://gateway.example", "chat/completions"),
-            vec![
-                "https://gateway.example/v1/chat/completions".to_string(),
-                "https://gateway.example/chat/completions".to_string(),
-            ]
+            spec_for(ModelProbeApp::Claude, "https://gateway.example", "m").url,
+            "https://gateway.example/v1/messages"
         );
         assert_eq!(
-            resolve_probe_urls("https://gateway.example/v1", "messages"),
-            vec!["https://gateway.example/v1/messages".to_string()]
+            spec_for(
+                ModelProbeApp::Claude,
+                "https://gateway.example/anthropic",
+                "m"
+            )
+            .url,
+            "https://gateway.example/anthropic/v1/messages"
         );
         assert_eq!(
-            resolve_probe_urls(
+            spec_for(ModelProbeApp::Claude, "https://gateway.example/v1", "m").url,
+            "https://gateway.example/v1/v1/messages"
+        );
+        assert_eq!(
+            spec_for(ModelProbeApp::Codex, "https://gateway.example", "m").url,
+            "https://gateway.example/responses"
+        );
+        assert_eq!(
+            spec_for(ModelProbeApp::Codex, "https://gateway.example/v1", "m").url,
+            "https://gateway.example/v1/responses"
+        );
+        assert_eq!(
+            spec_for(ModelProbeApp::GrokBuild, "https://gateway.example/v1", "m").url,
+            "https://gateway.example/v1/responses"
+        );
+        assert_eq!(
+            spec_for(ModelProbeApp::OpenCode, "https://gateway.example", "m").url,
+            "https://gateway.example/chat/completions"
+        );
+        assert_eq!(
+            spec_for(
+                ModelProbeApp::OpenCode,
                 "https://gateway.example/v1/chat/completions",
-                "chat/completions"
-            ),
-            vec!["https://gateway.example/v1/chat/completions".to_string()]
+                "m"
+            )
+            .url,
+            "https://gateway.example/v1/chat/completions"
         );
+        assert_eq!(
+            spec_for(ModelProbeApp::WorkBuddy, "https://gateway.example", "m").url,
+            "https://gateway.example/v1/chat/completions"
+        );
+        assert_eq!(
+            spec_for(
+                ModelProbeApp::WorkBuddy,
+                "https://gateway.example/openai",
+                "m"
+            )
+            .url,
+            "https://gateway.example/openai/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn claude_probe_matches_quick_setup_auth_token_contract() {
+        let base = "https://gateway.example/anthropic";
+        let token = "sk-ant-test";
+        let model = "claude-test";
+        let provider = Provider::with_id(
+            "fyagent-v2-quick-setup-claude".to_string(),
+            "Claude".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": base,
+                    "ANTHROPIC_AUTH_TOKEN": token,
+                    "ANTHROPIC_MODEL": model,
+                }
+            }),
+            None,
+        );
+        let adapter = ClaudeAdapter::new();
+        let auth = adapter.extract_auth(&provider).expect("auth");
+        let headers = adapter.get_auth_headers(&auth).expect("headers");
+        assert_eq!(headers[0].0.as_str(), "authorization");
+        assert_eq!(
+            headers[0].1.to_str().expect("header value"),
+            format!("Bearer {token}")
+        );
+
+        let spec = build_probe_spec(ModelProbeApp::Claude, base, token, model, false)
+            .expect("spec")
+            .0;
+        assert_eq!(
+            spec_header(&spec, "authorization"),
+            Some("Bearer sk-ant-test")
+        );
+        assert!(spec_header(&spec, "x-api-key").is_none());
+        assert_eq!(spec.url, format!("{base}/v1/messages"));
+        assert_eq!(spec.body["max_tokens"], json!(1));
+    }
+
+    #[test]
+    fn chat_probe_omits_max_tokens_even_for_o_series() {
+        let workbuddy = spec_for(ModelProbeApp::WorkBuddy, "https://gateway.example/v1", "o3");
+        let opencode = spec_for(
+            ModelProbeApp::OpenCode,
+            "https://gateway.example/v1",
+            "o4-mini",
+        );
+        assert!(workbuddy.body.get("max_tokens").is_none());
+        assert!(opencode.body.get("max_tokens").is_none());
+        assert_eq!(workbuddy.body["stream"], json!(true));
+        assert_eq!(opencode.body["stream"], json!(true));
+        assert_eq!(spec_header(&workbuddy, "accept"), Some("application/json"));
+        assert_eq!(spec_header(&opencode, "accept"), Some("application/json"));
+        assert!(spec_header(&workbuddy, "originator").is_none());
+    }
+
+    #[test]
+    fn all_apps_pad_probe_input_to_at_least_1k_tokens() {
+        let apps = [
+            ModelProbeApp::Claude,
+            ModelProbeApp::Codex,
+            ModelProbeApp::GrokBuild,
+            ModelProbeApp::WorkBuddy,
+            ModelProbeApp::OpenCode,
+        ];
+        let expected = probe_user_content();
+        assert!(estimate_input_tokens(expected) >= MIN_PROBE_INPUT_TOKENS);
+        for app in apps {
+            let spec = spec_for(app, "https://gateway.example/v1", "m");
+            assert_eq!(spec_user_content(&spec), expected);
+            assert_ne!(spec_user_content(&spec), "ping");
+        }
     }
 
     #[test]
@@ -643,8 +868,22 @@ mod tests {
         assert_eq!(result.model_used, "gpt-test");
         assert_eq!(result.http_status, Some(200));
         let captured = requests.lock().expect("requests").join("\n");
+        let captured_lower = captured.to_ascii_lowercase();
         assert!(captured.contains("POST /v1/chat/completions"));
         assert!(captured.contains("Bearer sk-test"));
+        assert!(captured.contains("\"stream\":true") || captured.contains("\"stream\": true"));
+        assert!(captured_lower.contains("accept: application/json"));
+        assert!(!captured_lower.contains("text/event-stream"));
+        assert!(!captured.contains("max_tokens"));
+        let content_types: Vec<&str> = captured
+            .lines()
+            .filter(|line| line.to_ascii_lowercase().starts_with("content-type:"))
+            .collect();
+        assert_eq!(
+            content_types,
+            ["content-type: application/json"],
+            "wire Content-Type must be a single bare application/json, got:\n{captured}"
+        );
     }
 
     #[tokio::test]
@@ -656,7 +895,7 @@ mod tests {
         let result = probe_with_client(
             &loopback_client(),
             ModelProbeApp::Claude,
-            &format!("{base}/v1"),
+            &base,
             "sk-test",
             "claude-test",
             false,
@@ -704,5 +943,106 @@ mod tests {
         assert!(!captured.contains("max_output_tokens"));
         assert!(captured.contains(crate::codex_config::CODEX_IMAGE_EXTENSION_HEADER));
         assert!(captured.contains(crate::codex_config::CODEX_IMAGE_EXTENSION_VALUE));
+    }
+
+    #[tokio::test]
+    async fn claude_probe_sends_bearer_to_claude_code_path() {
+        let body = "event: message_start\ndata: {\"type\":\"message_start\"}\n\n";
+        let (base, requests) = spawn_server(vec![http_response("200 OK", body)]);
+        let result = probe_with_client(
+            &loopback_client(),
+            ModelProbeApp::Claude,
+            &format!("{base}/anthropic"),
+            "sk-ant-test",
+            "claude-test",
+            false,
+        )
+        .await
+        .expect("probe");
+        assert!(result.success);
+        let captured = requests.lock().expect("requests").join("\n");
+        assert!(captured.contains("POST /anthropic/v1/messages"));
+        assert!(!captured.contains("POST /anthropic/messages "));
+        assert!(captured.contains("Bearer sk-ant-test"));
+        assert!(!captured.to_ascii_lowercase().contains("x-api-key"));
+        assert!(captured.contains("\"max_tokens\":1") || captured.contains("\"max_tokens\": 1"));
+    }
+
+    #[tokio::test]
+    async fn http_400_returns_body_without_url_fallback() {
+        let (base, requests) = spawn_server(vec![http_response(
+            "400 Bad Request",
+            r#"{"error":{"message":"invalid_request_error: schema"}}"#,
+        )]);
+        let result = probe_with_client(
+            &loopback_client(),
+            ModelProbeApp::Claude,
+            &format!("{base}/anthropic"),
+            "sk-ant-test",
+            "claude-test",
+            false,
+        )
+        .await
+        .expect("probe result");
+        assert!(!result.success);
+        assert_eq!(result.http_status, Some(400));
+        assert!(result.message.contains("invalid_request_error: schema"));
+        assert_eq!(requests.lock().expect("requests").len(), 1);
+        let captured = requests.lock().expect("requests").join("\n");
+        assert!(captured.contains("POST /anthropic/v1/messages"));
+    }
+
+    #[tokio::test]
+    async fn grok_build_probe_uses_responses() {
+        let body = "event: response.created\ndata: {\"type\":\"response.created\"}\n\n";
+        let (base, requests) = spawn_server(vec![http_response("200 OK", body)]);
+        let result = probe_with_client(
+            &loopback_client(),
+            ModelProbeApp::GrokBuild,
+            &format!("{base}/v1"),
+            "sk-test",
+            "grok-test",
+            false,
+        )
+        .await
+        .expect("probe");
+        assert!(result.success);
+        let captured = requests.lock().expect("requests").join("\n");
+        assert!(captured.contains("POST /v1/responses"));
+        assert!(!captured.contains("chat/completions"));
+        assert!(!captured.contains("max_output_tokens"));
+    }
+
+    #[tokio::test]
+    async fn opencode_chat_probe_streams_without_event_stream_accept() {
+        let body = "data: {\"choices\":[{\"delta\":{\"content\":\"OK\"}}]}\n\n";
+        let (base, requests) = spawn_server(vec![http_response("200 OK", body)]);
+        let result = probe_with_client(
+            &loopback_client(),
+            ModelProbeApp::OpenCode,
+            &format!("{base}/v1"),
+            "sk-test",
+            "o3",
+            false,
+        )
+        .await
+        .expect("probe");
+        assert!(result.success);
+        let captured = requests.lock().expect("requests").join("\n");
+        let captured_lower = captured.to_ascii_lowercase();
+        assert!(captured.contains("POST /v1/chat/completions"));
+        assert!(captured.contains("\"stream\":true") || captured.contains("\"stream\": true"));
+        assert!(captured_lower.contains("accept: application/json"));
+        assert!(!captured_lower.contains("text/event-stream"));
+        assert!(!captured.contains("max_tokens"));
+        let content_types: Vec<&str> = captured
+            .lines()
+            .filter(|line| line.to_ascii_lowercase().starts_with("content-type:"))
+            .collect();
+        assert_eq!(
+            content_types,
+            ["content-type: application/json"],
+            "wire Content-Type must be a single bare application/json, got:\n{captured}"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- V2 Models「测试连通」改为按各客户端真实协议发一次流式请求：Claude Messages + Bearer，Codex/Grok Responses，WorkBuddy/OpenCode Chat Completions；不再 404/400 换 URL 重试。
- 修复 reqwest `.json()` 再追加 `Content-Type` 导致的双 header，网关因此返回 HTTP 400 `Unsupported content type`。
- 所有应用探测输入垫到至少约 1K token，避免上游短请求拦截。

## Test plan
- [ ] 重启桌面应用后，WorkBuddy 对 OpenAI 兼容网关（如 `https://api.vibekey.cn` + `gpt-5.6-luna`）点「测试连通」，不再出现 HTTP 400 `Unsupported content type`
- [ ] 同一网关上「拉取模型」仍可用；连通成功后上游后台输入 token 约 1K+
- [ ] Claude / Codex / Grok Build / OpenCode 各测一次连通，确认走对应协议且仍为流式
- [ ] `mise run rust:test -- model_probe`（本地已通过，15 tests）

## Scope and rationale / 范围与原因

Model connectivity probes were guessing alternate URLs and sending a wire shape the target clients do not use. OpenAI-compatible gateways then rejected the request as `Unsupported content type` because reqwest `.json()` plus a second `Content-Type` header produced two identical lines. Short `ping` prompts also tripped upstream probe filters.

This PR projects one determined streaming request per app onto the post-Quick-Setup client contract, sends a single `Content-Type: application/json`, and pads user content to at least 1024 estimated input tokens.

Out of scope: Qoder/TRAE model probe, Provider reachability (`stream_check_url`), and Claude `x-api-key` (Quick Setup still writes `ANTHROPIC_AUTH_TOKEN` only).

## Evidence / 验证证据

- Focused checks / 聚焦检查: `mise run rust:test -- model_probe` — 15 passed
- Native or remote evidence / 原生或远程证据: desktop reproduction against `api.vibekey.cn` WorkBuddy `gpt-5.6-luna` after the Content-Type fix; input-token padding verified by unit test plus user upstream-dashboard check
- Not verified / 未验证: full `mise run check`; hosted PR/Merge Queue CI pending

## Risk and rollback / 风险与回退

Probe-only change: no Provider save, circuit breaker, or schema migration. Rollback is the single commit in this PR.

## Checklist / 检查清单

- [x] Tests cover observable success and failure behavior / 测试覆盖可观察成功与失败路径
- [x] No secret, certificate, personal config, `.venv`, or user data is included / 未包含 secret、证书、个人配置、`.venv` 或用户数据
- [ ] `mise run check` passes on the current host / 当前宿主完整门禁未在本次全量跑过
