### PR TITLE
ci: refresh star history every three hours

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -2,7 +2,7 @@ name: Star History
 
 on:
   schedule:
-    - cron: "17 3 * * *"
+    - cron: "17 */3 * * *"
   workflow_dispatch:
 
 permissions:

--- a/.trellis/spec/backend/github-ci-workflow.md
+++ b/.trellis/spec/backend/github-ci-workflow.md
@@ -148,6 +148,8 @@ Classification invariants:
   duplicate flags, and option injection fail closed.
 
 `star-history.yml` is repository automation rather than Required CI authority.
+Its scheduled refresh runs every three hours at minute 17, avoiding the
+top-of-hour scheduling peak while keeping the README chart reasonably fresh.
 GitHub's built-in `GITHUB_TOKEN` is not an owner/collaborator credential for the
 restricted stargazer timeline endpoint, so exact chart generation uses the
 repository secret `STAR_HISTORY_TOKEN`. Keep that credential out of the

--- a/tests/githubWorkflowTriggers.test.ts
+++ b/tests/githubWorkflowTriggers.test.ts
@@ -168,7 +168,7 @@ describe("GitHub workflow trigger policy", () => {
         "",
         "on:",
         "  schedule:",
-        '    - cron: "17 3 * * *"',
+        '    - cron: "17 */3 * * *"',
         "  workflow_dispatch:",
       ].join("\n"),
     );


### PR DESCRIPTION
## Summary
- refresh the README Star History chart every three hours at minute 17
- keep the existing manual dispatch and credential/publish boundaries unchanged
- update the workflow trigger contract and CI spec

## Validation
- mise run test:unit tests/githubWorkflowTriggers.test.ts
- mise run check:contracts
- YAML parse + git diff --check