### PR TITLE
ci: automate star history chart

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -1,0 +1,106 @@
+name: Star History
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: star-history
+  cancel-in-progress: true
+
+jobs:
+  generate:
+    name: Generate charts
+    runs-on: macos-15
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "1.27.0"
+          cache: false
+
+      - name: Fetch reviewed star-history generator
+        env:
+          STAR_HISTORY_SOURCE_SHA: 8b1f26dc5e9a17caa75da9351b688509ef312811
+        run: |
+          source_dir="$RUNNER_TEMP/star-history-source"
+          git init --quiet "$source_dir"
+          git -C "$source_dir" remote add origin https://github.com/xpzouying/star-history.git
+          git -C "$source_dir" fetch --quiet --depth=1 origin "$STAR_HISTORY_SOURCE_SHA"
+          test "$(git -C "$source_dir" rev-parse FETCH_HEAD)" = "$STAR_HISTORY_SOURCE_SHA"
+          git -C "$source_dir" checkout --quiet --detach FETCH_HEAD
+
+      - name: Generate light and dark charts
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          output_dir="$RUNNER_TEMP/star-history-output/assets"
+          mkdir -p "$output_dir"
+          cd "$RUNNER_TEMP/star-history-source"
+          go run ./cmd/star-history \
+            -repo "$GITHUB_REPOSITORY" \
+            -out-light "$output_dir/star-history.svg" \
+            -out-dark "$output_dir/star-history-dark.svg"
+
+      - name: Upload generated charts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: star-history-charts
+          path: ${{ runner.temp }}/star-history-output/assets/*.svg
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Publish charts
+    needs: generate
+    runs-on: macos-15
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+
+      - name: Download generated charts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: star-history-charts
+          path: ${{ runner.temp }}/star-history-output/assets
+
+      - name: Publish dedicated data branch
+        run: |
+          output_dir="$RUNNER_TEMP/star-history-output/assets"
+          test -s "$output_dir/star-history.svg"
+          test -s "$output_dir/star-history-dark.svg"
+          grep -q '<svg' "$output_dir/star-history.svg"
+          grep -q '<svg' "$output_dir/star-history-dark.svg"
+
+          if git fetch --quiet --depth=1 origin star-history:refs/remotes/origin/star-history 2>/dev/null; then
+            git show origin/star-history:assets/star-history.svg > "$RUNNER_TEMP/existing-star-history.svg"
+            git show origin/star-history:assets/star-history-dark.svg > "$RUNNER_TEMP/existing-star-history-dark.svg"
+            if cmp -s "$RUNNER_TEMP/existing-star-history.svg" "$output_dir/star-history.svg" \
+              && cmp -s "$RUNNER_TEMP/existing-star-history-dark.svg" "$output_dir/star-history-dark.svg"; then
+              echo "Star history is unchanged; skipping publish."
+              exit 0
+            fi
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout --orphan __star_history_publish
+          git rm -rf .
+          mkdir -p assets
+          cp "$output_dir/star-history.svg" assets/star-history.svg
+          cp "$output_dir/star-history-dark.svg" assets/star-history-dark.svg
+          git add assets/star-history.svg assets/star-history-dark.svg
+          git commit -m "chore: update star history chart"
+          git push --force origin HEAD:refs/heads/star-history

--- a/.trellis/spec/backend/github-ci-workflow.md
+++ b/.trellis/spec/backend/github-ci-workflow.md
@@ -115,6 +115,9 @@ Classification invariants:
   frontend, desktop, backend, or Windows-native product jobs;
 - commit-message policy (`commit-convention-push.yml` and
   `verify-commit-messages.mjs`) reaches contracts without becoming Full CI;
+- repository-owned GitHub automation that does not schedule or aggregate
+  Required CI (`labeler.yml` and `star-history.yml`) reaches contracts without
+  becoming CI authority;
 - tracked GitHub metadata/templates, optional agent/editor/Trellis governance,
   and repository-governance helpers reach contracts plus docs/spec where they
   are documentation/governance surfaces rather than product code;

--- a/README.md
+++ b/README.md
@@ -167,6 +167,13 @@ mise run build
 
 工具链与小范围检查命令见[开发文档](docs/fyagent/development/README.md)。
 
+## Star History
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/fy-agent/fyagent/star-history/assets/star-history-dark.svg">
+  <img src="https://raw.githubusercontent.com/fy-agent/fyagent/star-history/assets/star-history.svg" alt="FyAgent Star History">
+</picture>
+
 ## 项目沿革与授权
 
 FyAgent 的前身 VibeKey 曾设想把 AI 配置和操作权装进一块可以随身携带的实体键盘。项目继续推进后，我们发现真正需要随身带走的不是一块硬件，而是每个人自己的 AI 选择、习惯和工作方式。于是产品从硬件控制器转向跨平台桌面软件，也把名字改成了 **FyAgent（For You Agent）**。

--- a/scripts/ci/classify-changes.mjs
+++ b/scripts/ci/classify-changes.mjs
@@ -70,6 +70,7 @@ const RELEASE_CONTROL_FILES = new Set([
 const GITHUB_CONTRACT_FILES = new Set([
   ".github/labeler.yml",
   ".github/workflows/labeler.yml",
+  ".github/workflows/star-history.yml",
 ]);
 
 const GITHUB_DOCUMENTATION_FILES = new Set([

--- a/tests/classifyChanges.test.ts
+++ b/tests/classifyChanges.test.ts
@@ -215,6 +215,15 @@ describe("repository change classifier", () => {
       domains("contracts"),
     ],
     [
+      "GitHub repository automation",
+      [
+        ".github/labeler.yml",
+        ".github/workflows/labeler.yml",
+        ".github/workflows/star-history.yml",
+      ],
+      domains("contracts"),
+    ],
+    [
       "developer governance",
       [
         ".codex/hooks.json",

--- a/tests/githubWorkflowTriggers.test.ts
+++ b/tests/githubWorkflowTriggers.test.ts
@@ -158,6 +158,50 @@ describe("GitHub workflow trigger policy", () => {
     ]);
   });
 
+  it("updates Star History through a dedicated data branch with split token privileges", () => {
+    const source = readWorkflow("star-history.yml");
+    const triggerSection = readHeaderBefore(source, "\npermissions:");
+
+    expect(triggerSection).toBe(
+      [
+        "name: Star History",
+        "",
+        "on:",
+        "  schedule:",
+        '    - cron: "17 3 * * *"',
+        "  workflow_dispatch:",
+      ].join("\n"),
+    );
+    expect(source).toContain("permissions:\n  contents: read");
+    expect(source).toContain(
+      "generate:\n    name: Generate charts\n    runs-on: macos-15",
+    );
+    expect(source).toContain(
+      "generate:\n    name: Generate charts\n    runs-on: macos-15\n    timeout-minutes: 10\n    permissions:\n      contents: read",
+    );
+    expect(source).toContain(
+      "publish:\n    name: Publish charts\n    needs: generate\n    runs-on: macos-15\n    timeout-minutes: 5\n    permissions:\n      contents: write",
+    );
+    expect(source).toContain(
+      "STAR_HISTORY_SOURCE_SHA: 8b1f26dc5e9a17caa75da9351b688509ef312811",
+    );
+    expect(source).toContain(
+      "git push --force origin HEAD:refs/heads/star-history",
+    );
+    expect(source).not.toMatch(/HEAD:refs\/heads\/main/);
+    expect(source).not.toContain("secrets.");
+
+    const uses = [...source.matchAll(/^\s+uses:\s+(.+)$/gm)].map(
+      (match) => match[1],
+    );
+    expect(uses).toEqual([
+      "actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0",
+      "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1",
+      "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1",
+      "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1",
+    ]);
+  });
+
   it("keeps frontend labeling scoped to frontend-owned tests", () => {
     const source = fs
       .readFileSync(path.resolve(WORKFLOWS_DIR, "..", "labeler.yml"), "utf8")


### PR DESCRIPTION
## Summary

- render FyAgent Star History from the repository-owned stargazer timeline on a daily schedule
- publish generated light/dark SVGs to the dedicated `star-history` data branch so protected `main` is never bypassed
- pin reviewed GitHub Actions and the upstream `xpzouying/star-history` generator source, with read-only generation separated from write-only publication
- point the README at the generated data branch and cover the workflow security/trigger contract

## Validation

- `mise run test:unit -- tests/githubWorkflowTriggers.test.ts`
- `mise run format:check -- README.md .github/workflows/star-history.yml tests/githubWorkflowTriggers.test.ts`
- `mise run check:contracts`
- local end-to-end generation/publish simulation: first publish writes one two-file orphan commit; unchanged second publish is skipped
- bootstrapped `star-history` branch and verified both raw SVG URLs return HTTP 200