### PR TITLE
fix(ci): require star history credential

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -19,14 +19,30 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+    outputs:
+      configured: ${{ steps.credential.outputs.configured }}
     steps:
+      - name: Check star history credential
+        id: credential
+        env:
+          STAR_HISTORY_TOKEN: ${{ secrets.STAR_HISTORY_TOKEN }}
+        run: |
+          if [ -z "$STAR_HISTORY_TOKEN" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::STAR_HISTORY_TOKEN is not configured; keeping the existing Star History chart."
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Set up Go
+        if: steps.credential.outputs.configured == 'true'
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "1.27.0"
           cache: false
 
       - name: Fetch reviewed star-history generator
+        if: steps.credential.outputs.configured == 'true'
         env:
           STAR_HISTORY_SOURCE_SHA: 8b1f26dc5e9a17caa75da9351b688509ef312811
         run: |
@@ -38,8 +54,9 @@ jobs:
           git -C "$source_dir" checkout --quiet --detach FETCH_HEAD
 
       - name: Generate light and dark charts
+        if: steps.credential.outputs.configured == 'true'
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.STAR_HISTORY_TOKEN }}
         run: |
           output_dir="$RUNNER_TEMP/star-history-output/assets"
           mkdir -p "$output_dir"
@@ -50,6 +67,7 @@ jobs:
             -out-dark "$output_dir/star-history-dark.svg"
 
       - name: Upload generated charts
+        if: steps.credential.outputs.configured == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: star-history-charts
@@ -60,6 +78,7 @@ jobs:
   publish:
     name: Publish charts
     needs: generate
+    if: needs.generate.outputs.configured == 'true'
     runs-on: macos-15
     timeout-minutes: 5
     permissions:

--- a/.trellis/spec/backend/github-ci-workflow.md
+++ b/.trellis/spec/backend/github-ci-workflow.md
@@ -147,6 +147,16 @@ Classification invariants:
 - missing revisions, non-commit objects, malformed diff output, unsafe paths,
   duplicate flags, and option injection fail closed.
 
+`star-history.yml` is repository automation rather than Required CI authority.
+GitHub's built-in `GITHUB_TOKEN` is not an owner/collaborator credential for the
+restricted stargazer timeline endpoint, so exact chart generation uses the
+repository secret `STAR_HISTORY_TOKEN`. Keep that credential out of the
+publishing job: generation is read-only at the workflow-permission layer, while
+the separate publisher uses only its job-local `contents: write` built-in token
+to refresh the unprotected `star-history` data branch. When the secret is not
+configured, the workflow preserves the existing chart and exits successfully
+with a warning rather than publishing partial or fabricated history.
+
 The classifier's `forceFull` is path-derived only. Event policy is applied by
 the Required workflow after classification:
 

--- a/tests/githubWorkflowTriggers.test.ts
+++ b/tests/githubWorkflowTriggers.test.ts
@@ -177,11 +177,17 @@ describe("GitHub workflow trigger policy", () => {
       "generate:\n    name: Generate charts\n    runs-on: macos-15",
     );
     expect(source).toContain(
-      "generate:\n    name: Generate charts\n    runs-on: macos-15\n    timeout-minutes: 10\n    permissions:\n      contents: read",
+      "generate:\n    name: Generate charts\n    runs-on: macos-15\n    timeout-minutes: 10\n    permissions:\n      contents: read\n    outputs:\n      configured: ${{ steps.credential.outputs.configured }}",
     );
     expect(source).toContain(
-      "publish:\n    name: Publish charts\n    needs: generate\n    runs-on: macos-15\n    timeout-minutes: 5\n    permissions:\n      contents: write",
+      "publish:\n    name: Publish charts\n    needs: generate\n    if: needs.generate.outputs.configured == 'true'\n    runs-on: macos-15\n    timeout-minutes: 5\n    permissions:\n      contents: write",
     );
+    expect(source).toContain(
+      "STAR_HISTORY_TOKEN: ${{ secrets.STAR_HISTORY_TOKEN }}",
+    );
+    expect(source).toContain("GITHUB_TOKEN: ${{ secrets.STAR_HISTORY_TOKEN }}");
+    expect(source).not.toContain("GITHUB_TOKEN: ${{ github.token }}");
+    expect(source.match(/secrets\.STAR_HISTORY_TOKEN/g)).toHaveLength(2);
     expect(source).toContain(
       "STAR_HISTORY_SOURCE_SHA: 8b1f26dc5e9a17caa75da9351b688509ef312811",
     );
@@ -189,7 +195,9 @@ describe("GitHub workflow trigger policy", () => {
       "git push --force origin HEAD:refs/heads/star-history",
     );
     expect(source).not.toMatch(/HEAD:refs\/heads\/main/);
-    expect(source).not.toContain("secrets.");
+    const publishStart = source.indexOf("\n  publish:\n");
+    expect(publishStart).toBeGreaterThan(-1);
+    expect(source.slice(publishStart)).not.toContain("secrets.");
 
     const uses = [...source.matchAll(/^\s+uses:\s+(.+)$/gm)].map(
       (match) => match[1],


### PR DESCRIPTION
## Summary

- use a dedicated `STAR_HISTORY_TOKEN` for the restricted GitHub stargazer timeline because hosted `GITHUB_TOKEN` is rejected by GitHub
- preserve the existing chart and emit a warning when that credential is not configured
- keep the dedicated credential out of the publish job; the `star-history` data-branch push still uses only job-local `contents: write`
- record and test the credential boundary

## Evidence

- real workflow dispatch on `main` reproduced `Resource not accessible by integration` for REST and GraphQL with the built-in `GITHUB_TOKEN`
- `mise run test:unit -- tests/githubWorkflowTriggers.test.ts`
- Prettier check for managed changed files
- Ruby YAML parse for `.github/workflows/star-history.yml`
- `mise run check:contracts`