### PR TITLE
feat(frontend): catalog-first agent directory and shell layout fixes

### DIFF
--- a/.trellis/spec/frontend/index.md
+++ b/.trellis/spec/frontend/index.md
@@ -87,9 +87,10 @@ Before changing renderer code:
 The integrated V2 shell has six non-empty product routes: Agents, Models,
 Skills, MCP, Prompts, and Memory. The V3 chrome presents them as three left
 groups (`AI软件配置`, expandable `配置管理`, `记忆模块`); `TopBar` keeps
-Brand and tools only. `/agents` owns the install-state scan projection and a
-four-section configuration shell that delegates writes to the existing
-Skills/MCP/Prompts owners and waits for authoritative readback. All six routes
+Brand and tools only. `/agents` owns a catalog-first directory (all seven
+supported agents, first-entry auto-scan, configure/install gated by
+readiness) and a four-section configuration shell that delegates writes to
+the existing Skills/MCP/Prompts owners and waits for authoritative readback. All six routes
 use bounded feature ports. Prompts manages the seven existing native prompt
 applications; Memory manages four fixed OpenClaw/Hermes long-term resources
 plus OpenClaw daily memory. Browser preview is explicitly native-only and

--- a/.trellis/spec/frontend/reuse.md
+++ b/.trellis/spec/frontend/reuse.md
@@ -26,7 +26,7 @@ cleanup pass after duplication already shipped.
    architecture-fit review.
 4. Existing shared chrome that already matches the job is mandatory. Do not
    fork a page-local copy of `FeatureTabs`, `FeatureSearch`, `FeatureList`,
-   `FeaturePagination`, `AssignmentPanel`, `InstallTargetDialog`, `SelectionLens` / `SelectionLensGroup`, `SplitPanes`,
+   `FeaturePagination`, `AssignmentPanel`, `InstallTargetDialog`, `SelectionLens` / `SelectionLensGroup`, `fySpringTransition` / V2 `Collapsible`, `SplitPanes`,
    `CatalogMasterDetail`, `CatalogOfficialLinks`, `SecretInput`, `ExternalLinkButton`, FeaturePorts,
    or the TRAE/OpenCode `modelsShared` / `modelChips` helpers. Agent / Skills / MCP / Models / Prompts
    product order and display names come from `src/v2/shared/features/directory.ts`.
@@ -144,7 +144,9 @@ conflict with `--fy-*` tokens. Extend this owner with `Button` and
 Phosphor CSR carets.
 
 Related shared owners already in place: `SelectionLens` /
-`SelectionLensGroup` (nav, catalog, UI Lab), `AssignmentPanel` (Skills/MCP
+`SelectionLensGroup` (nav, catalog, UI Lab), `fySpringTransition` in
+`shared/ui/motion.ts` plus V2 `Collapsible` (side-nav 「配置管理」),
+`AssignmentPanel` (Skills/MCP
 switches plus Skills/MCP install/ZIP/restore radio), `InstallTargetDialog`
 (Skills and MCP discovery install), `SplitPanes`, `CatalogMasterDetail`, `CatalogOfficialLinks`,
 `SecretInput`, `ExternalLinkButton`, `CopyablePath`, FeaturePorts, and
@@ -277,6 +279,7 @@ already share `modelsShared`, `modelChips`, `ModelConnectivityTest`, and `feedba
 | A feature page hand-rolls `fy-feature-tab` instead of `FeatureTabs`                                  | Unit/architecture test fails; use `FeatureTabs`                          |
 | Management search is a raw `Input type="search"` on Skills/MCP/Memory/Prompts/Discovery              | Use `FeatureSearch`; leftover `ManagementListSearch` stays leftover-only |
 | V2 imports leftover `src/components` or `src/lib`                                                    | Architecture test fails                                                  |
+| V2 imports leftover `src/components/ui/collapsible.tsx` or `framer-motion` outside `motion.ts`       | Architecture test fails; use V2 `Collapsible` / `fySpringTransition`     |
 | Skills install picker is not `AssignmentPanel mode="radio"`                                          | Reuse test / page test fails; extend `AssignmentPanel`                   |
 | MCP discovery Agent picker is a checkbox grid or defaults to `DEFAULT_NEW_APPS`                      | Page test fails; reuse shared `InstallTargetDialog`                      |
 | Skill/MCP install writes on **安装到 {label}** without showing the destination                       | Page test fails; **下一步** then **确认安装** after `InstallPathPreview` |

--- a/.trellis/spec/frontend/v2-agent-models.md
+++ b/.trellis/spec/frontend/v2-agent-models.md
@@ -536,8 +536,11 @@ fetch/save controls.
 
 ### Writable Models disclosure and draft commit state
 
-- Provider Quick Setup, WorkBuddy, and OpenCode must show `ModelsWriteDisclosure`
-  before a local save can run. Every displayed target comes from a native DTO;
+- Provider Quick Setup, WorkBuddy, and OpenCode must show
+  `ModelsWriteConfirmDialog` after the user clicks save and before a local save
+  can run. The write-target disclosure is not laid out on the page. Cancel
+  closes the dialog and does not start the save; confirm proceeds with the
+  already-validated request. Every displayed target comes from a native DTO;
   React never constructs `~/.codex`, `.workbuddy`, `.config/opencode`, or a
   backup path. Each row visibly labels `将修改` and `备份位置`, and states that
   the single rolling backup is replaced by the immediately previous preimage.
@@ -851,10 +854,10 @@ fetch/save controls.
   carries non-secret live-change state, plan risks remain request-attributed,
   the current draft's key is cleared at terminal handling, and a matching
   `currentId` reread is described only as fixed-ID activation confirmation.
-- Good: a writable Models panel shows native `将修改` / `备份位置` metadata,
-  saves revision N, and becomes clean only if no N+1 edit happened while the
-  request was pending. A successful save also invalidates probe feedback from
-  the old revision.
+- Good: a writable Models panel opens native `将修改` / `备份位置` metadata in
+  the save-confirm dialog, not as page layout, saves revision N, and becomes
+  clean only if no N+1 edit happened while the request was pending. A successful
+  save also invalidates probe feedback from the old revision.
 - Good: Codex/Grok Build probes use Responses, Claude uses Messages with
   Bearer (Quick Setup `ANTHROPIC_AUTH_TOKEN`) and `{base}/v1/messages`, and
   WorkBuddy/OpenCode use streaming Chat Completions (`stream: true`) with

--- a/.trellis/spec/frontend/v2-agent-models.md
+++ b/.trellis/spec/frontend/v2-agent-models.md
@@ -4,16 +4,23 @@
 > `SUPERSEDES_DIRECT_JUMPS_ONLY`: clauses below that restrict the Agent
 > directory to direct capability jumps, forbid a capability-item/configuration
 > surface, or require the previous master/detail-only information architecture
-> are superseded. `/agents` now owns software scan states plus a selected-Agent
-> configuration shell with four sections: `模型 / Skills / MCP / 提示词`, a
-> return-to-directory action, and entry points to the existing global management
-> routes. The capability matrix, native data owners, installer boundaries,
+> are superseded. `/agents` now owns a catalog-first software directory plus a
+> selected-Agent configuration shell with four sections:
+> `模型 / Skills / MCP / 提示词`, a return-to-directory action, and entry
+> points to the existing global management routes.
+> `SUPERSEDES_INSTALLED_ONLY_DIRECTORY`: clauses below that keep the idle
+> directory empty, require a manual first 「开始扫描」, or project only
+> installed cards are superseded. Catalog success shows all seven supported
+> agents immediately; first entry auto-scans readiness in the background;
+> scan/job state gates configure and install/update, not row existence.
+> The capability matrix, native data owners, installer boundaries,
 > unsupported/assisted semantics, browser-authority limits, official links and
 > vendor-specific write rules in this document remain fully authoritative.
 > In particular, V3 must not turn Qoder model writes or TRAE assisted model
 > setup into direct writes, and must not invent prompt writers for unsupported
-> Agent targets. Tests for the old direct-jump-only layout must be replaced by
-> scan/configure state, four-section navigation and capability-honesty tests.
+> Agent targets. Tests for the old direct-jump-only or installed-only layout
+> must be replaced by catalog-first scan/configure/lifecycle and
+> capability-honesty tests.
 
 ## 1. Scope / Trigger
 
@@ -38,8 +45,9 @@ its own capability workflow:
 - QoderWork CN, TRAE Work CN, WorkBuddy, and Grok Build each expose one
   catalog-owned product link; Claude Code exposes separate CLI and Desktop
   links; OpenCode exposes `product` then `cli`. `/agents` no longer uses the
-  old master/detail capability-jump directory. The page owns a scan directory
-  plus a selected-Agent configuration shell with four sections:
+  old master/detail capability-jump directory. The page owns a catalog-first
+  directory of all supported agents plus a selected-Agent configuration shell
+  with four sections:
   `模型 / Skills / MCP / 提示词`. Official product/cli/desktop links, Provider
   summaries, installer panels, Qoder Hooks editors, and MCP validation stay
   on their existing owners (`/models`, `/skills`, `/mcp`, or native
@@ -375,20 +383,43 @@ export type AgentSection = (typeof AGENT_SECTION_IDS)[number];
   Missing or invalid `section` is replaced with `models`. Returning to the
   directory clears both params. The last in-session configuration may be
   restored only when the Agents route becomes active again without a target.
+- Catalog success renders every catalog entry in the existing catalog /
+  `PRODUCT_DIRECTORY` order. Scan state does not decide whether a row exists.
+  Do not filter `not_installed`, `unknown`, `unavailable`, pending, or failed
+  reads out of the list. Do not replace missing software with skeleton cards.
 - Scan state lives in `useAgentDirectoryScan`. Status is
   `idle | scanning | complete`. `start()` is a no-op while `scanning`.
-  Each catalog id refetches `useAgentInstallReadiness`; a query error or
-  thrown refetch is a technical failure, not an install-state card.
-- Completed and in-progress lists project only
-  `installState === "installed" || installState === "installed_not_runnable"`.
-  `not_installed`, `unknown`, missing results, and failed reads never enter
-  the normal software cards. Filter in TypeScript; do not hide rows with CSS.
+  First directory entry on a mounted Agents page session auto-starts one
+  background scan (`autoStart: true`); returning to `/agents` while the
+  keep-alive page instance survives must not unconditionally rescan. Manual
+  「重新扫描」 remains. Each catalog id refetches `useAgentInstallReadiness`;
+  a query error or thrown refetch is a technical failure, never converted to
+  `not_installed`, and never drops the row.
+- Per-row overlay (`observeAgentDirectoryRow`) is pending until that id
+  settles. 「进行配置」 is enabled only when existence is proven:
+  `installState === "installed" || installState === "installed_not_runnable"`,
+  including a retained successful result while a later scan is refreshing.
+  Pending, `not_installed`, `unknown`, `unavailable`, read failure, and an
+  in-flight install/update keep configure disabled.
+- Lifecycle slot sits to the left of 「进行配置」. Generic agents use
+  `FeaturePorts.agentInstallReadiness` through `useAgentLifecycleAction`.
+  Visible 一键安装 / 一键更新 come only from `allowedActions` plus the
+  current install/updateState (install when `not_installed` and `install` is
+  allowed; update when existence is proven, `updateState === update_available`,
+  and `update` is allowed). Backend omission is not a fake button.
+  Generic jobs show the real stage and never invent a percent. After terminal
+  success/failure/cancel/timeout the UI rereads readiness (`applyReadiness`);
+  it must not set an optimistic installed flag.
+- Codex install/update stay on `useCodexDesktopInstaller` /
+  `FeaturePorts.codexDesktop`. Directory Codex cards project that view model
+  (`projectCodexDirectoryAction`) and may show the VM's real percent; they
+  must not start a generic Agent job or copy the downloader.
 - A complete scan with zero successful reads uses the error notice and keeps
   the previous successful result set when one exists. Partial read failures
-  use a warning and still show the successful installed cards.
-- Directory cards use catalog `displayName` plus `进行配置`. The
-  configuration shell header shows brand + display name + `返回`, then
-  `FeatureTabs` for `模型 / Skills / MCP / 提示词`.
+  use a warning; every catalog row remains visible.
+- Directory cards use catalog `displayName` plus the lifecycle slot and
+  「进行配置」. The configuration shell header shows brand + display name +
+  `返回`, then `FeatureTabs` for `模型 / Skills / MCP / 提示词`.
 - Models section is observation-only. It may list native/provider snapshots
   and link to `/models?target=<modelTarget>`. It must not write models,
   mount Provider quick setup, or turn Qoder `unsupported` / TRAE `assisted`
@@ -779,6 +810,14 @@ fetch/save controls.
 | Native observation fails on Models                                                                                           | Show controlled unavailable/unknown; never infer absence                                                   |
 | Runtime value is unknown                                                                                                     | Preserve `null`/`unverified`; never display "not installed"                                                |
 | Agent directory mounts Hooks editor, MCP validation, observation, or unsupported lists                                       | Page test fails; those surfaces stay off the Agent directory                                               |
+| Agent directory hides not-installed/unknown/failed rows or waits for scan before showing catalog cards                       | Page/browser test fails; catalog success shows all seven rows immediately                                  |
+| First `/agents` entry requires a manual 「开始扫描」 before readiness reads                                                  | Page test fails; the mounted Agents page auto-starts one background scan                                   |
+| 「进行配置」 is enabled before `installed` / `installed_not_runnable` (including retained success)                           | Page test fails; pending/not-installed/unknown/unavailable/error stay gated                                |
+| Directory shows 一键安装/一键更新 the backend omitted from `allowedActions`                                                  | Page test fails; generic actions follow `allowedActions`, Codex follows the desktop installer VM           |
+| Generic Agent job UI invents a download percent                                                                              | Page/hook test fails; generic progress is stage-only                                                       |
+| Directory treats action success as installed without readiness/Codex reread                                                  | Page test fails; `applyReadiness` / installer refresh is the authority                                     |
+| Directory Codex row starts `start_agent_action` for install/update                                                           | Page test fails; Codex stays on `codexDesktop`                                                             |
+| Browser Provider/WorkBuddy/OpenCode save skips `保存前确认` / `确认保存`                                                    | Browser test fails; the dialog is the write-target disclosure, not optional chrome                         |
 | Non-Codex Agent detail omits 「产品介绍」 or Codex detail shows that region                                                  | Page test fails; intros are page-local copy, never catalog `description`                                   |
 | Agent directory intro or Codex installer copy names FyAgent                                                                  | Intro/page/installer test fails; Agent directory copy describes the third-party product only               |
 | QoderWork CN catalog description or Agent intro mentions Hooks                                                               | Catalog/intro test fails; Qoder user-facing copy must not name Hooks                                       |
@@ -825,6 +864,12 @@ fetch/save controls.
 
 ## 5. Good / Base / Bad Cases
 
+- Good: `/agents` catalog success shows all seven software cards immediately,
+  auto-starts one background readiness scan, enables 「进行配置」 only after
+  `installed` / `installed_not_runnable` (kept during rescan refresh), shows
+  一键安装/一键更新 only from `allowedActions` or the Codex desktop installer
+  projection, and rereads authority after an action instead of flipping an
+  optimistic installed flag.
 - Good: `/models` opens on QoderWork CN at the top, all seven local icons
   render, Qoder states 官方不支持第三方模型配置, does not render 「管理 MCP」
   or 「打开官方设置」 or 「测试连通」. TRAE Models has no
@@ -918,6 +963,10 @@ Required focused coverage includes:
   full rollback, rollback-partial structured outcome, secret-free errors,
   native `writeTargets`, targeted live preservation for Claude/Codex/Grok
   fixtures, exact rolling backups, and backup-failure no-primary-write;
+  browser Provider/WorkBuddy/OpenCode saves click `确认保存` on
+  `保存前确认` before Change Plan `确认应用` or the atomic apply; they must
+  not click a CSS-class primary button inside the panel (the header, probe,
+  and installer can share that class);
   Codex image-extension derivation must write `experimental_bearer_token`
   when `requires_openai_auth` is false and must keep the key in `auth.json`
   only when image-extension is off;
@@ -936,6 +985,13 @@ Required focused coverage includes:
   target panels; the other primary routes keep the same in-session page.
   Secrets stay in component memory only. Immediate WorkBuddy
   existing-model delete after an unrecoverable-delete confirmation.
+- Agent directory catalog-first coverage: seven articles after catalog
+  success, first-entry auto-scan, per-row pending/scanning, configure only
+  when `installed` / `installed_not_runnable` (retained during rescan),
+  一键安装/一键更新 only from `allowedActions` or the Codex desktop
+  installer projection, generic jobs show stage not percent, action success
+  requires authoritative readback, and technical failure is not rendered as
+  not-installed or removed from the list.
 - Agent readiness exact seven-ID/exact-key/sensitive-field-negative coverage,
   closed `startAction`/`cancelAction`/`getActionJob` wires, opaque
   `expectedReleaseId` grammar, `allowedActions` as the only control source,
@@ -972,10 +1028,12 @@ Required focused coverage includes:
   Claude, Codex, and Grok Build all expose 「拉取模型」.
   Claude shows a warn-only explicit `/v1` pathname notice and a placeholder
   without `/v1`.
-  Agent directory tests prove only `direct` capability jumps, no capability-item
-  grid or catalog description, shared official
-  primary buttons, page-local 「产品介绍」 on non-Codex details, Codex without
-  that region, no FyAgent host copy on Agent directory surfaces, and the absence of observation/Hooks/MCP panels. Product
+  Agent directory tests prove catalog-first seven-row presence, auto-scan,
+  configure gating, honest install/update controls, four-section navigation,
+  capability honesty, shared official primary buttons on Models, page-local
+  「产品介绍」 on non-Codex details, Codex without that region, no FyAgent
+  host copy on Agent directory surfaces, and the absence of
+  observation/Hooks/MCP panels. Product
   pages have no outer h1/subtitle.
 
 Browser tests prove renderer/IPC wiring only. Rust tests prove service/command
@@ -1005,6 +1063,27 @@ await ports.agentInstallReadiness.startAction({
   agentId: "workbuddy",
   action: "install",
   expectedReleaseId: readiness.releaseId ?? undefined,
+});
+```
+
+Wrong: hide not-installed agents until scan completes, or mark a row
+installed from the action job without rereading readiness.
+
+```ts
+const cards = entries.filter((entry) =>
+  isInstalled(scan.results[entry.id]?.installState),
+);
+setInstalled(true); // after startAction succeeded, before get()
+```
+
+Correct: catalog entries always render; scan/job state is an overlay;
+configure and install/update follow authoritative readiness / Codex local
+status.
+
+```ts
+entries.map((entry) => {
+  const row = observeAgentDirectoryRow(entry.id, scan.state);
+  return <AgentDirectoryCard entry={entry} observation={row} />;
 });
 ```
 

--- a/.trellis/spec/frontend/v2-shell.md
+++ b/.trellis/spec/frontend/v2-shell.md
@@ -308,8 +308,10 @@ L3 interactive glass       selected lens, tools, tooltip, and popover
   glass edge, an inset highlight, and a depth shadow. Do not use an opaque
   white dashboard, selected underline, rainbow/chromatic effects, or fake
   native chrome.
-- Use `@samasante/liquid-glass` only behind `LiquidGlassLens`. Mount at most one
-  production instance, inside the active `NavLink`; do not stretch it across
+- Use `@samasante/liquid-glass` only behind `LiquidGlassLens`. Do not wrap
+  production navigation labels in `LiquidGlassLens`: SVG refraction smears the
+  selected text. Production selected state is the `SelectionLens` overlay plus
+  CSS. The UI Lab may mount one isolated specimen. Do not stretch a lens across
   the navigation track, tools, popovers, content plane, or background.
 - Use `SelectionLens` for interruptible exclusive option tracks: primary nav,
   catalog lists, feature tabs, feature lists, and UI Lab tabs. Feature pages
@@ -334,8 +336,9 @@ L3 interactive glass       selected lens, tools, tooltip, and popover
   collapse to the track origin (`inset`, `inset`). Do not give catalog rails a
   second slider. Do not interpolate size with `transform: scale`.
 - The `NavLink` owns hit area, focus, accessible name, and `aria-current`.
-  Refraction is decorative enhancement. Project CSS must independently express
-  tint, selected border/color/shadow, edge/highlight, and backdrop fallback.
+  Selected labels stay ordinary CSS text. Do not wrap them in `LiquidGlassLens`.
+  Project CSS must independently express tint, selected border/color/shadow,
+  edge/highlight, and backdrop fallback.
 - Keep broad structural glass in CSS. SVG filters are not a substitute for
   accessible state and must not be animated across layout or multiplied across
   controls. Do not put the SVG `Glass` node on the sliding pill, and do not
@@ -412,7 +415,7 @@ Agent/Models, Skills, and MCP ports do not by themselves make it Release-ready.
 | A `layoutId` pill uses non-uniform scale with `backdrop-filter`            | Architecture test fails; overlay must spring `left`/`top`/`width`/`height` and must not animate `transform: scale` |
 | Changing the active option remounts the overlay or restarts from `{width:0}` | Unit test fails; the same overlay node must keep identity and retarget from current geometry |
 | First show or show-after-`hidden` collapses to the track origin (`inset`, `inset`) | Unit and architecture tests fail; appear must use `selectionLensCollapsedOrigin` of the active host |
-| Any normal production route                                            | Exactly one active primary link, one production `LiquidGlassLens`, and one nav `SelectionLens` overlay; other tracks may each have their own pill |
+| Any normal production route                                            | Exactly one active primary link and one nav `SelectionLens` overlay; no production `LiquidGlassLens`; other tracks may each have their own pill |
 | UI Lab development route                                               | No primary link active; the lab may render one isolated lens specimen              |
 | SVG/backdrop filter unavailable                                        | CSS tint, edge, shadow, focus, and selected state remain readable                  |
 | React StrictMode or repeated ready calls                               | One native `frontend-deeplink-ready` emission per renderer lifetime                |
@@ -436,10 +439,10 @@ Agent/Models, Skills, and MCP ports do not by themselves make it Release-ready.
 ## 5. Good / Base / Bad Cases
 
 - **Good:** Clicking `AI软件配置` changes the hash to `#/agents`; that
-  `NavLink` alone owns `aria-current="page"`, contains the sole production
-  `LiquidGlassLens` for that leaf, remains keyboard-focusable, and the left
-  nav track keeps one overlay `SelectionLens` aligned to the active leaf or
-  the collapsed configuration toggle. A second click before the spring
+  `NavLink` alone owns `aria-current="page"`, keeps a sharp CSS label, remains
+  keyboard-focusable, and the left nav track keeps one overlay `SelectionLens`
+  aligned to the active leaf or the collapsed configuration toggle. Production
+  routes mount no `LiquidGlassLens`. A second click before the spring
   settles keeps the same overlay node and continues from its current box.
   Opening a page with a catalog or feature rail expands that page's pill
   from the selected row's top-left, not from the rail's parent origin.
@@ -469,8 +472,8 @@ mise run build:renderer
 ```
 
 - Unit tests assert default/wildcard redirects, six-route order, Router-owned
-  selection, `aria-current`, a sole production `LiquidGlassLens`, one nav
-  `SelectionLens` overlay on the track, the L1 control spring, stable overlay
+  selection, `aria-current`, no production `LiquidGlassLens` on nav labels, one
+  nav `SelectionLens` overlay on the track, the L1 control spring, stable overlay
   node identity when the active option changes, appear origin at the active
   host top-left via `selectionLensCollapsedOrigin` (not the track origin), no
   lens outside a
@@ -551,7 +554,7 @@ the pill expands from that host's top-left, not from the track origin.
     {({ isActive }) => (
       <>
         <SelectionLens active={isActive} />
-        {isActive ? <LiquidGlassLens>{item.label}</LiquidGlassLens> : item.label}
+        <span className="fy-side-navigation-item-label">{item.label}</span>
       </>
     )}
   </NavLink>
@@ -584,8 +587,8 @@ await getCurrentWindow().setDecorations(false);
 return <button aria-label="Close" onClick={closeWindow} />;
 ```
 
-Correct: let Router own the semantic link, wrap only its active label with the
-bounded internal lens, and keep caption buttons outside React. Overlay drag
+Correct: let Router own the semantic link, keep the selected label as CSS
+text, and keep caption buttons outside React. Overlay drag
 chrome stays in `TopBar.tsx`; `titleBarStyle: Overlay` and window geometry
 stay with the host.
 
@@ -594,7 +597,7 @@ stay with the host.
   {({ isActive }) => (
     <>
       <SelectionLens active={isActive} />
-      {isActive ? <LiquidGlassLens>{item.label}</LiquidGlassLens> : item.label}
+      <span className="fy-side-navigation-item-label">{item.label}</span>
     </>
   )}
 </NavLink>

--- a/.trellis/spec/frontend/v2-shell.md
+++ b/.trellis/spec/frontend/v2-shell.md
@@ -345,6 +345,12 @@ L3 interactive glass       selected lens, tools, tooltip, and popover
   host (that host's top-left, size 0) and springs open in place. Do not
   collapse to the track origin (`inset`, `inset`). Do not give catalog rails a
   second slider. Do not interpolate size with `transform: scale`.
+  `SelectionLensGroup` must retarget that overlay when in-scope layout moves
+  the host, including sibling reflow from V2 `Collapsible` height. Observing
+  only the host and the track box is not enough: neither resizes when
+  「配置管理」 expands and 「记忆模块」 translates down inside a
+  `min-height: 100%` track. Observe in-scope descendants (skip the overlay
+  node). Do not use `layoutId` to chase that translation.
 - The `NavLink` owns hit area, focus, accessible name, and `aria-current`.
   Selected labels stay ordinary CSS text. Do not wrap them in `LiquidGlassLens`.
   Project CSS must independently express tint, selected border/color/shadow,
@@ -428,6 +434,7 @@ Agent/Models, Skills, and MCP ports do not by themselves make it Release-ready.
 | V2 imports `framer-motion` outside `shared/ui/motion.ts`            | Architecture test fails; SelectionLens and Collapsible consume the motion owner |
 | Changing the active option remounts the overlay or restarts from `{width:0}` | Unit test fails; the same overlay node must keep identity and retarget from current geometry |
 | First show or show-after-`hidden` collapses to the track origin (`inset`, `inset`) | Unit and architecture tests fail; appear must use `selectionLensCollapsedOrigin` of the active host |
+| 「记忆模块」 is selected, then 「配置管理」 expands | Overlay follows the memory host; unit tests observe in-scope descendants and retarget on sibling resize; Playwright keeps the pill on the memory link |
 | Any normal production route                                            | Exactly one active primary link and one nav `SelectionLens` overlay; no production `LiquidGlassLens`; other tracks may each have their own pill |
 | UI Lab development route                                               | No primary link active; the lab may render one isolated lens specimen              |
 | SVG/backdrop filter unavailable                                        | CSS tint, edge, shadow, focus, and selected state remain readable                  |
@@ -498,6 +505,9 @@ mise run build:renderer
   caption buttons, six non-empty product pages, and idempotent ready behavior.
   Browser/jsdom shells have no drag strip; native macOS may show one inert
   V2 `TopBar` Overlay strip above the chrome row.
+  Side-navigation tests cover collapsing 「配置管理」 while a configuration
+  leaf is active, and expanding it while 「记忆模块」 is active so the overlay
+  stays on the memory host instead of the pre-expand coordinate.
 - Architecture/static tests reject legacy dependencies, upward layer imports,
   direct Tauri imports outside `shared/platform/tauri`, and the retired
   window-frame contract. They keep `framer-motion` behind
@@ -515,7 +525,9 @@ mise run build:renderer
   the left navigation; the three navigation groups and TopBar tools are
   reachable; all six product pages non-empty;
   hash/selected/ARIA/lens agreement;
-  left-navigation keyboard order on the default shell route; absence of fake
+  left-navigation keyboard order on the default shell route; memory selected
+  then 「配置管理」 expanded keeps the nav overlay on the memory link;
+  absence of fake
   chrome; and no
   console, page, or framework-overlay error.
 - UI Lab browser tests cover translucent surfaces, backdrop or meaningful CSS
@@ -574,6 +586,22 @@ the pill expands from that host's top-left, not from the track origin.
     )}
   </NavLink>
 </SelectionLensGroup>
+```
+
+Wrong: observe only the overlay host and the track box. Expanding
+「配置管理」 translates 「记忆模块」 without resizing either node, so the
+pill stays between 模型管理 and Skills 管理.
+
+```ts
+observer.observe(scope);
+observer.observe(host);
+```
+
+Correct: observe in-scope descendants except the overlay, then spring the
+same overlay to the host's new box.
+
+```ts
+observeLayoutSubtree(scope, observer);
 ```
 
 Wrong: import `framer-motion` in a widget, or hide 「配置管理」 with only

--- a/.trellis/spec/frontend/v2-shell.md
+++ b/.trellis/spec/frontend/v2-shell.md
@@ -154,7 +154,11 @@ reimplement this origin. Do not use Motion `layoutId` or `LayoutGroup` scale
 projection for this pill: non-uniform `scaleX` plus `backdrop-filter` smears
 the capsule and the label. `SelectionLens` only registers the active host; it
 is not the painted node. Do not import `framer-motion` outside
-`shared/ui/SelectionLens.tsx`. The lifecycle-ready
+`shared/ui/motion.ts`. That file owns `fySpringTransition`
+(`stiffness: 520`, `damping: 42`, `mass: 0.62`) and re-exports `animate` /
+`motion` / `useMotionValue` / `useReducedMotion`. `SelectionLens` and the V2
+`Collapsible` adapter both consume it; pages and widgets import the adapter,
+not Motion. The lifecycle-ready
 operation returns `Promise<void>` and owns a module-level promise guard. Its
 native side effect remains the existing payload-free `frontend-deeplink-ready`
 event.
@@ -256,8 +260,14 @@ input to `PersistentPrimaryOutlet`.
   left-navigation controls. `SideNavigation` owns `ArrowUp` / `ArrowDown` /
   `Home` / `End` among currently visible controls. The configuration toggle
   uses `ArrowRight` to expand or enter the leaf list, and `ArrowLeft` /
-  `Escape` to collapse and return focus to the toggle. Native caption
-  controls are outside the renderer and outside this tab-order contract.
+  `Escape` to collapse and return focus to the toggle. 「配置管理」
+  open/close uses the V2 `Collapsible` adapter (`@radix-ui/react-collapsible`
+  plus `fySpringTransition`); do not import leftover
+  `src/components/ui/collapsible.tsx` and do not invent a second cubic-bezier.
+  Closed or closing leaves are `hidden` / `inert` / `aria-hidden` and must
+  not enter Tab or arrow-key cycling, including during the close animation.
+  Native caption controls are outside the renderer and outside this tab-order
+  contract.
 
 ### Window chrome
 
@@ -350,9 +360,12 @@ L3 interactive glass       selected lens, tools, tooltip, and popover
   legacy `src/index.css`, dark-theme tokens, UI wrappers, or `src/i18n/**`.
 - Namespace V2 selectors. Do not use `transition: all`, animate the
   `backdrop-filter` property, globally hide scrollbars, or ignore
-  `prefers-reduced-motion`. `SelectionLens` is the only approved layout
-  animation; it springs overlay geometry and collapses to an instant swap when
-  the user prefers reduced motion. Never combine `layoutId` scale projection
+  `prefers-reduced-motion`. Approved layout motion lives in
+  `shared/ui/motion.ts`: `SelectionLens` springs overlay geometry and V2
+  `Collapsible` springs 「配置管理」 height/caret from the same
+  `fySpringTransition`. Both collapse to an instant or near-instant swap when
+  the user prefers reduced motion. Do not add another spring token or CSS
+  `ease` for that disclosure. Never combine `layoutId` scale projection
   with `backdrop-filter` on the same node. Fill-height master/detail columns
   use shared `SplitPanes` (`shared/ui/split`); do not copy catalog rail
   classes onto Skills, MCP, Prompts, or Memory. Split-pane children fill the
@@ -412,7 +425,7 @@ Agent/Models, Skills, and MCP ports do not by themselves make it Release-ready.
 | Condition                                                              | Required result                                                                    |
 | ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
 | Empty hash, root route, or unknown route                               | Redirect to `#/agents`; Agent directory alone has `aria-current="page"`            |
-| A `layoutId` pill uses non-uniform scale with `backdrop-filter`            | Architecture test fails; overlay must spring `left`/`top`/`width`/`height` and must not animate `transform: scale` |
+| V2 imports `framer-motion` outside `shared/ui/motion.ts`            | Architecture test fails; SelectionLens and Collapsible consume the motion owner |
 | Changing the active option remounts the overlay or restarts from `{width:0}` | Unit test fails; the same overlay node must keep identity and retarget from current geometry |
 | First show or show-after-`hidden` collapses to the track origin (`inset`, `inset`) | Unit and architecture tests fail; appear must use `selectionLensCollapsedOrigin` of the active host |
 | Any normal production route                                            | Exactly one active primary link and one nav `SelectionLens` overlay; no production `LiquidGlassLens`; other tracks may each have their own pill |
@@ -478,7 +491,9 @@ mise run build:renderer
   host top-left via `selectionLensCollapsedOrigin` (not the track origin), no
   lens outside a
   group, no `layoutId` / `LayoutGroup` on the pill adapter, left-navigation
-  group / leaf / expanded / collapsed / keyboard behavior, stable accessible
+  group / leaf / expanded / collapsed / keyboard behavior, `aria-expanded` on
+  「配置管理」, closed/closing leaves excluded from Tab/arrow cycling,
+  reduced-motion instant collapse, stable accessible
   names, inert tool clicks, absence of custom
   caption buttons, six non-empty product pages, and idempotent ready behavior.
   Browser/jsdom shells have no drag strip; native macOS may show one inert
@@ -486,9 +501,9 @@ mise run build:renderer
 - Architecture/static tests reject legacy dependencies, upward layer imports,
   direct Tauri imports outside `shared/platform/tauri`, and the retired
   window-frame contract. They keep `framer-motion` behind
-  `shared/ui/SelectionLens.tsx`, reject `layoutId` / `LayoutGroup` on that
-  adapter, reject collapsing the pill to `left.set(inset)` / `top.set(inset)`,
-  and keep `@samasante/liquid-glass` behind
+  `shared/ui/motion.ts`, reject `layoutId` / `LayoutGroup` on the
+  SelectionLens adapter, reject collapsing the pill to `left.set(inset)` /
+  `top.set(inset)`, and keep `@samasante/liquid-glass` behind
   `LiquidGlassLens`. They keep HTTP(S) jumps on `ExternalLinkButton` /
   `useOpenExternal`. They positively allow only the exact neutral Codex
   shared boundary and negatively prove that a neighboring shared path remains
@@ -559,6 +574,22 @@ the pill expands from that host's top-left, not from the track origin.
     )}
   </NavLink>
 </SelectionLensGroup>
+```
+
+Wrong: import `framer-motion` in a widget, or hide 「配置管理」 with only
+instant `hidden` and a separate CSS `ease` on the caret.
+
+```tsx
+import { motion } from "framer-motion";
+<ul hidden={!expanded}>{items}</ul>
+```
+
+Correct: pages/widgets import V2 `Collapsible`; only `shared/ui/motion.ts`
+imports Motion. Height and caret share `fySpringTransition`. Closed leaves
+stay out of keyboard cycling.
+
+```tsx
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "../../shared/ui/Collapsible";
 ```
 
 Wrong: give split-pane children `height: 100%` with visible overflow, so

--- a/.trellis/spec/frontend/v2-skills-mcp.md
+++ b/.trellis/spec/frontend/v2-skills-mcp.md
@@ -527,6 +527,12 @@ function ExternalLinkButton(props: {
   transports show that no local directory exists. Skill 市场 installs use
   source **从 Skill 市场安装**, not GitHub. `.fy-feature-code` and
   `.fy-feature-path-value` have no dark pill background.
+  `.fy-feature-definition` must keep that copy action inside the info card
+  in the two-column info grid (`min-width: 1181px`). Do not floor the label
+  column at `90px` while the value column can shrink to `0`: **复制** then
+  paints past the card. Size labels with `minmax(0, max-content)` and give
+  copy-only `dd` cells `min-width: min-content`. Do not `overflow: hidden`
+  the card to clip the button.
 - MCP has permanent Installed and Discover tabs. Discover is a static curated
   catalog of about 20–30 installable items: each card is either one-click or a
   credential/config form. Discover classification is only “直接安装” versus
@@ -619,6 +625,7 @@ function ExternalLinkButton(props: {
 | Skill/MCP install writes after picking a target, before path confirm | Page test fails; **下一步** must show the destination; host waits for **确认安装** |
 | MCP/Skills assignment order is alphabetical or Claude-first      | Page/component test fails; order must match Agent catalog                 |
 | `.fy-feature-list` is restored to CSS Grid                       | List rows overlap because `SelectionLens` occupies a grid track           |
+| `.fy-feature-definition` floors labels at `90px` in info cards   | Copy-only **复制** overflows the card in the two-column info grid         |
 | A supported app is missing from the local icon map               | Type/asset test fails; never render a remote fallback or broken image     |
 | An assignment icon contributes an accessible name                | Component accessibility test fails; switch text remains the sole name     |
 | Viewport changes between two- and three-column layouts           | Render exactly one panel: seven unique Skill or seven unique MCP switches |
@@ -775,11 +782,15 @@ git diff --check
   summary line, Skills page-level discovery
   scroll, MCP `.fy-feature-discovery-scroll` overflow, and no overflow on
   `.fy-feature-detail-scroll`.
+  CSS tests keep `.fy-feature-definition` at
+  `minmax(0, max-content) minmax(0, 1fr)` with copy-only `dd` `min-width:
+  min-content` so **复制** stays inside the info card.
 - Browser tests cover `900x600`, `1152x640`, `1232x700`, and `1440x900`, with
   populated two-/three-column layouts, a single correctly-sized assignment
   panel whose switch accessible names match catalog order, visible split
   separators above 760px, assignment rows contained
-  inside their pane, no overlapping list rows, no overflow, no secret
+  inside their pane, no overlapping list rows, no overflow, copy actions
+  contained in source info cards, no secret
   rendering, exact invoke payloads, and authoritative refetch.
 - Browser tests do not replace native Windows Tauri/WebView2 acceptance,
   actual filesystem/config writes, or 125%/150% display-scale review.
@@ -858,6 +869,28 @@ Correct: use a column flex track; the lens stays out of flow.
 .fy-feature-list {
   display: flex;
   flex-direction: column;
+}
+```
+
+Wrong: floor info-card labels at `90px` so the value column can collapse
+under the copy button.
+
+```css
+.fy-feature-definition {
+  grid-template-columns: minmax(90px, max-content) minmax(0, 1fr);
+}
+```
+
+Correct: let labels shrink and keep a copy-only path at its min-content
+width.
+
+```css
+.fy-feature-definition {
+  grid-template-columns: minmax(0, max-content) minmax(0, 1fr);
+}
+.fy-feature-definition
+  dd:has(> .fy-feature-path:not(:has(.fy-feature-path-value))) {
+  min-width: min-content;
 }
 ```
 

--- a/.trellis/tasks/archive/2026-08/08-26-agent-directory-lifecycle-ux/check.jsonl
+++ b/.trellis/tasks/archive/2026-08/08-26-agent-directory-lifecycle-ux/check.jsonl
@@ -1,0 +1,4 @@
+{"file":".trellis/spec/frontend/reuse.md","reason":"检查是否新增重复组件、依赖或 page-local 轮子"}
+{"file":".trellis/spec/frontend/v2-shell.md","reason":"检查侧栏键盘/ARIA/Motion/reduced-motion 与架构测试"}
+{"file":".trellis/tasks/08-26-agent-directory-lifecycle-ux/research/execution-context.md","reason":"检查 7 项目录、readiness/action 真实性、配置门禁、Codex special owner 与安全边界"}
+{"file":".trellis/spec/backend/codex-desktop-installer.md","reason":"检查 Codex 没有被通用 Agent installer 吞并或复制下载链"}

--- a/.trellis/tasks/archive/2026-08/08-26-agent-directory-lifecycle-ux/design.md
+++ b/.trellis/tasks/archive/2026-08/08-26-agent-directory-lifecycle-ux/design.md
@@ -1,0 +1,129 @@
+# Technical Design — AI 软件目录生命周期 UX
+
+## 1. Design Intent
+
+本设计不新增一个“Agent 管理框架”，而是把现有四层权威状态组合成一个渐进 UI：
+
+1. **Catalog layer** — 决定有哪些软件、顺序、名称和描述。
+2. **Readiness layer** — 决定某个软件是否已安装、是否可更新、哪些 lifecycle action 被允许。
+3. **Action/job layer** — 决定安装/更新正在做什么以及最终是否结束。
+4. **Configuration layer** — 只有在目录确认软件存在后，才允许进入现有模型/Skills/MCP/提示词配置 shell。
+
+核心原则是单向投影，不做反向猜测：目录不从配置文件推断安装，不从按钮状态推断 action 成功，不从 display name 推断 installer。
+
+## 2. Recommended Architecture (not a frozen file contract)
+
+### 2.1 Directory projection
+
+`AgentDirectory` 应从 catalog entries 直接渲染完整列表。scan controller 只提供每一行的 readiness overlay/state，不再决定“这一行是否存在”。
+
+推荐把 scan controller 的页面消费模型从“installed entries list”调整为“per-agent observation”：
+
+```text
+catalog entry
+  + no result yet            -> queued/scanning presentation
+  + readiness installed      -> configurable presentation
+  + readiness not_installed  -> install/update presentation as allowed
+  + readiness unknown/error  -> blocked/error presentation
+```
+
+具体 TypeScript type、reducer action 名称和是否增加 selector helper 不固定，只要求 derived state 有一个清晰 owner，避免卡片组件散落条件分支。
+
+### 2.2 First-entry progressive scan
+
+保留 TanStack Query 作为 readiness cache/transport owner。现有 `useAgentInstallReadiness(agentId, false)` + `refetch()` 可继续使用；首次目录 mount/active 后由一个一次性 effect 调用现有 `start()` 或等价入口。
+
+“渐进”指每个 promise settle 后立即进入 reducer/cache，而不是等 `Promise.all` 的最终完成才渲染。现有 reducer 已做到 per-item settle，因此优先扩展而非重写。
+
+是否把 7 个读取完全并发、分批、或有限并发属于可替换细节。默认保持简单；只有 profiling 或 backend 证据证明并发造成问题时再加调度。
+
+### 2.3 Lifecycle action adapter
+
+目录需要一个小的 action view model，而不是直接知道两个 installer domain 的内部细节。
+
+推荐组合：
+
+- **Generic Agent path**：从现有 `AgentInstallReadinessSection` 抽取 start/poll/terminal/reread 流程，继续调用 `FeaturePorts.agentInstallReadiness`。
+- **Codex path**：直接复用 `useCodexDesktopInstaller` / `FeaturePorts.codexDesktop`，只做目录行需要的紧凑投影。
+
+页面可消费的 view model 至少应表达：当前可见 primary action（install/update/none）、是否 busy、真实 stage/progress、动作错误，以及 run/retry/cancel（如果当前 backend 真正支持）。字段名和组件拆分允许实现时调整。
+
+不得创建 `startAgentInstall()` 之类绕过现有 FeaturePorts 的第二套 Tauri adapter。
+
+### 2.4 Progress semantics
+
+统一的是“用户知道现在在进行什么”，不是强制统一数据形态：
+
+- Generic Agent snapshot：stage 是唯一事实，显示 stage + spinner/indeterminate feedback。
+- Codex snapshot：沿用既有 percent / bytes / speed；目录可以只显示 percent + concise stage，但来源仍是现有 view model。
+- Immediate CLI action：调用 pending 时显示处理中；返回后马上 authoritative reread。
+
+终态永远触发权威 refresh。UI action success 与 readiness success 是两个不同事件。
+
+### 2.5 Side navigation motion
+
+当前 SelectionLens 的 `selectionLensTransition` 是项目已经调校过的 motion signature。推荐把这个 spring 作为 shared motion token/owner，让 collapsible 内容和 caret 在同源参数下运动。
+
+语义层优先使用已安装的 Radix Collapsible，而不是手写 disclosure：它提供 controlled `open`, `onOpenChange`, `data-state` 和内容尺寸变量。由于 V2 禁止 import legacy UI wrapper，实现应在 V2 shared 层使用 package 或薄 adapter，而不是引用 `src/components/ui/collapsible.tsx`。
+
+现行 V2 shell spec 把 `framer-motion` 限制在 SelectionLens 文件。为了本需求，可以选择以下任一小范围演进：
+
+1. 把 motion token/primitive 抽到一个 V2 shared motion owner，并把静态规则收敛为“Motion 只允许在 reviewed shared motion owners”；或
+2. 在不破坏模块职责的前提下让现有 shared owner 提供 collapsible motion adapter。
+
+推荐 1，因为职责更清楚，但不把文件名写成长期产品契约。
+
+不要用一个新的手调 `cubic-bezier(...)` 假装等价 spring；也不要新增动画依赖。
+
+### 2.6 Accessibility / focus
+
+Radix/trigger 继续承担 disclosure 的 `aria-expanded`/state。现有 SideNavigation 的自定义 ArrowRight/ArrowLeft/Escape/Home/End 语义保留。
+
+关闭动画期间需要保证即将关闭的 leaf 不进入键盘导航计算；实现可依赖 Radix presence/focus semantics，或在 shared adapter 中提供明确的 closed/inert filtering。具体 DOM 结构可变，但测试必须冻结行为而非实现细节。
+
+`prefers-reduced-motion` 直接切换最终布局，spring token 不执行 layout travel。
+
+## 3. State and Action Matrix
+
+| Readiness / job | Left lifecycle slot | Configure | Notes |
+| --- | --- | --- | --- |
+| first scan pending | `正在扫描…` | disabled | row is already visible |
+| read failed / unknown / unavailable | blocked/error status | disabled | never convert to not-installed |
+| not installed + `install` allowed | `一键安装` | disabled | click uses backend-authorized action |
+| not installed + install not allowed | no fake install; honest unavailable state | disabled | optional reason copy |
+| installed + update available + `update` allowed | `一键更新` | enabled | update is optional; config remains valid unless action is running |
+| installed + up-to-date | none | enabled | no redundant install control |
+| action busy | real stage / progress | normally disabled during the mutation | avoid configuring against changing install state |
+| action terminal | refreshing/readback | gated by new authoritative result | no optimistic success |
+
+`installed_not_runnable` 保留当前目录把它视为“存在”的兼容语义；实现若发现某个配置动作实际要求 runnable，应在相应配置 owner 中做更窄门禁，而不是把整个目录状态重新定义。
+
+## 4. Serial Implementation Boundaries
+
+本任务在一个开发分支中串行推进。阶段边界用于控制复杂度和验证范围，不是独立模块契约：
+
+1. **Side navigation motion** — 先收敛 shared motion/collapsible owner 与 SideNavigation 行为，保证键盘、ARIA、reduced-motion 稳定。
+2. **Progressive scan** — 再演进 `useAgentDirectoryScan`，建立 catalog-first、per-row settle、首次自动扫描和 retained result 语义。
+3. **Lifecycle actions** — 抽取/复用 generic action runner，并为 Codex 建立最薄的目录投影；不改 backend contract。
+4. **Directory composition** — 将前三阶段结果接入 `AgentDirectory` 和 `Page.css`，统一 configure gate、安装/更新按钮、busy/progress/error/readback。
+5. **Integration / QA / SPEC** — 更新 unit/browser tests，完成 shell 联动、响应式、能力真实性与最终 spec 收口。
+
+阶段之间允许根据最新代码做小幅合并或调整顺序，只要不改变 PRD 的用户可见结果和安全边界。不要为了阶段形式制造临时 API，也不要保留只服务于“未来 Integration”的包装层。
+
+## 5. Compatibility / Rollback
+
+- 不改 Agent catalog wire contract。
+- 不改 install readiness/action wire contract，除非实现发现真实 backend bug；任何 contract 扩大必须回到规划评审。
+- 不改 Codex installer wire contract。
+- 目录变化是 renderer behavior；按串行阶段保留清晰 diff 和 focused validation，出现回归时优先回退最近阶段的接线，而不是破坏后端安全 contract。
+- 现有 dirty V3 工作需要在开始实现前识别和保护；本任务继续在单一分支中工作，不创建额外 Worktree 来绕开这些改动。
+
+## 6. Open-source / Reuse Decision
+
+本轮无需新依赖：
+
+- Radix Collapsible 已在仓库中，并提供标准 disclosure、controlled state、`data-state` 与内容尺寸变量。
+- Motion/Framer Motion 已在仓库中，physics spring 原生支持 stiffness/damping/mass；现有 SelectionLens 已有满意参数。
+- TanStack Query 已在仓库中，disabled/lazy query + manual refetch 足以支持现有 readiness transport。
+
+因此“再找一个 collapse animation library / lazy loader / installer progress library”都属于重复造轮子。

--- a/.trellis/tasks/archive/2026-08/08-26-agent-directory-lifecycle-ux/implement.jsonl
+++ b/.trellis/tasks/archive/2026-08/08-26-agent-directory-lifecycle-ux/implement.jsonl
@@ -1,0 +1,5 @@
+{"file":".trellis/spec/frontend/reuse.md","reason":"复用优先级、V2 shared owner 与禁止重复造轮子的执行边界"}
+{"file":".trellis/spec/frontend/v2-shell.md","reason":"SideNavigation、SelectionLens、Motion/reduced-motion 与 V2 架构边界"}
+{"file":".trellis/tasks/08-26-agent-directory-lifecycle-ux/research/execution-context.md","reason":"裁剪后的 Agent directory/readiness/action/Codex/motion 稳定执行边界，避免大型 owning spec 注入截断"}
+{"file":".trellis/spec/backend/codex-desktop-installer.md","reason":"Codex 专用 installer owner 与 Agent Catalog 复用边界"}
+{"file":".trellis/tasks/08-26-agent-directory-lifecycle-ux/research/planning-evidence.md","reason":"本任务已完成的本地/官方调研与架构结论，执行方默认直接复用"}

--- a/.trellis/tasks/archive/2026-08/08-26-agent-directory-lifecycle-ux/implement.md
+++ b/.trellis/tasks/archive/2026-08/08-26-agent-directory-lifecycle-ux/implement.md
@@ -1,0 +1,89 @@
+# Implementation Plan — Single Branch / Serial Execution
+
+## Phase 0 — Start Gate
+
+1. 只使用当前任务：`.trellis/tasks/08-26-agent-directory-lifecycle-ux`。
+2. 后续开发只使用一个开发分支；不要创建子任务或并行 Worktree。
+3. 开始修改产品代码前检查当前 working tree，识别已有 V3 Agent/Shell 改动并保护它们，不覆盖用户未授权变更。
+4. 读取本任务 `prd.md`、`design.md`、`research/planning-evidence.md`、`research/execution-context.md` 以及 `implement.jsonl` / `check.jsonl`。
+5. 默认直接采用已经完成的调研和复用方案；只有代码现状与规划冲突、出现真实能力缺口或新的兼容/安全问题时，才做针对性补充调研。
+
+## Phase 1 — Sidebar Collapse Motion
+
+1. 确认 SelectionLens、SideNavigation 和 V2 shared UI 中没有新的等价 owner。
+2. 优先复用现有 Radix Collapsible + Motion；不新增动画/Disclosure 依赖。
+3. 建立或扩展最小 shared motion/collapsible owner，使 SelectionLens 与折叠内容复用同一 spring source。
+4. 将「配置管理」展开/收起接入该 owner；保留 Router active state、`aria-expanded`、ArrowRight / ArrowLeft / Escape / Home / End。
+5. caret 与内容运动保持同源，不保留互相冲突的独立 easing；`prefers-reduced-motion` 直接或近即时切换。
+6. 运行 focused SideNavigation / architecture tests 和 `mise run typecheck:v2`。
+
+**阶段检查点**：没有新增依赖、没有第二套 motion token、键盘/ARIA/reduced-motion 不回归后再继续。
+
+## Phase 2 — Progressive Directory Scan
+
+1. 在现有 `useAgentDirectoryScan` 上最小演进，保留 request-id/stale guard、retained results、single-flight 和 TanStack Query owner。
+2. 让 catalog 决定 7 行是否存在；scan state 只决定每行当前 readiness/pending/error presentation。
+3. 加入首次进入目录的 auto-start gate；注意 V2 keep-alive，避免每次重新显示 `/agents` 都无条件重扫。
+4. 保留 manual rescan；单项 readiness settle 后立即更新该行，不等待全部 promise 完成。
+5. 覆盖 partial failure、all failure、rescan retained result、stale previous request completion。
+6. 运行 focused Agent page/hook Vitest 和 `mise run typecheck:v2`。
+
+**阶段检查点**：首屏目录不再依赖扫描结果，技术失败不会被转换为 not-installed，首次自动扫描只触发一次。
+
+## Phase 3 — Lifecycle Actions / Progress Reuse
+
+1. 检查是否已有 generic Agent action hook；若没有，从 `AgentInstallReadinessSection` 抽取现有 start → poll → terminal → authoritative refresh runner，不复制代码。
+2. generic path 只根据当前 readiness 的 `allowedActions` 暴露 install/update，并继续使用 `FeaturePorts.agentInstallReadiness`。
+3. immediate CLI action 使用 pending → authoritative refresh；有 jobId 的动作展示真实 stage 并处理 terminal/failure/timeout/cancel。
+4. Codex 直接复用 `useCodexDesktopInstaller` / `FeaturePorts.codexDesktop`，目录只消费需要的最小投影；不复制 percent、speed、subscription、downloader 或 release validation。
+5. 不扩大 backend DTO，不为了 UI 伪造 generic numeric progress。
+6. 写 focused tests：install/update、job stage、immediate action、failure/reason、timeout、refresh、Codex owner honesty。
+7. 运行相关 Vitest 和 `mise run typecheck:v2`。
+
+**阶段检查点**：generic/Codex owner 边界清楚，动作终态后一定权威回读，没有 optimistic installed flag。
+
+## Phase 4 — Agent Directory Composition
+
+1. 将 `AgentDirectory` 改为 catalog-driven full list，并接入 per-row scan projection。
+2. 集中派生 configure gate，避免 JSX 多处重复判断：首次未确认 / not-installed / unknown / unavailable / 当前动作中不可配置；已确认存在时按 PRD 兼容语义开放。
+3. 在「进行配置」左侧接 lifecycle slot：扫描中 / 一键安装 / 一键更新 / action stage/progress / failure state。
+4. 未安装 + backend 允许 install 才显示「一键安装」；已安装 + update_available + backend 允许 update 才显示「一键更新」。不支持的平台不显示 fake action。
+5. 调整 `Page.css` action group、responsive 和状态 presentation；继续使用现有 design tokens/primitives，不引入第二设计体系。
+6. 安装/更新成功后只依赖刷新后的 readiness/Codex local state重渲染，不写本地“安装成功”事实。
+7. 更新 Agent page unit tests，删除旧的 idle 空列表 / installed-only 断言，加入完整状态矩阵。
+
+**阶段检查点**：7 行首屏存在、逐项扫描、configure gate、install/update 条件、busy/progress/readback 都能在 unit tests 中独立证明。
+
+## Phase 5 — Browser Integration / SPEC / Final Gate
+
+1. 更新 `tests/v2-browser/agents-v3.spec.ts`：首屏全量、自动 scan、渐进 settle、install/update/readback、partial failure/rescan，并保留 Skills/MCP/Models capability honesty。
+2. 联合运行 SideNavigation/browser shell，确认 collapse animation 不影响 route、focus、active SelectionLens 和 reduced-motion。
+3. 检查 responsive / overflow / error recovery。
+4. 更新 `.trellis/spec/frontend/v2-agent-models.md`，必要时更新 `v2-shell.md` / reuse spec；只记录最终稳定规则，不固化临时 hook 名称或本次串行施工步骤。
+5. 最少运行：
+
+```bash
+mise run typecheck:v2
+mise run test:v2
+mise run test:v2:browser
+mise run build:renderer
+```
+
+6. 根据当时仓库 mandatory gate 补 `mise run check` 或等价 required checks。
+
+## Final Review Checklist
+
+- 没有第二 catalog / installer / query / motion owner。
+- 没有新增不必要依赖。
+- 不支持的平台没有 fake 一键安装。
+- Generic job 没有 fake percentage。
+- Codex 没有复制 downloader/progress engine。
+- action success 后有 authoritative readback。
+- first scan 不空白，rescan 不闪空。
+- reduced-motion / keyboard / ARIA 正确。
+- 新 shared code 有真实复用价值，没有为了阶段拆分制造一次性 abstraction。
+- 全部工作在一个分支串行完成，没有 Worktree/子任务残留。
+
+## Execution Flexibility
+
+阶段顺序是推荐的风险控制路径，不是死板的代码合同。执行方如果发现最新代码已经有等价 helper/component，直接复用并缩小改动；如果两个相邻阶段在当前代码中天然应该一起改，可以合并实现并在阶段检查点统一验证。只有新增依赖、扩大 wire/backend contract、改变安全边界或用户可见语义时，才需要回到规划评审。

--- a/.trellis/tasks/archive/2026-08/08-26-agent-directory-lifecycle-ux/prd.md
+++ b/.trellis/tasks/archive/2026-08/08-26-agent-directory-lifecycle-ux/prd.md
@@ -1,0 +1,113 @@
+# AI 软件目录渐进扫描、安装更新与侧栏动效
+
+## Goal
+
+让 `/agents` 的「我的 AI 软件」成为一个始终有内容、状态逐步变得可信的目录：目录加载后立即显示全部受支持软件，首次进入自动在后台读取每个软件的安装/更新状态，按真实扫描结果开放配置或安装/更新动作，并让用户看到动作进度。同时让左侧「配置管理」展开/收起拥有与现有 SelectionLens 一致的顺滑弹簧手感。
+
+本任务的主要价值是把已经存在的 catalog、readiness、installer/action、Motion、Radix 和 TanStack Query 能力正确组合起来，而不是新增第二套扫描器、安装器、软件注册表或动画体系。
+
+规划采用「稳定边界 + 推荐实现 + 可替换细节」：用户可见行为、真实性、安全边界、复用原则和串行阶段目标属于稳定要求；内部 hook 名称、组件颗粒度、状态字段命名、少量布局细节可在实现时按最新代码调整。
+
+## Background / Confirmed Facts
+
+- 当前生产 V2 Agent 目录来自唯一 `AgentCatalog`，固定支持 7 个 catalog ID；不应增加第二份前端软件表。
+- 当前 `AgentDirectory` 在未扫描时为空，并且扫描中/完成后只投影已安装项，这正是本次要改变的用户体验。
+- 当前 `useAgentDirectoryScan` 已通过 TanStack Query 的 disabled queries + `refetch()` 读取 7 个 `AgentInstallReadiness`，有 request id、partial settle、失败保留旧成功结果等基础能力。
+- `AgentInstallReadiness` 已提供 `installState`、`updateState`、`releaseId`、`allowedActions` 和 reason codes；renderer 不需要也不允许猜测 URL、命令、安装路径或 package format。
+- 通用 Agent action façade 已提供 `start_agent_action` / `get_agent_action_job` / `cancel_agent_action`。Job snapshot 当前提供阶段而非下载百分比。
+- Codex 安装/更新仍由独立 `codexDesktop` port 和 `useCodexDesktopInstaller` 管理；该 view model 已有真实下载百分比、字节数/速度、事件订阅和终态刷新能力。通用 Agent façade 对 Codex install/update 明确返回 `managed_by_codex_desktop`。
+- 当前 `AgentInstallReadinessSection` 已实现通用 Agent action 的 start → poll job → terminal → readiness reread 流程，但没有接入目录；应优先抽取/复用这段能力，而不是再写一份轮询器。
+- 当前 SelectionLens 使用 `framer-motion` physics spring：`stiffness: 520`、`damping: 42`、`mass: 0.62`。侧栏内容本身仍由 `hidden` 立即切换，没有展开/收起动画。
+- 项目已经依赖 `@radix-ui/react-collapsible`、`framer-motion` 和 `@tanstack/react-query`。V2 不能运行时导入 legacy `src/components/ui/collapsible.tsx`，但可以在 V2 shared owner 中复用已采用的 package 能力。
+- 当前工作树存在与 V3 Agent/Shell 相关的未提交变更。实施前先识别并保护这些现有改动；本任务后续只使用一个开发分支，不创建并行 Worktree，也不覆盖用户未授权的变更。
+
+## Requirements
+
+### R1 — 目录先显示，状态后填充
+
+- Agent catalog 成功加载后，目录按现有 catalog / `PRODUCT_DIRECTORY` 的权威顺序显示全部受支持软件，不因尚未扫描、未安装、unknown 或单项读取失败而把软件从目录中移除。
+- 首次进入目录视图自动开始一次后台扫描。用户不需要先点击「开始扫描」才能看到软件或触发第一次状态读取。
+- 扫描应是渐进式体验：单项完成即可更新该行，不需要等待全部 7 项结束后统一揭示结果。
+- 「lazy / 渐进」的核心要求是 display-first + background readiness，而不是强制一种调度算法。实现可以保持并发，也可以在有证据时做有限并发；不得仅为了“看起来 lazy”自造复杂任务调度器。
+- 页面存活期间返回目录时保留已有结果；首次自动扫描只触发一次，仍保留用户可操作的「重新扫描」。
+
+### R2 — 每行状态与配置门禁
+
+- 第一次状态尚未返回的行必须明确显示「正在扫描」或等价状态；「进行配置」不可点击。
+- 扫描确认 `installed` 或既有兼容语义 `installed_not_runnable` 后，可按既有配置能力开放「进行配置」。
+- `not_installed`、`unknown`、`unavailable`、首次读取失败或没有可信 readiness 的行不得开放「进行配置」。
+- 重新扫描期间如果存在上一次成功的安装结果，可以保留已知可配置状态，同时显式展示正在刷新；不要求为重新扫描制造整页闪烁或把已有成功结果清空。
+- 单项技术失败必须与「未安装」区分；失败不能被渲染成绿色/已安装，也不能偷偷移除该软件。
+
+### R3 — 一键安装 / 一键更新
+
+- 每行操作区以 backend readiness 的 `allowedActions` 和专用 Codex owner 为唯一权限来源。
+- 扫描确认未安装且后端允许 `install` 时，在「进行配置」左侧显示「一键安装」；扫描确认已安装且 `updateState === update_available` 且后端允许 `update` 时显示「一键更新」。
+- 已安装且无需更新时不显示多余的一键安装按钮。
+- backend 明确不允许当前平台/来源的一键安装时，前端不得因为产品文案而伪造一个可点击按钮。可以显示受控的不可用原因或只保留状态；具体文案由集成任务结合现有 reason copy 收敛。
+- Codex install/update 必须继续复用现有 `codexDesktop` installer owner；不得把 Codex 塞进通用 Agent job，也不得复制 Codex 下载/校验逻辑。
+- 其他 Agent 必须复用现有 `agentInstallReadiness.startAction/getActionJob/cancelAction`；不得增加第二套 invoke、下载器或安装命令表。
+
+### R4 — 真实进度和终态回读
+
+- 点击安装或更新后，用户必须在对应行感知当前动作正在进行；动作区至少展示 spinner + 当前阶段文案。
+- 通用 Agent job 只提供 stage 时，只展示真实 stage（checking / downloading / installing / verifying 等），不得伪造百分比。
+- Codex 已有真实 determinate progress 时继续展示已有百分比/下载信息，允许目录卡片用更紧凑的投影，但不得重新计算一套不一致的进度。
+- 动作成功不能直接把 UI 乐观改成「已安装」。终态后必须重新读取权威 readiness / Codex local status；只有回读确认后才开放配置或移除安装/更新按钮。
+- 失败、取消、`operation_conflict`、`refresh_required` 等保持可理解且可恢复；具体重试按钮形式可由实现结合现有 Button/notice 组件决定。
+
+### R5 — 配置管理展开/收起动效
+
+- 左侧「配置管理」展开/收起不再使用瞬时 `hidden` 切换作为唯一视觉反馈。
+- 运动手感复用现有 SelectionLens physics spring，而不是新增独立 cubic-bezier 或另一套运动常量。
+- 优先使用项目已安装的 Radix Collapsible 语义能力和现有 Motion 能力；不得引入新的动画/Disclosure 依赖。
+- 保留当前 Router 选中、`aria-expanded`、ArrowRight / ArrowLeft / Escape / Home / End 等键盘行为。
+- `prefers-reduced-motion` 下必须即时或近即时切换，不能强迫用户观看 layout animation。
+- 允许实现阶段把 motion token 抽到更合理的 shared owner、增加一个薄 V2 shared collapsible adapter，或采用等价的 shared 组合；不要把具体文件名固化为产品契约。
+
+### R6 — 复用与快速迭代约束
+
+- 搜索/复用优先级：现有 shared owner → 已采用依赖 → 维护良好的开源组件 → 才考虑自研。
+- 本轮调研已证明现有依赖足够，因此默认不新增 npm package / Rust crate。
+- 执行代理不需要重新做一轮宽泛技术选型；以本任务 research/design 为默认方案。只有代码已变化、现有 owner 不能满足、或出现新的兼容/安全问题时，再做针对性补充调研并记录证据。
+- 规划不锁死内部命名或微观实现。如果执行阶段发现更小、更复用、且不改变本 PRD 可观察行为的实现，可自行调整并在 review 中说明。
+
+### R7 — 单任务串行开发形态
+
+- 本需求只保留当前这一个 Trellis 任务，后续在同一个开发分支中完成，不创建子任务或并行 Worktree。
+- 推荐按以下顺序推进：侧栏动效 → 渐进扫描状态 → 生命周期动作/进度复用 → Agent Directory 卡片接线 → 集成测试与 SPEC 收口。
+- 每个阶段完成后先运行 focused validation，再进入下一阶段。阶段边界用于降低回归和方便定位问题，不要求人为制造独立公共 API 或提交。
+- 如果最新代码结构表明相邻两个阶段合并实现更简单，可以做最小调整；不要为了遵守阶段形式重复包装、制造 adapter 或抽象。
+- 整个任务由同一执行方持续维护上下文，最终统一完成页面/浏览器验收和 spec 更新。
+
+## Out of Scope
+
+- 新增支持软件、改变 7 个 Agent catalog 的产品范围或顺序。
+- 重写后端 Agent installer/source policy、放宽 Windows 安全边界、给 renderer 暴露 URL/path/hash/命令。
+- 为通用 Agent job 新增虚假百分比或仅为本 UI 扩大 backend DTO；若实现中证明真实数值进度是必要的新产品需求，应单独评审。
+- 重构整个 Agent configuration 四分区、Models/Skills/MCP/Prompts 的业务写入路径。
+- 新增第二个设计系统、动画库、query 库或安装器框架。
+
+## Acceptance Criteria
+
+- [ ] Catalog 成功后，无论是否扫描，7 个支持软件均按权威顺序显示；初始列表不再为空。
+- [ ] 首次进入目录自动扫描；每行有独立的 pending/scanning → settled 反馈，全部完成前已完成行可以先更新。
+- [ ] 首次未确认/未安装/失败的软件「进行配置」不可用；已确认安装的软件按既有语义可进入配置。
+- [ ] 未安装 + backend 允许 install 的行显示「一键安装」；可更新 + backend 允许 update 的行显示「一键更新」；不允许的动作不被前端伪造。
+- [ ] 一键安装/更新点击后，对应行显示真实阶段；Codex 复用现有真实 determinate progress，通用 Agent 不伪造百分比。
+- [ ] 安装/更新终态后重新读取权威状态；没有成功回读时不提前开放配置或宣称成功。
+- [ ] Codex 继续走 `codexDesktop` owner；其他 Agent 继续走 `agentInstallReadiness` action façade；无第二套下载器、invoke wrapper 或软件注册表。
+- [ ] 「配置管理」展开/收起使用与 SelectionLens 同源的 spring 手感，并保留键盘、ARIA 与 reduced-motion 行为。
+- [ ] 未新增 animation/disclosure/query 依赖；新增 shared 能力（如有）有明确复用理由且没有复制现有组件。
+- [ ] 全部实现只在一个开发分支中串行完成，不创建并行 Worktree/子任务；现有未提交产品改动得到识别和保护，没有被覆盖。
+- [ ] `mise run typecheck:v2`、相关 Vitest、`mise run test:v2:browser`（受影响 Agent/Shell 场景）和 `mise run build:renderer` 通过；最终整体验收按当时项目 gate 执行。
+
+## Risks / Deferred Items
+
+- 通用 Agent job 当前只有阶段，没有数值型进度；本轮明确接受 stage progress，不把“感知到进度”错误解释成伪百分比。
+- 某些平台/Agent 的 backend 本身会拒绝一键安装（例如受安全约束的安装格式）。UI 必须忠实反映 `allowedActions`；如果产品之后要求所有平台都可一键安装，这是单独的 backend 能力项目。
+- 当前相关 V3 改动尚未全部提交。开始产品代码实现前必须先检查这些改动与本任务的关系，并在同一开发分支内兼容处理；不要通过额外 Worktree 规避冲突。
+
+## Planning Evidence
+
+- 见 `research/planning-evidence.md`。该文件记录本地代码证据、现有复用点以及 Radix / Motion / TanStack Query 官方资料。

--- a/.trellis/tasks/archive/2026-08/08-26-agent-directory-lifecycle-ux/research/execution-context.md
+++ b/.trellis/tasks/archive/2026-08/08-26-agent-directory-lifecycle-ux/research/execution-context.md
@@ -1,0 +1,190 @@
+# Curated Execution Context — Agent Directory Lifecycle UX
+
+This file is a task-scoped context summary for execution context injection. It does not
+replace the owning specs; it exists because some owning specs exceed Trellis'
+single-file injection budget and the relevant Agent Directory clauses are near
+the end of those documents.
+
+## 1. Stable Product Set
+
+The Agent catalog remains the only supported-software registry. The current
+catalog order is:
+
+```text
+qoderwork
+trae-work
+workbuddy
+grokbuild
+codex
+claude-code
+opencode
+```
+
+Do not create a second page-local array to decide what software exists.
+Catalog display names/descriptions and `PRODUCT_DIRECTORY` remain the existing
+owners used by the V2 page.
+
+## 2. New Directory Behavior for This Task
+
+The older V3 implementation currently documents/implements scan-on-demand and
+filters normal cards to installed-only. This parent task intentionally changes
+that renderer behavior:
+
+- catalog success -> all 7 rows are immediately present;
+- first directory entry -> automatic background readiness scan;
+- per-row readiness settles progressively;
+- scan state controls status/actions, not row existence;
+- first unresolved / not-installed / unknown / unavailable / failed row cannot
+  enter configuration;
+- a retained successful installed result may remain usable during rescan;
+- technical read failure is never converted to not-installed.
+
+The existing four-section Agent configuration shell (`models / skills / mcp /
+prompts`) remains unchanged except for the directory gate that enters it.
+
+## 3. Existing Readiness Contract
+
+Renderer uses only the existing `AgentInstallReadiness` shape:
+
+```text
+installState = not_installed | installed | installed_not_runnable |
+               unknown | unavailable
+updateState  = unavailable | unknown | up_to_date | update_available |
+               latest_unknown
+allowedActions = closed AgentActionId[]
+releaseId = optional opaque backend-generated value
+```
+
+Renderer must not add or infer URL, path, command, token, hash, package format,
+signer identity, or bypass fields.
+
+For directory configuration gating, this task preserves the existing renderer
+compatibility treatment that `installed` and `installed_not_runnable` prove the
+software exists. If a particular configuration owner later requires a runnable
+process, apply that narrower check there rather than redefining the global
+install state.
+
+## 4. Existing Lifecycle Action Contract
+
+Generic actions stay on the existing closed port:
+
+```text
+startAgentAction(agentId, install|update, expectedReleaseId?)
+getAgentActionJob(jobId)
+cancelAgentAction(jobId)
+```
+
+The job stages are:
+
+```text
+checking -> downloading -> installing -> verifying_installation
+         -> succeeded | failed | cancelled
+```
+
+Generic job snapshots do not contain a numeric download percentage. Show the
+real stage; do not fabricate percent.
+
+`allowedActions` is authoritative for whether generic install/update can be
+offered. Platform/source safety may legitimately remove an action.
+
+## 5. Codex Special Owner
+
+Codex install/update remains outside the generic Agent action job. Generic
+readiness returns `managed_by_codex_desktop` for those actions.
+
+Use the existing V2 Codex Desktop installer owner/view model. It already owns:
+
+- local/remote status;
+- install/update/launch primary action derivation;
+- job event subscription and stale snapshot rejection;
+- cancellation;
+- terminal refresh;
+- true determinate progress, downloaded bytes, and speed when available.
+
+Do not duplicate the Codex downloader, job subscription, progress math, or
+expected-release validation inside Agent Directory.
+
+## 6. Scan Owner
+
+`useAgentDirectoryScan` already uses seven disabled TanStack readiness queries
+and manual `refetch()` calls. It already has request-id stale protection,
+partial settle state, current failures, retained result data, and a scan
+single-flight check.
+
+Extend this owner. Do not call Tauri directly from the page and do not create a
+second query client/cache.
+
+The first-entry auto-start can live in the scan hook or the Agent page,
+whichever makes keep-alive semantics clearer. It must run once per mounted
+page session, while manual rescan remains available.
+
+## 7. Existing Generic Action Runner to Reuse
+
+`AgentInstallReadinessSection` already implements the useful generic runner:
+
+```text
+start action
+  -> set checking/busy
+  -> if jobId: poll getActionJob at bounded interval
+  -> classify terminal/timeout/reason
+  -> reread readiness
+```
+
+Prefer extracting this behavior into a reusable hook/view-model over copying it
+into `AgentDirectory`.
+
+## 8. Side Navigation Motion Contract
+
+The current tuned SelectionLens spring is:
+
+```text
+type: spring
+stiffness: 520
+damping: 42
+mass: 0.62
+```
+
+The new configuration-group collapse should reuse this spring source, not a
+new cubic-bezier. Preserve active lens behavior, `aria-expanded`, keyboard
+navigation, and `prefers-reduced-motion`.
+
+Project dependencies already include Radix Collapsible and Framer Motion. Use
+those adopted capabilities in a V2 shared owner; do not import the legacy V1
+collapsible wrapper and do not add another package.
+
+## 9. Reuse / Architecture Rules
+
+Order of preference:
+
+```text
+existing shared owner
+  -> already-adopted dependency
+  -> maintained open-source candidate (only if a real gap remains)
+  -> bespoke implementation with recorded reason
+```
+
+This planning pass found no dependency gap. Execution agents should not repeat
+broad package research. Targeted research is appropriate only when the current
+baseline contradicts this context or exposes a concrete missing capability.
+
+V2 page/widget code must continue using FeaturePorts instead of direct Tauri
+imports. Shared code should be promoted only for a real/likely second consumer;
+do not turn this quick iteration into a new framework.
+
+## 10. Serial Execution Shape
+
+This task is executed by one agent on one development branch. Do not create
+parallel Trellis children or Worktrees.
+
+Recommended order:
+
+1. shared collapse motion + SideNavigation;
+2. scan controller / per-row projection / first-entry auto scan;
+3. generic action runner + thin Codex projection;
+4. AgentDirectory card composition + Page.css;
+5. unit/browser integration, final checks, and owning-spec updates.
+
+Run focused validation at each boundary, but do not manufacture public APIs or
+temporary adapters merely to preserve the phase split. Adjacent phases may be
+combined when the current code makes that simpler and the stable behavior and
+safety boundaries remain unchanged.

--- a/.trellis/tasks/archive/2026-08/08-26-agent-directory-lifecycle-ux/research/planning-evidence.md
+++ b/.trellis/tasks/archive/2026-08/08-26-agent-directory-lifecycle-ux/research/planning-evidence.md
@@ -1,0 +1,125 @@
+# Planning Evidence — Agent Directory Lifecycle UX
+
+Date: 2026-08-26
+
+## 1. Local Code Evidence
+
+### Existing motion owner
+
+- `src/v2/shared/ui/SelectionLens.tsx` already owns a tuned physics spring:
+  `type: spring`, `stiffness: 520`, `damping: 42`, `mass: 0.62`.
+- `src/v2/app/styles/shell.css` currently animates only the caret with
+  `160ms ease`; the collapsible list uses `[hidden] { display: none; }`, so
+  content open/close has no layout animation.
+- `.trellis/spec/frontend/v2-shell.md` intentionally centralizes V2 motion and
+  requires reduced-motion support. The new behavior should evolve that shared
+  owner instead of importing Motion ad hoc in SideNavigation.
+
+### Existing catalog / scan owner
+
+- `src/v2/pages/agents/AgentDirectory.tsx` currently filters cards through
+  `projectInstalledEntries`, so idle state is empty and not-installed/unknown
+  entries disappear.
+- `src/v2/pages/agents/useAgentDirectoryScan.ts` already keeps request IDs,
+  settled IDs, current success/failure IDs, retained results, and disabled
+  TanStack queries for all 7 Agent IDs. It is an extension point, not code to
+  replace wholesale.
+- `src/v2/shared/features/queries.ts` already centralizes readiness query keys
+  and calls `FeaturePorts.agentInstallReadiness.get`.
+- `src/v2/shared/features/directory.ts` / catalog types are the existing
+  product-order owner. No second frontend supported-software registry is
+  needed.
+
+### Existing install/update owners
+
+- `src/v2/shared/features/agent-install-readiness.ts` defines the closed
+  readiness/action contract (`install`, `update`, `launch`, auth actions) and
+  rejects extra wire fields.
+- `src/v2/shared/platform/tauri/feature-ports/agentInstallReadiness.ts` already
+  wraps all generic Agent lifecycle invokes.
+- `src/v2/pages/agents/AgentInstallReadinessSection.tsx` already contains the
+  generic action loop: start action, poll job every bounded interval, surface
+  stage/failure, then reread readiness. This is reusable behavior even though
+  the section is not currently mounted by `AgentsPage`.
+- `src-tauri/src/agent_install/jobs.rs` job snapshot contains stage and
+  cancellable state, but no byte/percent progress. A generic percentage would
+  therefore be fabricated.
+- `src-tauri/src/agent_install/mod.rs` reuses Tooling for Claude/Grok/OpenCode,
+  a managed desktop flow for Qoder/TRAE/WorkBuddy, and explicitly rejects
+  Codex install/update with `managed_by_codex_desktop`.
+- `src/v2/shared/codex-desktop/useCodexDesktopInstaller.ts` is the established
+  Codex view model and already owns event subscription, stale snapshot
+  rejection, terminal reread, percentage, downloaded bytes and speed.
+
+### Existing dependency stack
+
+`package.json` already includes:
+
+- `@radix-ui/react-collapsible ^1.1.12`
+- `framer-motion ^12.23.25`
+- `@tanstack/react-query ^5.90.3`
+
+No new dependency is justified by this feature.
+
+## 2. Official External Evidence
+
+### Radix Collapsible
+
+Official docs: https://www.radix-ui.com/primitives/docs/components/collapsible
+
+Relevant evidence:
+
+- controlled `open` / `onOpenChange` is supported;
+- Root/Trigger/Content expose `data-state=open|closed`;
+- Content exposes `--radix-collapsible-content-width/height` for size animation;
+- primitive follows the Disclosure WAI-ARIA pattern and supports Enter/Space.
+
+Conclusion: use the already-adopted primitive semantics instead of writing a
+second disclosure implementation. V2 should wrap/use the package in its own
+shared layer rather than import the legacy V1 wrapper.
+
+### Motion physics spring
+
+Official docs: https://motion.dev/docs/react-transitions
+
+Relevant evidence:
+
+- physics springs are configured with `stiffness`, `damping`, and `mass`;
+- spring animation can retarget naturally from current motion state;
+- time/bounce settings are overridden when physics parameters are set.
+
+Conclusion: the existing SelectionLens values are a real reusable physics
+signature. Do not translate them to an unrelated CSS `ease` curve.
+
+### TanStack Query lazy/disabled queries
+
+Official docs:
+https://tanstack.com/query/latest/docs/framework/react/guides/disabling-queries
+
+Relevant evidence:
+
+- `enabled: false` prevents automatic mount/background fetch;
+- the returned `refetch` can manually trigger the query;
+- docs explicitly describe enabling later as a lazy-query pattern.
+
+Conclusion: the repository's existing readiness hooks can support automatic
+first-entry progressive scanning without adding another data-fetch layer.
+
+## 3. Architecture Decision
+
+The preferred stack is therefore:
+
+```text
+Catalog (existing)
+  -> all 7 rows visible
+TanStack readiness queries (existing)
+  -> progressive per-row state
+Agent action façade / Codex installer (existing)
+  -> install/update + real progress semantics
+Radix Collapsible + shared Motion spring (existing dependencies)
+  -> smooth, accessible side-nav collapse
+```
+
+No external package search found a capability gap that justifies adding a new
+dependency. Execution agents should research further only if the current code
+has materially changed or a concrete capability gap is discovered.

--- a/.trellis/tasks/archive/2026-08/08-26-agent-directory-lifecycle-ux/task.json
+++ b/.trellis/tasks/archive/2026-08/08-26-agent-directory-lifecycle-ux/task.json
@@ -1,0 +1,29 @@
+{
+  "id": "agent-directory-lifecycle-ux",
+  "name": "agent-directory-lifecycle-ux",
+  "title": "AI 软件目录渐进扫描、安装更新与侧栏动效",
+  "description": "在单一开发分支中串行实现 AI 软件目录的全量首屏、渐进扫描、配置门禁、一键安装/更新与进度，以及配置管理展开收起动效；优先复用现有能力。",
+  "status": "completed",
+  "dev_type": null,
+  "scope": null,
+  "package": null,
+  "priority": "P1",
+  "creator": "pythonrust",
+  "assignee": "pythonrust",
+  "createdAt": "2026-08-26",
+  "completedAt": "2026-08-26",
+  "branch": null,
+  "base_branch": "main",
+  "worktree_path": null,
+  "commit": null,
+  "pr_url": null,
+  "subtasks": [],
+  "children": [],
+  "parent": null,
+  "relatedFiles": [],
+  "notes": "",
+  "meta": {
+    "execution_shape": "single_branch_serial",
+    "planning_style": "stable_boundaries_flexible_implementation"
+  }
+}

--- a/.trellis/workspace/pythonrust/index.md
+++ b/.trellis/workspace/pythonrust/index.md
@@ -8,7 +8,7 @@
 
 <!-- @@@auto:current-status -->
 - **Active File**: `journal-1.md`
-- **Total Sessions**: 53
+- **Total Sessions**: 54
 - **Last Active**: 2026-08-26
 <!-- @@@/auto:current-status -->
 
@@ -19,7 +19,7 @@
 <!-- @@@auto:active-documents -->
 | File | Lines | Status |
 |------|-------|--------|
-| `journal-1.md` | ~1753 | Active |
+| `journal-1.md` | ~1775 | Active |
 <!-- @@@/auto:active-documents -->
 
 ---
@@ -29,6 +29,7 @@
 <!-- @@@auto:session-history -->
 | # | Date | Title | Commits | Branch |
 |---|------|-------|---------|--------|
+| 54 | 2026-08-26 | Agent directory lifecycle UX | `7725099b`, `92d97cf7` | `dev/laiyongjie` |
 | 53 | 2026-08-26 | Reuse-first specs and release preflight decoupling | `83724a38`, `4db05412` | `docs/reuse-first-spec` |
 | 53 | 2026-08-25 | Agent one-click install and Codex multi-account auth | `2f468156`, `d9c582b5` | `feat/agent-install-auth` |
 | 52 | 2026-08-25 | Finalize CI scope and title policy | `7b9e4a29` | `ci/refine-change-classifier` |

--- a/.trellis/workspace/pythonrust/journal-1.md
+++ b/.trellis/workspace/pythonrust/journal-1.md
@@ -1751,3 +1751,25 @@ Codified reuse-first engineering across frontend/backend/guides; decoupled Relea
 ### Status
 
 [OK] **Completed**
+
+
+## Session 54: Agent directory lifecycle UX
+
+**Date**: 2026-08-26
+**Task**: Agent directory lifecycle UX
+**Branch**: `dev/laiyongjie`
+
+### Summary
+
+Catalog-first Agent directory with auto scan, honest install/update progress, shared collapse spring, and Provider save-confirm browser tests; specs updated then task archived.
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `7725099b` | (see git log) |
+| `92d97cf7` | (see git log) |
+
+### Status
+
+[OK] **Completed**

--- a/src/v2/app/styles/features.css
+++ b/src/v2/app/styles/features.css
@@ -153,18 +153,24 @@
 }
 .fy-feature-definition {
   display: grid;
-  grid-template-columns: minmax(90px, max-content) minmax(0, 1fr);
+  grid-template-columns: minmax(0, max-content) minmax(0, 1fr);
   gap: 8px 12px;
   margin: 0;
   font-size: 12px;
 }
 .fy-feature-definition dt {
+  min-width: 0;
   color: var(--fy-text-secondary);
+  overflow-wrap: anywhere;
 }
 .fy-feature-definition dd {
   min-width: 0;
   margin: 0;
   overflow-wrap: anywhere;
+}
+.fy-feature-definition
+  dd:has(> .fy-feature-path:not(:has(.fy-feature-path-value))) {
+  min-width: min-content;
 }
 .fy-feature-code {
   font-family: ui-monospace, Consolas, monospace;

--- a/src/v2/app/styles/shell.css
+++ b/src/v2/app/styles/shell.css
@@ -192,11 +192,6 @@
 .fy-side-navigation-caret {
   flex: 0 0 auto;
   color: var(--fy-text-tertiary);
-  transition: transform 160ms ease;
-}
-
-.fy-side-navigation-toggle[aria-expanded="true"] .fy-side-navigation-caret {
-  transform: rotate(180deg);
 }
 
 .fy-side-navigation-items {

--- a/src/v2/app/styles/shell.css
+++ b/src/v2/app/styles/shell.css
@@ -280,30 +280,6 @@
   -webkit-backdrop-filter: blur(16px) saturate(1.3);
 }
 
-.fy-side-navigation-toggle .fy-liquid-glass-lens,
-.fy-side-navigation-item .fy-liquid-glass-lens {
-  display: flex;
-  width: 100%;
-  min-width: 0;
-  height: 36px;
-  border-color: transparent;
-  background-color: transparent;
-  background-image: none;
-  box-shadow: none;
-  backdrop-filter: none;
-  -webkit-backdrop-filter: none;
-}
-
-.fy-side-navigation-toggle .fy-liquid-glass-lens {
-  height: 40px;
-}
-
-.fy-side-navigation-group:not(.fy-side-navigation-group-collapsible)
-  .fy-side-navigation-item
-  .fy-liquid-glass-lens {
-  height: 40px;
-}
-
 .fy-side-navigation-item-pending {
   opacity: 0.72;
 }

--- a/src/v2/pages/agents/AgentDirectory.tsx
+++ b/src/v2/pages/agents/AgentDirectory.tsx
@@ -1,73 +1,315 @@
+import { useCallback, type ReactNode } from "react";
+
 import { getAgentBrand } from "../../shared/assets/agents";
-import type {
-  AgentInstallReadiness,
-  AgentInstallState,
-} from "../../shared/features/agent-install-readiness";
+import { useCodexDesktopInstaller } from "../../shared/codex-desktop/useCodexDesktopInstaller";
+import type { AgentInstallReadiness } from "../../shared/features/agent-install-readiness";
+import { useFeatures } from "../../shared/features/provider";
 import {
   AGENT_CATALOG_IDS,
   type AgentCatalogEntry,
   type AgentCatalogId,
 } from "../../shared/features/types";
 import { BrandIconFrame } from "../../shared/ui/catalog";
-import { Button, EmptyState, InlineNotice } from "../../shared/ui/primitives";
-import type {
-  AgentDirectoryScanController,
-  AgentDirectoryScanState,
-} from "./useAgentDirectoryScan";
+import { Button, InlineNotice, Spinner } from "../../shared/ui/primitives";
 
-function isInstalledState(state: AgentInstallState | undefined): boolean {
-  return state === "installed" || state === "installed_not_runnable";
+import {
+  observeAgentDirectoryRow,
+  type AgentDirectoryRowObservation,
+} from "./agentDirectoryScanProjection";
+import {
+  projectCodexDirectoryAction,
+  type CodexDirectoryActionProjection,
+} from "./codexDirectoryActionProjection";
+import type { AgentDirectoryScanController } from "./useAgentDirectoryScan";
+import {
+  jobStageCopy,
+  useAgentLifecycleAction,
+  type AgentLifecycleActionView,
+} from "./useAgentLifecycleAction";
+
+function isInstalledReadiness(
+  data: AgentInstallReadiness | undefined,
+): boolean {
+  return (
+    data?.installState === "installed" ||
+    data?.installState === "installed_not_runnable"
+  );
 }
 
-function projectInstalledEntries(
-  entries: readonly AgentCatalogEntry[],
-  scan: AgentDirectoryScanState,
-): AgentCatalogEntry[] {
-  return entries.filter((entry) => {
-    const result = scan.results[entry.id];
-    return isInstalledState(result?.installState);
-  });
+function scanButtonLabel(
+  status: AgentDirectoryScanController["state"]["status"],
+): string {
+  if (status === "scanning") return "扫描中…";
+  if (status === "complete") return "重新扫描";
+  return "开始扫描";
 }
 
-function AgentDirectoryCard({
+function rowKindCopy(observation: AgentDirectoryRowObservation): string | null {
+  if (observation.refreshing) return "正在刷新";
+  if (observation.kind === "pending") return null;
+  if (observation.readFailed && !isInstalledReadiness(observation.readiness)) {
+    return "读取失败";
+  }
+  if (observation.kind === "error") return "读取失败";
+  if (observation.kind === "unknown") return "状态未知";
+  if (observation.kind === "unavailable") return "当前不可用";
+  return null;
+}
+
+function directoryBusyCopy(
+  observation: AgentDirectoryRowObservation,
+): string | null {
+  if (observation.kind === "pending" && !observation.refreshing) {
+    return "正在扫描";
+  }
+  if (observation.refreshing) return "正在刷新";
+  return null;
+}
+
+function codexBusyCopy(projection: CodexDirectoryActionProjection): string {
+  if (projection.state === "job_downloading" && projection.percent !== null) {
+    return `正在下载 ${projection.percent}%`;
+  }
+  switch (projection.state) {
+    case "job_checking":
+      return "正在检查来源";
+    case "job_preflight":
+      return "正在执行安装前检查";
+    case "job_downloading":
+      return "正在下载";
+    case "job_installing":
+      return "正在安装";
+    case "job_verifying_installation":
+      return "正在确认安装结果";
+    default:
+      return "处理中…";
+  }
+}
+
+function DirectoryCardShell({
   entry,
-  scanning,
+  observation,
+  lifecycleBusy,
+  lifecycleSlot,
   onConfigure,
 }: {
   entry: AgentCatalogEntry;
-  scanning: boolean;
+  observation: AgentDirectoryRowObservation;
+  lifecycleBusy: boolean;
+  lifecycleSlot: ReactNode;
   onConfigure: (agentId: AgentCatalogId) => void;
 }) {
+  const kindCopy = rowKindCopy(observation);
+  const configurable = observation.configurable && !lifecycleBusy;
   return (
-    <article className="fy-agent-directory-card" data-agent-id={entry.id}>
+    <article
+      className="fy-agent-directory-card"
+      data-agent-id={entry.id}
+      data-row-kind={observation.kind}
+    >
       <BrandIconFrame asset={getAgentBrand(entry.id)} size="detail" />
       <div className="fy-agent-directory-card-copy">
         <div className="fy-agent-directory-card-heading">
           <h2>{entry.displayName}</h2>
+          {kindCopy ? (
+            <span
+              className="fy-agent-directory-status"
+              data-status={
+                observation.kind === "error" || observation.readFailed
+                  ? "error"
+                  : observation.kind === "unknown" ||
+                      observation.kind === "unavailable"
+                    ? "unknown"
+                    : "warning"
+              }
+            >
+              {kindCopy}
+            </span>
+          ) : null}
         </div>
         <p className="fy-agent-directory-description">{entry.description}</p>
       </div>
-      <Button disabled={scanning} onClick={() => onConfigure(entry.id)}>
-        进行配置
-      </Button>
+      <div className="fy-agent-directory-card-actions">
+        {lifecycleSlot}
+        <Button disabled={!configurable} onClick={() => onConfigure(entry.id)}>
+          进行配置
+        </Button>
+      </div>
     </article>
   );
 }
 
-function AgentDirectorySkeletonCard({ keyIndex }: { keyIndex: number }) {
+function DirectoryActionFeedback({ error }: { error: string | null }) {
+  if (!error) return null;
+  return <p className="fy-agent-directory-card-feedback">{error}</p>;
+}
+
+function ScanningSlot({ label }: { label: string }) {
   return (
-    <div
-      className="fy-agent-directory-card is-skeleton"
-      aria-hidden="true"
-      data-testid={`skeleton-card-${keyIndex}`}
-    >
-      <div className="fy-agent-skeleton-icon" />
-      <div className="fy-agent-directory-card-copy">
-        <div className="fy-agent-skeleton-title" />
-        <div className="fy-agent-skeleton-desc" />
-      </div>
-    </div>
+    <span className="fy-agent-directory-lifecycle-status" role="status">
+      <Spinner label={label} />
+      {label}
+    </span>
   );
+}
+
+function BusySlot({ label }: { label: string }) {
+  return (
+    <span className="fy-agent-directory-lifecycle-status" role="status">
+      <Spinner label={label} />
+      {label}
+    </span>
+  );
+}
+
+function primaryActionLabel(action: "install" | "update"): string {
+  return action === "install" ? "一键安装" : "一键更新";
+}
+
+function GenericDirectoryCard({
+  entry,
+  observation,
+  onConfigure,
+  onReadinessChange,
+}: {
+  entry: AgentCatalogEntry;
+  observation: AgentDirectoryRowObservation;
+  onConfigure: (agentId: AgentCatalogId) => void;
+  onReadinessChange: (data: AgentInstallReadiness) => void;
+}) {
+  const { ports } = useFeatures();
+  const lifecycle = useAgentLifecycleAction({
+    agentId: entry.id,
+    port: ports.agentInstallReadiness,
+    readiness: observation.readiness ?? null,
+    onReadinessChange,
+  });
+  const scanningCopy = directoryBusyCopy(observation);
+  return (
+    <DirectoryCardShell
+      entry={entry}
+      observation={observation}
+      lifecycleBusy={lifecycle.busy}
+      onConfigure={onConfigure}
+      lifecycleSlot={
+        <>
+          <GenericLifecycleSlot
+            observation={observation}
+            scanningCopy={scanningCopy}
+            lifecycle={lifecycle}
+          />
+          <DirectoryActionFeedback error={lifecycle.error} />
+        </>
+      }
+    />
+  );
+}
+
+function GenericLifecycleSlot({
+  observation,
+  scanningCopy,
+  lifecycle,
+}: {
+  observation: AgentDirectoryRowObservation;
+  scanningCopy: string | null;
+  lifecycle: AgentLifecycleActionView;
+}) {
+  if (lifecycle.busy) {
+    return (
+      <BusySlot
+        label={lifecycle.stage ? jobStageCopy(lifecycle.stage) : "处理中…"}
+      />
+    );
+  }
+  if (scanningCopy && !lifecycle.primaryAction) {
+    return <ScanningSlot label={scanningCopy} />;
+  }
+  if (lifecycle.primaryAction) {
+    return (
+      <Button onClick={() => void lifecycle.runPrimary()}>
+        {primaryActionLabel(lifecycle.primaryAction)}
+      </Button>
+    );
+  }
+  if (lifecycle.canRetry) {
+    return <Button onClick={() => void lifecycle.retry()}>重试</Button>;
+  }
+  if (scanningCopy) {
+    return <ScanningSlot label={scanningCopy} />;
+  }
+  if (observation.kind === "pending") {
+    return <ScanningSlot label="正在扫描" />;
+  }
+  return null;
+}
+
+function CodexDirectoryCard({
+  entry,
+  observation,
+  projection,
+  onConfigure,
+  onRun,
+}: {
+  entry: AgentCatalogEntry;
+  observation: AgentDirectoryRowObservation;
+  projection: CodexDirectoryActionProjection;
+  onConfigure: (agentId: AgentCatalogId) => void;
+  onRun: () => Promise<void>;
+}) {
+  const scanningCopy = directoryBusyCopy(observation);
+  const error = projection.error?.details.redactedMessage ?? null;
+  return (
+    <DirectoryCardShell
+      entry={entry}
+      observation={observation}
+      lifecycleBusy={projection.busy}
+      onConfigure={onConfigure}
+      lifecycleSlot={
+        <>
+          <CodexLifecycleSlot
+            scanningCopy={scanningCopy}
+            observation={observation}
+            projection={projection}
+            onRun={onRun}
+          />
+          <DirectoryActionFeedback error={error} />
+        </>
+      }
+    />
+  );
+}
+
+function CodexLifecycleSlot({
+  scanningCopy,
+  observation,
+  projection,
+  onRun,
+}: {
+  scanningCopy: string | null;
+  observation: AgentDirectoryRowObservation;
+  projection: CodexDirectoryActionProjection;
+  onRun: () => Promise<void>;
+}) {
+  if (projection.busy) {
+    return <BusySlot label={codexBusyCopy(projection)} />;
+  }
+  if (observation.kind === "pending" && !observation.refreshing) {
+    return <ScanningSlot label="正在扫描" />;
+  }
+  if (projection.canRun && projection.primaryAction) {
+    return (
+      <Button onClick={() => void onRun()}>
+        {primaryActionLabel(projection.primaryAction)}
+      </Button>
+    );
+  }
+  if (projection.canRetry) {
+    return <Button onClick={() => void onRun()}>重试</Button>;
+  }
+  if (scanningCopy) {
+    return <ScanningSlot label={scanningCopy} />;
+  }
+  return null;
 }
 
 export function AgentDirectory({
@@ -79,28 +321,30 @@ export function AgentDirectory({
   scanController: AgentDirectoryScanController;
   onConfigure: (agentId: AgentCatalogId) => void;
 }) {
-  const { state, start } = scanController;
+  const { ports } = useFeatures();
+  const installer = useCodexDesktopInstaller();
+  const { state, start, applyReadiness } = scanController;
   const scanning = state.status === "scanning";
   const complete = state.status === "complete";
   const hasSuccessfulResults = Object.keys(state.results).length > 0;
-
   const currentReadiness = state.currentSuccessIds
     .map((id) => state.results[id])
     .filter((item): item is AgentInstallReadiness => Boolean(item));
-
   const discoveredCount = currentReadiness.filter((item) =>
-    isInstalledState(item.installState),
+    isInstalledReadiness(item),
   ).length;
-
   const allFailed = complete && state.currentSuccessIds.length === 0;
   const hasTechnicalError = state.currentFailureIds.length > 0;
+  const codexProjection = projectCodexDirectoryAction(installer);
 
-  const installedEntries =
-    complete || scanning ? projectInstalledEntries(entries, state) : [];
-
-  const remainingSkeletonCount = scanning
-    ? Math.max(0, AGENT_CATALOG_IDS.length - state.settledIds.length)
-    : 0;
+  const runCodexAndReread = useCallback(async () => {
+    await installer.runPrimaryAction();
+    try {
+      applyReadiness("codex", await ports.agentInstallReadiness.get("codex"));
+    } catch {
+      /* Keep the last scan observation until an authoritative reread succeeds. */
+    }
+  }, [applyReadiness, installer, ports.agentInstallReadiness]);
 
   return (
     <section className="fy-agent-directory" aria-label="AI 软件目录">
@@ -114,11 +358,7 @@ export function AgentDirectory({
             disabled={scanning}
             onClick={start}
           >
-            {scanning
-              ? "扫描中…"
-              : complete && hasSuccessfulResults
-                ? "重新扫描"
-                : "开始扫描"}
+            {scanButtonLabel(state.status)}
           </Button>
         </div>
       </header>
@@ -150,25 +390,33 @@ export function AgentDirectory({
         <InlineNotice tone="warning">
           {state.currentFailureIds.length} 个软件状态读取失败，成功结果已更新。
         </InlineNotice>
-      ) : complete && installedEntries.length === 0 ? (
-        <EmptyState title="未发现已安装的 AI 软件" />
       ) : null}
 
       <div className="fy-agent-directory-list">
-        {installedEntries.map((entry) => (
-          <AgentDirectoryCard
-            key={entry.id}
-            entry={entry}
-            scanning={scanning}
-            onConfigure={onConfigure}
-          />
-        ))}
-        {Array.from({ length: remainingSkeletonCount }).map((_, index) => (
-          <AgentDirectorySkeletonCard
-            key={`skeleton-${index}`}
-            keyIndex={index}
-          />
-        ))}
+        {entries.map((entry) => {
+          const observation = observeAgentDirectoryRow(entry.id, state);
+          if (entry.id === "codex") {
+            return (
+              <CodexDirectoryCard
+                key={entry.id}
+                entry={entry}
+                observation={observation}
+                projection={codexProjection}
+                onConfigure={onConfigure}
+                onRun={runCodexAndReread}
+              />
+            );
+          }
+          return (
+            <GenericDirectoryCard
+              key={entry.id}
+              entry={entry}
+              observation={observation}
+              onConfigure={onConfigure}
+              onReadinessChange={(data) => applyReadiness(entry.id, data)}
+            />
+          );
+        })}
       </div>
     </section>
   );

--- a/src/v2/pages/agents/AgentInstallReadinessSection.tsx
+++ b/src/v2/pages/agents/AgentInstallReadinessSection.tsx
@@ -1,25 +1,25 @@
 import { useEffect, useState } from "react";
 
-import {
-  AGENT_REASON_CODES,
-  type AgentActionId,
-  type AgentActionJobStage,
-  type AgentInstallReadiness,
-  type AgentInstallReadinessPort,
-  type AgentInstallState,
-  type AgentReasonCode,
-  type AgentUpdateState,
+import type {
+  AgentActionId,
+  AgentActionJobStage,
+  AgentInstallReadiness,
+  AgentInstallReadinessPort,
+  AgentInstallState,
+  AgentUpdateState,
 } from "../../shared/features/agent-install-readiness";
 import type { AgentCatalogId } from "../../shared/features/types";
 import { Button, InlineNotice, Spinner } from "../../shared/ui/primitives";
 
+import {
+  jobStageCopy,
+  reasonCopy,
+  useAgentLifecycleAction,
+} from "./useAgentLifecycleAction";
+
 type ReadinessPort = AgentInstallReadinessPort;
 
 const NATIVE_ONLY_COPY = "安装准备度仅在桌面应用接线后可读取";
-const JOB_POLL_MS = 800;
-const MAX_JOB_POLLS = 2250;
-const ACTION_INCOMPLETE_COPY = "操作未能完成。此区域不会推断安装成功。";
-const ACTION_SUCCEEDED_COPY = "操作已完成。下面是再次读取的状态，不是推断。";
 
 const unavailablePort: ReadinessPort = {
   get: async () => {
@@ -81,75 +81,6 @@ function actionLabel(action: AgentActionId): string {
     case "auth_connect_provider":
       return "连接 Provider";
   }
-}
-
-function reasonCopy(code: AgentReasonCode): string | null {
-  switch (code) {
-    case "managed_by_codex_desktop":
-      return "安装与更新由现有 Codex Desktop 安装器管理。";
-    case "interactive_user_unavailable":
-      return "当前 Windows 提升环境不会代为执行安装命令。";
-    case "platform_unsupported":
-      return "当前平台没有可用的官方安装包。";
-    case "source_not_verified":
-      return "官方来源当前不可用，请改用产品页面。";
-    case "official_page_only":
-      return "请改用官方产品下载页。不会使用固定的历史版本地址。";
-    case "provider_connection_required":
-      return "OpenCode 需要连接 Provider，而不是全局登录。";
-    case "auth_state_unknown":
-      return null;
-    case "operation_conflict":
-      return "已有安装任务进行中，请等待当前任务结束。";
-    case "refresh_required":
-      return "来源已变化，请刷新后再试。";
-    case "cancelled":
-      return "操作已取消。";
-    case "executor_not_implemented":
-      return "当前无法完成安装步骤。";
-    case "installed_not_runnable":
-      return "已写入安装位置，但还不能确认可以运行。";
-    default:
-      return null;
-  }
-}
-
-function jobStageCopy(stage: AgentActionJobStage): string {
-  switch (stage) {
-    case "checking":
-      return "正在检查来源";
-    case "downloading":
-      return "正在下载安装包";
-    case "installing":
-      return "正在安装";
-    case "verifying_installation":
-      return "正在确认安装结果";
-    case "succeeded":
-      return "正在读取安装结果";
-    case "failed":
-      return "操作失败";
-    case "cancelled":
-      return "操作已取消";
-  }
-}
-
-function isTerminalJobStage(stage: AgentActionJobStage): boolean {
-  return stage === "succeeded" || stage === "failed" || stage === "cancelled";
-}
-
-function failureCopy(code: AgentReasonCode | null): string {
-  return (code && reasonCopy(code)) || ACTION_INCOMPLETE_COPY;
-}
-
-function actionErrorReason(error: unknown): AgentReasonCode | null {
-  if (!error || typeof error !== "object" || !("reasonCode" in error)) {
-    return null;
-  }
-  const code = error.reasonCode;
-  return typeof code === "string" &&
-    (AGENT_REASON_CODES as readonly string[]).includes(code)
-    ? (code as AgentReasonCode)
-    : null;
 }
 
 function ReadinessSummary({
@@ -233,10 +164,14 @@ function AgentInstallReadinessContent({
     | { status: "ready"; data: AgentInstallReadiness }
     | { status: "unavailable" }
   >({ status: "loading" });
-  const [busy, setBusy] = useState(false);
-  const [jobStage, setJobStage] = useState<AgentActionJobStage | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [success, setSuccess] = useState<string | null>(null);
+  const lifecycle = useAgentLifecycleAction({
+    agentId,
+    port,
+    readiness: state.status === "ready" ? state.data : null,
+    onReadinessChange: (data) => {
+      setState({ status: "ready", data });
+    },
+  });
 
   useEffect(() => {
     let active = true;
@@ -252,54 +187,6 @@ function AgentInstallReadinessContent({
       active = false;
     };
   }, [agentId, port]);
-
-  const runAction = async (action: AgentActionId) => {
-    if (state.status !== "ready") return;
-    setBusy(true);
-    setJobStage("checking");
-    setError(null);
-    setSuccess(null);
-    try {
-      const result = await port.startAction({
-        agentId,
-        action,
-        expectedReleaseId: state.data.releaseId ?? undefined,
-      });
-      setJobStage(result.stage);
-      if (result.jobId) {
-        let snapshot = await port.getActionJob(result.jobId);
-        setJobStage(snapshot.stage);
-        for (let attempt = 0; attempt < MAX_JOB_POLLS; attempt += 1) {
-          if (isTerminalJobStage(snapshot.stage)) {
-            break;
-          }
-          await new Promise((resolve) =>
-            window.setTimeout(resolve, JOB_POLL_MS),
-          );
-          snapshot = await port.getActionJob(result.jobId);
-          setJobStage(snapshot.stage);
-        }
-        if (!isTerminalJobStage(snapshot.stage)) {
-          setError("安装仍在进行。超时不会被当成成功或失败。");
-        } else if (snapshot.stage === "succeeded") {
-          setSuccess(ACTION_SUCCEEDED_COPY);
-        } else {
-          setError(failureCopy(snapshot.reasonCode));
-        }
-      } else if (result.stage === "succeeded") {
-        setSuccess(ACTION_SUCCEEDED_COPY);
-      } else {
-        setError(failureCopy(result.reasonCode));
-      }
-      const data = await port.get(agentId);
-      setState({ status: "ready", data });
-    } catch (error) {
-      setError(failureCopy(actionErrorReason(error)));
-    } finally {
-      setBusy(false);
-      setJobStage(null);
-    }
-  };
 
   return (
     <section className="fy-agent-section" aria-label="安装方式">
@@ -317,11 +204,11 @@ function AgentInstallReadinessContent({
         ) : (
           <ReadinessSummary
             data={state.data}
-            busy={busy}
-            jobStage={jobStage}
-            error={error}
-            success={success}
-            onAction={(action) => void runAction(action)}
+            busy={lifecycle.busy}
+            jobStage={lifecycle.stage}
+            error={lifecycle.error}
+            success={lifecycle.success}
+            onAction={(action) => void lifecycle.run(action)}
           />
         )}
       </div>

--- a/src/v2/pages/agents/Page.css
+++ b/src/v2/pages/agents/Page.css
@@ -126,30 +126,36 @@
   gap: 10px;
 }
 
-.fy-agent-directory-card.is-skeleton {
-  opacity: 0.7;
+.fy-agent-directory-card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  min-width: 0;
 }
 
-.fy-agent-skeleton-icon {
-  width: 64px;
-  height: 64px;
-  border-radius: 14px;
-  background: rgba(226, 243, 255, 0.08);
+.fy-agent-directory-lifecycle-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 32px;
+  color: var(--fy-text-secondary);
+  font-size: 12px;
+  font-weight: 650;
 }
 
-.fy-agent-skeleton-title {
-  width: 140px;
-  height: 18px;
-  border-radius: 4px;
-  background: rgba(226, 243, 255, 0.08);
-  margin-bottom: 6px;
-}
-
-.fy-agent-skeleton-desc {
-  width: 260px;
+.fy-agent-directory-lifecycle-status .fy-control-spinner {
+  width: 14px;
   height: 14px;
-  border-radius: 4px;
-  background: rgba(226, 243, 255, 0.05);
+}
+
+.fy-agent-directory-card-feedback {
+  flex-basis: 100%;
+  margin: 0;
+  color: var(--fy-danger-text);
+  font-size: 11px;
+  line-height: 1.45;
 }
 
 .fy-agent-models-list {
@@ -916,9 +922,14 @@
     grid-template-columns: auto minmax(0, 1fr);
   }
 
-  .fy-agent-directory-card > .fy-control-button {
+  .fy-agent-directory-card-actions {
     grid-column: 1 / -1;
     justify-self: stretch;
+  }
+
+  .fy-agent-directory-card-actions > .fy-control-button {
+    flex: 1 1 auto;
+    justify-content: center;
   }
 
   .fy-agent-resource-workspace {

--- a/src/v2/pages/agents/Page.tsx
+++ b/src/v2/pages/agents/Page.tsx
@@ -25,7 +25,7 @@ export function AgentsPage() {
   const pageActive = pathname === "/agents";
   const [searchParams, setSearchParams] = useSearchParams();
   const catalogQuery = useAgentCatalog();
-  const scanController = useAgentDirectoryScan();
+  const scanController = useAgentDirectoryScan({ autoStart: true });
   const lastConfiguration = useRef<{
     target: (typeof PRODUCT_DIRECTORY)[number]["agentId"];
     section: AgentSection;

--- a/src/v2/pages/agents/agentDirectoryScanProjection.ts
+++ b/src/v2/pages/agents/agentDirectoryScanProjection.ts
@@ -1,0 +1,72 @@
+import type {
+  AgentInstallReadiness,
+  AgentInstallState,
+} from "../../shared/features/agent-install-readiness";
+import type { AgentCatalogId } from "../../shared/features/types";
+
+export type AgentDirectoryScanView = {
+  status: "idle" | "scanning" | "complete";
+  settledIds: readonly AgentCatalogId[];
+  currentFailureIds: readonly AgentCatalogId[];
+  results: Partial<Record<AgentCatalogId, AgentInstallReadiness>>;
+};
+
+export type AgentDirectoryRowKind =
+  | "pending"
+  | "installed"
+  | "not_installed"
+  | "unknown"
+  | "unavailable"
+  | "error";
+
+export type AgentDirectoryRowObservation = {
+  agentId: AgentCatalogId;
+  kind: AgentDirectoryRowKind;
+  readiness: AgentInstallReadiness | undefined;
+  scanning: boolean;
+  refreshing: boolean;
+  configurable: boolean;
+  readFailed: boolean;
+};
+
+export function isAgentExistenceProven(
+  installState: AgentInstallState | undefined,
+): installState is "installed" | "installed_not_runnable" {
+  return (
+    installState === "installed" || installState === "installed_not_runnable"
+  );
+}
+
+function kindFromInstallState(
+  installState: AgentInstallState,
+): Exclude<AgentDirectoryRowKind, "pending" | "error"> {
+  if (isAgentExistenceProven(installState)) return "installed";
+  return installState;
+}
+
+export function observeAgentDirectoryRow(
+  agentId: AgentCatalogId,
+  scan: AgentDirectoryScanView,
+): AgentDirectoryRowObservation {
+  const settled = scan.settledIds.includes(agentId);
+  const scanning = scan.status === "scanning" && !settled;
+  const readFailed = scan.currentFailureIds.includes(agentId);
+  const readiness = scan.results[agentId];
+  const configurable = isAgentExistenceProven(readiness?.installState);
+  const refreshing = scanning && readiness !== undefined;
+  const kind = readiness
+    ? kindFromInstallState(readiness.installState)
+    : settled || readFailed || scan.status === "complete"
+      ? "error"
+      : "pending";
+
+  return {
+    agentId,
+    kind,
+    readiness,
+    scanning,
+    refreshing,
+    configurable,
+    readFailed,
+  };
+}

--- a/src/v2/pages/agents/codexDirectoryActionProjection.ts
+++ b/src/v2/pages/agents/codexDirectoryActionProjection.ts
@@ -1,0 +1,62 @@
+import type {
+  CodexDesktopProgress,
+  InstallerErrorDto,
+  InstallerPrimaryAction,
+  InstallerViewState,
+} from "@/shared/codex-desktop";
+
+import type { AgentLifecyclePrimaryAction } from "./useAgentLifecycleAction";
+
+export type CodexDirectoryActionSource = {
+  primaryAction: InstallerPrimaryAction;
+  primaryDisabled: boolean;
+  isActing: boolean;
+  state: InstallerViewState;
+  progress: CodexDesktopProgress | undefined;
+  error: InstallerErrorDto | null;
+  canCancel: boolean;
+  operationFailed: boolean;
+};
+
+export type CodexDirectoryActionProjection = {
+  primaryAction: AgentLifecyclePrimaryAction | null;
+  busy: boolean;
+  percent: number | null;
+  state: InstallerViewState;
+  error: InstallerErrorDto | null;
+  canRun: boolean;
+  canRetry: boolean;
+  canCancel: boolean;
+};
+
+function projectPercent(
+  progress: CodexDesktopProgress | undefined,
+): number | null {
+  const percent = progress?.percent;
+  return typeof percent === "number" && Number.isFinite(percent)
+    ? percent
+    : null;
+}
+
+function projectPrimaryAction(
+  action: InstallerPrimaryAction,
+): AgentLifecyclePrimaryAction | null {
+  return action === "install" || action === "update" ? action : null;
+}
+
+export function projectCodexDirectoryAction(
+  source: CodexDirectoryActionSource,
+): CodexDirectoryActionProjection {
+  const primaryAction = projectPrimaryAction(source.primaryAction);
+  const busy = source.isActing || source.state.startsWith("job_");
+  return {
+    primaryAction,
+    busy,
+    percent: projectPercent(source.progress),
+    state: source.state,
+    error: source.error,
+    canRun: primaryAction !== null && !source.primaryDisabled && !busy,
+    canRetry: source.primaryAction === "retry" || source.operationFailed,
+    canCancel: source.canCancel,
+  };
+}

--- a/src/v2/pages/agents/useAgentDirectoryScan.ts
+++ b/src/v2/pages/agents/useAgentDirectoryScan.ts
@@ -1,4 +1,4 @@
-import { useReducer } from "react";
+import { useCallback, useEffect, useReducer, useRef } from "react";
 
 import type { AgentInstallReadiness } from "../../shared/features/agent-install-readiness";
 import { useAgentInstallReadiness } from "../../shared/features/queries";
@@ -19,7 +19,7 @@ export type AgentDirectoryScanState = {
   lastSuccessfulScanAt: number | null;
 };
 
-type AgentDirectoryScanAction =
+export type AgentDirectoryScanAction =
   | { type: "start"; requestId: number }
   | {
       type: "settled";
@@ -27,7 +27,17 @@ type AgentDirectoryScanAction =
       agentId: AgentCatalogId;
       data?: AgentInstallReadiness;
     }
-  | { type: "finish"; requestId: number; finishedAt: number };
+  | { type: "finish"; requestId: number; finishedAt: number }
+  | {
+      type: "applyReadiness";
+      agentId: AgentCatalogId;
+      data: AgentInstallReadiness;
+    };
+
+export type UseAgentDirectoryScanOptions = {
+  /** AgentsPage must pass true. Default stays false for hook-level tests. */
+  autoStart?: boolean;
+};
 
 const initialScanState: AgentDirectoryScanState = {
   status: "idle",
@@ -43,7 +53,7 @@ function appendUnique<T>(items: readonly T[], item: T): T[] {
   return items.includes(item) ? [...items] : [...items, item];
 }
 
-function scanReducer(
+export function scanReducer(
   state: AgentDirectoryScanState,
   action: AgentDirectoryScanAction,
 ): AgentDirectoryScanState {
@@ -55,6 +65,12 @@ function scanReducer(
       settledIds: [],
       currentSuccessIds: [],
       currentFailureIds: [],
+    };
+  }
+  if (action.type === "applyReadiness") {
+    return {
+      ...state,
+      results: { ...state.results, [action.agentId]: action.data },
     };
   }
   if (action.requestId !== state.requestId) return state;
@@ -102,18 +118,34 @@ function useReadinessQueries() {
   };
 }
 
-export function useAgentDirectoryScan() {
+export function useAgentDirectoryScan(options?: UseAgentDirectoryScanOptions) {
+  const autoStart = options?.autoStart ?? false;
   const [state, dispatch] = useReducer(scanReducer, initialScanState);
   const queries = useReadinessQueries();
+  const queriesRef = useRef(queries);
+  const stateRef = useRef(state);
 
-  const start = () => {
-    if (state.status === "scanning") return;
-    const requestId = state.requestId + 1;
+  useEffect(() => {
+    queriesRef.current = queries;
+    stateRef.current = state;
+  });
+
+  const start = useCallback(() => {
+    if (stateRef.current.status === "scanning") return;
+    const requestId = stateRef.current.requestId + 1;
+    stateRef.current = {
+      ...stateRef.current,
+      status: "scanning",
+      requestId,
+      settledIds: [],
+      currentSuccessIds: [],
+      currentFailureIds: [],
+    };
     dispatch({ type: "start", requestId });
     void Promise.all(
       AGENT_CATALOG_IDS.map(async (agentId) => {
         try {
-          const result = await queries[agentId].refetch();
+          const result = await queriesRef.current[agentId].refetch();
           dispatch({
             type: "settled",
             requestId,
@@ -127,11 +159,33 @@ export function useAgentDirectoryScan() {
     ).then(() => {
       dispatch({ type: "finish", requestId, finishedAt: Date.now() });
     });
-  };
+  }, []);
 
-  return { state, start };
+  const applyReadiness = useCallback(
+    (agentId: AgentCatalogId, data: AgentInstallReadiness) => {
+      dispatch({ type: "applyReadiness", agentId, data });
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (!autoStart) return;
+    start();
+  }, [autoStart, start]);
+
+  return { state, start, applyReadiness };
 }
 
 export type AgentDirectoryScanController = ReturnType<
   typeof useAgentDirectoryScan
 >;
+
+export {
+  isAgentExistenceProven,
+  observeAgentDirectoryRow,
+} from "./agentDirectoryScanProjection";
+export type {
+  AgentDirectoryRowKind,
+  AgentDirectoryRowObservation,
+  AgentDirectoryScanView,
+} from "./agentDirectoryScanProjection";

--- a/src/v2/pages/agents/useAgentLifecycleAction.ts
+++ b/src/v2/pages/agents/useAgentLifecycleAction.ts
@@ -1,0 +1,348 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  AGENT_REASON_CODES,
+  type AgentActionId,
+  type AgentActionJobStage,
+  type AgentInstallReadiness,
+  type AgentInstallReadinessPort,
+  type AgentReasonCode,
+} from "../../shared/features/agent-install-readiness";
+import type { AgentCatalogId } from "../../shared/features/types";
+
+export const AGENT_LIFECYCLE_JOB_POLL_MS = 800;
+export const AGENT_LIFECYCLE_MAX_JOB_POLLS = 2250;
+export const AGENT_LIFECYCLE_INCOMPLETE_COPY =
+  "操作未能完成。此区域不会推断安装成功。";
+export const AGENT_LIFECYCLE_SUCCEEDED_COPY =
+  "操作已完成。下面是再次读取的状态，不是推断。";
+export const AGENT_LIFECYCLE_TIMEOUT_COPY =
+  "安装仍在进行。超时不会被当成成功或失败。";
+
+export type AgentLifecyclePrimaryAction = "install" | "update";
+
+export type AgentLifecycleActionView = {
+  primaryAction: AgentLifecyclePrimaryAction | null;
+  busy: boolean;
+  stage: AgentActionJobStage | null;
+  percent: number | null;
+  error: string | null;
+  reasonCode: AgentReasonCode | null;
+  success: string | null;
+  canCancel: boolean;
+  canRetry: boolean;
+  run: (action: AgentActionId) => Promise<void>;
+  runPrimary: () => Promise<void>;
+  retry: () => Promise<void>;
+  cancel: () => Promise<void>;
+};
+
+export function isTerminalAgentJobStage(stage: AgentActionJobStage): boolean {
+  return stage === "succeeded" || stage === "failed" || stage === "cancelled";
+}
+
+export function deriveAgentLifecyclePrimaryAction(
+  readiness: AgentInstallReadiness | null,
+): AgentLifecyclePrimaryAction | null {
+  if (!readiness) return null;
+  const allowed = new Set(readiness.allowedActions);
+  if (readiness.installState === "not_installed" && allowed.has("install")) {
+    return "install";
+  }
+  if (
+    (readiness.installState === "installed" ||
+      readiness.installState === "installed_not_runnable") &&
+    readiness.updateState === "update_available" &&
+    allowed.has("update")
+  ) {
+    return "update";
+  }
+  return null;
+}
+
+export function reasonCopy(code: AgentReasonCode): string | null {
+  switch (code) {
+    case "managed_by_codex_desktop":
+      return "安装与更新由现有 Codex Desktop 安装器管理。";
+    case "interactive_user_unavailable":
+      return "当前 Windows 提升环境不会代为执行安装命令。";
+    case "platform_unsupported":
+      return "当前平台没有可用的官方安装包。";
+    case "source_not_verified":
+      return "官方来源当前不可用，请改用产品页面。";
+    case "official_page_only":
+      return "请改用官方产品下载页。不会使用固定的历史版本地址。";
+    case "provider_connection_required":
+      return "OpenCode 需要连接 Provider，而不是全局登录。";
+    case "auth_state_unknown":
+      return null;
+    case "operation_conflict":
+      return "已有安装任务进行中，请等待当前任务结束。";
+    case "refresh_required":
+      return "来源已变化，请刷新后再试。";
+    case "cancelled":
+      return "操作已取消。";
+    case "executor_not_implemented":
+      return "当前无法完成安装步骤。";
+    case "installed_not_runnable":
+      return "已写入安装位置，但还不能确认可以运行。";
+    default:
+      return null;
+  }
+}
+
+export function jobStageCopy(stage: AgentActionJobStage): string {
+  switch (stage) {
+    case "checking":
+      return "正在检查来源";
+    case "downloading":
+      return "正在下载安装包";
+    case "installing":
+      return "正在安装";
+    case "verifying_installation":
+      return "正在确认安装结果";
+    case "succeeded":
+      return "正在读取安装结果";
+    case "failed":
+      return "操作失败";
+    case "cancelled":
+      return "操作已取消";
+  }
+}
+
+export function agentLifecycleFailureCopy(
+  code: AgentReasonCode | null,
+): string {
+  return (code && reasonCopy(code)) || AGENT_LIFECYCLE_INCOMPLETE_COPY;
+}
+
+export function actionErrorReason(error: unknown): AgentReasonCode | null {
+  if (!error || typeof error !== "object" || !("reasonCode" in error)) {
+    return null;
+  }
+  const code = error.reasonCode;
+  return typeof code === "string" &&
+    (AGENT_REASON_CODES as readonly string[]).includes(code)
+    ? (code as AgentReasonCode)
+    : null;
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, ms);
+  });
+}
+
+export function useAgentLifecycleAction({
+  agentId,
+  port,
+  readiness,
+  onReadinessChange,
+  pollIntervalMs = AGENT_LIFECYCLE_JOB_POLL_MS,
+  maxPolls = AGENT_LIFECYCLE_MAX_JOB_POLLS,
+}: {
+  agentId: AgentCatalogId;
+  port: AgentInstallReadinessPort;
+  readiness: AgentInstallReadiness | null;
+  onReadinessChange?: (data: AgentInstallReadiness) => void;
+  pollIntervalMs?: number;
+  maxPolls?: number;
+}): AgentLifecycleActionView {
+  const [busy, setBusy] = useState(false);
+  const [stage, setStage] = useState<AgentActionJobStage | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [reasonCode, setReasonCode] = useState<AgentReasonCode | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [cancellable, setCancellable] = useState(false);
+  const [jobId, setJobId] = useState<string | null>(null);
+
+  const generationRef = useRef(0);
+  const runningRef = useRef(false);
+  const lastActionRef = useRef<AgentActionId | null>(null);
+  const readinessRef = useRef(readiness);
+  const onReadinessChangeRef = useRef(onReadinessChange);
+  const portRef = useRef(port);
+  const agentIdRef = useRef(agentId);
+  const pollIntervalMsRef = useRef(pollIntervalMs);
+  const maxPollsRef = useRef(maxPolls);
+
+  useEffect(() => {
+    readinessRef.current = readiness;
+    onReadinessChangeRef.current = onReadinessChange;
+    portRef.current = port;
+    agentIdRef.current = agentId;
+    pollIntervalMsRef.current = pollIntervalMs;
+    maxPollsRef.current = maxPolls;
+  });
+
+  useEffect(() => {
+    return () => {
+      generationRef.current += 1;
+      runningRef.current = false;
+    };
+  }, []);
+
+  const primaryAction = useMemo(
+    () => deriveAgentLifecyclePrimaryAction(readiness),
+    [readiness],
+  );
+
+  const reread = useCallback(async (generation: number): Promise<boolean> => {
+    try {
+      const data = await portRef.current.get(agentIdRef.current);
+      if (generationRef.current !== generation) return false;
+      onReadinessChangeRef.current?.(data);
+      return true;
+    } catch {
+      return false;
+    }
+  }, []);
+
+  const run = useCallback(
+    async (action: AgentActionId) => {
+      const current = readinessRef.current;
+      if (!current || runningRef.current) return;
+      if (!current.allowedActions.includes(action)) return;
+
+      const generation = generationRef.current + 1;
+      generationRef.current = generation;
+      runningRef.current = true;
+      lastActionRef.current = action;
+      setJobId(null);
+      setBusy(true);
+      setStage("checking");
+      setCancellable(false);
+      setError(null);
+      setReasonCode(null);
+      setSuccess(null);
+
+      let outcome: "succeeded" | "failed" | "cancelled" | "timeout" | "error";
+      let outcomeReason: AgentReasonCode | null;
+
+      try {
+        const result = await portRef.current.startAction({
+          agentId: agentIdRef.current,
+          action,
+          expectedReleaseId: current.releaseId ?? undefined,
+        });
+        if (generationRef.current !== generation) return;
+        setStage(result.stage);
+
+        if (result.jobId) {
+          setJobId(result.jobId);
+          let snapshot = await portRef.current.getActionJob(result.jobId);
+          if (generationRef.current !== generation) return;
+          setStage(snapshot.stage);
+          setCancellable(snapshot.cancellable);
+
+          for (let attempt = 0; attempt < maxPollsRef.current; attempt += 1) {
+            if (isTerminalAgentJobStage(snapshot.stage)) {
+              break;
+            }
+            await wait(pollIntervalMsRef.current);
+            if (generationRef.current !== generation) return;
+            snapshot = await portRef.current.getActionJob(result.jobId);
+            if (generationRef.current !== generation) return;
+            setStage(snapshot.stage);
+            setCancellable(snapshot.cancellable);
+          }
+
+          if (!isTerminalAgentJobStage(snapshot.stage)) {
+            outcome = "timeout";
+            outcomeReason = null;
+          } else if (snapshot.stage === "succeeded") {
+            outcome = "succeeded";
+            outcomeReason = snapshot.reasonCode;
+          } else if (snapshot.stage === "cancelled") {
+            outcome = "cancelled";
+            outcomeReason = snapshot.reasonCode;
+          } else {
+            outcome = "failed";
+            outcomeReason = snapshot.reasonCode;
+          }
+        } else if (result.stage === "succeeded") {
+          outcome = "succeeded";
+          outcomeReason = result.reasonCode;
+        } else if (result.stage === "cancelled") {
+          outcome = "cancelled";
+          outcomeReason = result.reasonCode;
+        } else {
+          outcome = "failed";
+          outcomeReason = result.reasonCode;
+        }
+      } catch (caught) {
+        if (generationRef.current !== generation) return;
+        outcome = "error";
+        outcomeReason = actionErrorReason(caught);
+      }
+
+      const readbackOk = await reread(generation);
+      if (generationRef.current !== generation) return;
+
+      setReasonCode(outcomeReason);
+      if (outcome === "succeeded" && readbackOk) {
+        setSuccess(AGENT_LIFECYCLE_SUCCEEDED_COPY);
+        setError(null);
+      } else if (outcome === "timeout") {
+        setSuccess(null);
+        setError(AGENT_LIFECYCLE_TIMEOUT_COPY);
+      } else {
+        setSuccess(null);
+        setError(agentLifecycleFailureCopy(outcomeReason));
+      }
+      runningRef.current = false;
+      setBusy(false);
+      setStage(null);
+      setCancellable(false);
+      setJobId(null);
+    },
+    [reread],
+  );
+
+  const runPrimary = useCallback(async () => {
+    const next = deriveAgentLifecyclePrimaryAction(readinessRef.current);
+    if (!next) return;
+    await run(next);
+  }, [run]);
+
+  const retry = useCallback(async () => {
+    const last = lastActionRef.current;
+    if (last && readinessRef.current?.allowedActions.includes(last)) {
+      await run(last);
+      return;
+    }
+    await runPrimary();
+  }, [run, runPrimary]);
+
+  const cancel = useCallback(async () => {
+    if (!jobId || !cancellable) return;
+    const requestedJobId = jobId;
+    const generation = generationRef.current;
+    try {
+      const snapshot = await portRef.current.cancelAction(requestedJobId);
+      if (generationRef.current !== generation) return;
+      setStage(snapshot.stage);
+      setCancellable(snapshot.cancellable);
+    } catch (caught) {
+      if (generationRef.current !== generation) return;
+      setReasonCode(actionErrorReason(caught));
+      setError(agentLifecycleFailureCopy(actionErrorReason(caught)));
+    }
+  }, [cancellable, jobId]);
+
+  return {
+    primaryAction,
+    busy,
+    stage,
+    percent: null,
+    error,
+    reasonCode,
+    success,
+    canCancel: busy && jobId !== null && cancellable,
+    canRetry: !busy && error !== null,
+    run,
+    runPrimary,
+    retry,
+    cancel,
+  };
+}

--- a/src/v2/pages/models/OpenCodeModelsPanel.tsx
+++ b/src/v2/pages/models/OpenCodeModelsPanel.tsx
@@ -4,7 +4,10 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { classNames } from "../../shared/design-system/classNames";
 import { useFeatures } from "../../shared/features/provider";
 import { useOpenCodeModelSnapshot } from "../../shared/features/queries";
-import type { OpenCodeSaveModelsRequest } from "../../shared/features/types";
+import type {
+  ModelWriteTarget,
+  OpenCodeSaveModelsRequest,
+} from "../../shared/features/types";
 import { CatalogDetail } from "../../shared/ui/catalog";
 import {
   Button,
@@ -26,9 +29,10 @@ import { GroupedModelChips, ModelSearchField } from "./modelChips";
 import { ModelConnectivityTest } from "./ModelConnectivityTest";
 import {
   ModelsPanelHeader,
-  ModelsWriteDisclosure,
+  ModelsWriteConfirmDialog,
   NoApiKeyOption,
   useModelsDraftCommit,
+  useModelsWriteConfirm,
 } from "./modelsShared";
 import { isHttpUrl, parseManualModelIds } from "./quickSetup";
 import {
@@ -75,6 +79,12 @@ export function OpenCodeModelsPanel({ active }: { active: boolean }) {
     revision: number;
   } | null>(null);
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+  const writeConfirm = useModelsWriteConfirm<{
+    request: OpenCodeSaveModelsRequest;
+    revision: number;
+    draftIds: string[];
+    targets: readonly ModelWriteTarget[];
+  }>();
   const writeLock = useRef(false);
   const mountedRef = useRef(true);
   const baseUrlInputRef = useRef<HTMLInputElement>(null);
@@ -332,7 +342,7 @@ export function OpenCodeModelsPanel({ active }: { active: boolean }) {
   };
 
   const startSave = () => {
-    if (writeLock.current) return;
+    if (writeLock.current || writeConfirm.open) return;
     const draftIds = collectDraftIds();
     if (draftIds.length === 0) {
       show("draft", { tone: "error", title: "请至少添加一个模型 ID" });
@@ -340,12 +350,29 @@ export function OpenCodeModelsPanel({ active }: { active: boolean }) {
       return;
     }
     if (!validateConnection()) return;
-    const submittedRevision = draftCommit.captureRevision();
-    if (parseManualModelIds(manualDraft).length > 0) {
-      setDraftModelIds(draftIds);
-      setManualDraft("");
-    }
-    void saveRequest(buildSaveRequest(draftIds), submittedRevision);
+    const snapshot = snapshotQuery.data;
+    if (!snapshot) return;
+    writeConfirm.requestConfirm({
+      request: buildSaveRequest(draftIds),
+      revision: draftCommit.captureRevision(),
+      draftIds,
+      targets: [
+        {
+          path: snapshot.path,
+          backupPath: snapshot.backupPath,
+          exists: snapshot.exists,
+        },
+      ],
+    });
+  };
+
+  const confirmWrite = () => {
+    if (writeLock.current) return;
+    const pending = writeConfirm.takePending();
+    if (!pending) return;
+    setDraftModelIds(pending.draftIds);
+    setManualDraft("");
+    void saveRequest(pending.request, pending.revision);
   };
 
   const confirmOverwrite = () => {
@@ -446,17 +473,6 @@ export function OpenCodeModelsPanel({ active }: { active: boolean }) {
           暂时无法读取 OpenCode 配置，请重试。
         </InlineNotice>
       )}
-      {!loading && !readFailed && snapshotQuery.data ? (
-        <ModelsWriteDisclosure
-          targets={[
-            {
-              path: snapshotQuery.data.path,
-              backupPath: snapshotQuery.data.backupPath,
-              exists: snapshotQuery.data.exists,
-            },
-          ]}
-        />
-      ) : null}
 
       <section
         className="fy-models-existing"
@@ -770,6 +786,14 @@ export function OpenCodeModelsPanel({ active }: { active: boolean }) {
           </p>
         ) : null}
       </Dialog>
+      <ModelsWriteConfirmDialog
+        open={writeConfirm.open}
+        targets={writeConfirm.pending?.targets ?? []}
+        onConfirm={confirmWrite}
+        onCancel={() => {
+          writeConfirm.takePending();
+        }}
+      />
     </CatalogDetail>
   );
 }

--- a/src/v2/pages/models/Page.css
+++ b/src/v2/pages/models/Page.css
@@ -208,11 +208,8 @@
 
 .fy-models-write-disclosure {
   display: grid;
-  gap: 8px;
-  padding: 12px;
-  border: 1px solid var(--fy-border);
-  border-radius: 12px;
-  background: var(--fy-surface);
+  gap: 10px;
+  min-width: 0;
 }
 
 .fy-models-write-disclosure > p {

--- a/src/v2/pages/models/Page.tsx
+++ b/src/v2/pages/models/Page.tsx
@@ -18,6 +18,7 @@ import {
 } from "../../shared/features/queries";
 import type {
   CodexProviderMutationWarning,
+  ModelWriteTarget,
   ProviderAppId,
   ProviderQuickSetupRequest,
 } from "../../shared/features/types";
@@ -67,10 +68,11 @@ import {
 import { ModelConnectivityTest } from "./ModelConnectivityTest";
 import {
   ModelsPanelHeader,
-  ModelsWriteDisclosure,
+  ModelsWriteConfirmDialog,
   NoApiKeyOption,
   NoticeView,
   useModelsDraftCommit,
+  useModelsWriteConfirm,
 } from "./modelsShared";
 import { OpenCodeModelsPanel } from "./OpenCodeModelsPanel";
 import { QoderModelsPanel } from "./QoderModelsPanel";
@@ -146,6 +148,12 @@ function WorkBuddyPanel({ active }: { active: boolean }) {
   const { notices, show, clear, dismiss } =
     useFieldNotices<WorkBuddyNoticeField>();
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+  const writeConfirm = useModelsWriteConfirm<{
+    request: WorkBuddySaveRequest;
+    revision: number;
+    draftIds: string[];
+    targets: readonly ModelWriteTarget[];
+  }>();
   const [workBuddySaveRequest, setWorkBuddySaveRequest] =
     useState<WorkBuddySaveRequest | null>(null);
   const [workBuddySavePlan, setWorkBuddySavePlan] = useState<ChangePlan | null>(
@@ -343,7 +351,7 @@ function WorkBuddyPanel({ active }: { active: boolean }) {
   };
 
   const startSave = () => {
-    if (writeLock.current) return;
+    if (writeLock.current || writeConfirm.open) return;
     const draftIds = collectDraftIds();
     const hasDraft = draftIds.length > 0;
     if (!hasDraft) {
@@ -355,6 +363,8 @@ function WorkBuddyPanel({ active }: { active: boolean }) {
       return;
     }
     if (!validateConnection()) return;
+    const status = statusQuery.data;
+    if (!status) return;
     const submittedRevision = draftCommit.captureRevision();
     const request = buildSaveRequest(draftIds);
     const submittedApiKey = request.apiKey.trim();
@@ -373,11 +383,27 @@ function WorkBuddyPanel({ active }: { active: boolean }) {
       focusControl(manualModelsInputRef.current);
       return;
     }
-    if (parseManualModelIds(manualDraft).length > 0) {
-      setDraftModelIds(draftIds);
-      setManualDraft("");
-    }
-    void createSavePlan(request, submittedRevision);
+    writeConfirm.requestConfirm({
+      request,
+      revision: submittedRevision,
+      draftIds,
+      targets: [
+        {
+          path: status.path,
+          backupPath: status.backupPath,
+          exists: status.exists,
+        },
+      ],
+    });
+  };
+
+  const confirmWrite = () => {
+    if (writeLock.current) return;
+    const pending = writeConfirm.takePending();
+    if (!pending) return;
+    setDraftModelIds(pending.draftIds);
+    setManualDraft("");
+    void createSavePlan(pending.request, pending.revision);
   };
 
   const createSavePlan = async (
@@ -589,17 +615,6 @@ function WorkBuddyPanel({ active }: { active: boolean }) {
           暂时无法读取 WorkBuddy 配置，请重试。
         </InlineNotice>
       )}
-      {!loading && !readFailed && statusQuery.data ? (
-        <ModelsWriteDisclosure
-          targets={[
-            {
-              path: statusQuery.data.path,
-              backupPath: statusQuery.data.backupPath,
-              exists: statusQuery.data.exists,
-            },
-          ]}
-        />
-      ) : null}
       <section
         className="fy-models-existing"
         data-testid="workbuddy-model-ids"
@@ -870,6 +885,14 @@ function WorkBuddyPanel({ active }: { active: boolean }) {
           </p>
         ) : null}
       </Dialog>
+      <ModelsWriteConfirmDialog
+        open={writeConfirm.open}
+        targets={writeConfirm.pending?.targets ?? []}
+        onConfirm={confirmWrite}
+        onCancel={() => {
+          writeConfirm.takePending();
+        }}
+      />
     </CatalogDetail>
   );
 }
@@ -945,6 +968,11 @@ function ProviderPanel({
     message?: string;
   } | null>(null);
   const writeLock = useRef(false);
+  const writeConfirm = useModelsWriteConfirm<{
+    request: ProviderQuickSetupRequest;
+    revision: number;
+    targets: readonly ModelWriteTarget[];
+  }>();
   const submittedRevisionRef = useRef(0);
   const mountedRef = useRef(true);
   const nameInputRef = useRef<HTMLInputElement>(null);
@@ -1049,8 +1077,8 @@ function ProviderPanel({
     return true;
   };
 
-  const submit = async () => {
-    if (writeLock.current || writesBlocked) return;
+  const requestSave = () => {
+    if (writeLock.current || writesBlocked || writeConfirm.open) return;
     const validated = validateQuickSetup(
       {
         name,
@@ -1074,18 +1102,36 @@ function ProviderPanel({
       if (firstInvalidField) fieldRefs[firstInvalidField].current?.focus();
       return;
     }
+    const targets = summaryQuery.data?.writeTargets ?? [];
+    if (targets.length === 0) return;
+    writeConfirm.requestConfirm({
+      request: buildQuickSetupRequest(
+        app,
+        validated.value,
+        app === "codex" ? { imageExtension, websockets } : undefined,
+      ),
+      revision: draftCommit.captureRevision(),
+      targets,
+    });
+  };
 
+  const confirmWrite = () => {
+    if (writeLock.current) return;
+    const pending = writeConfirm.takePending();
+    if (!pending) return;
+    void submit(pending.request, pending.revision);
+  };
+
+  const submit = async (
+    request: ProviderQuickSetupRequest,
+    submittedRevision: number,
+  ) => {
+    if (writeLock.current || writesBlocked) return;
     writeLock.current = true;
-    const submittedRevision = draftCommit.captureRevision();
     setBusy(true);
     setErrors({});
     setNotice(null);
     setWarningCodes([]);
-    const request = buildQuickSetupRequest(
-      app,
-      validated.value,
-      app === "codex" ? { imageExtension, websockets } : undefined,
-    );
     if (app === "codex") {
       submittedRevisionRef.current = submittedRevision;
       setCodexSavePreviewError(null);
@@ -1288,7 +1334,7 @@ function ProviderPanel({
             Boolean(codexSaveRequest || codexSavePlan) ||
             (summaryQuery.data?.writeTargets.length ?? 0) === 0
           }
-          onClick={() => void submit()}
+          onClick={requestSave}
         >
           {busy
             ? "配置中…"
@@ -1304,11 +1350,6 @@ function ProviderPanel({
           暂时无法读取当前配置，请稍后重试。
         </InlineNotice>
       )}
-      {!queryUnavailable && !queryPending ? (
-        <ModelsWriteDisclosure
-          targets={summaryQuery.data?.writeTargets ?? []}
-        />
-      ) : null}
       {!queryUnavailable && !queryPending && (
         <div
           className="fy-models-status-grid"
@@ -1575,6 +1616,14 @@ function ProviderPanel({
           </ul>
         </InlineNotice>
       )}
+      <ModelsWriteConfirmDialog
+        open={writeConfirm.open}
+        targets={writeConfirm.pending?.targets ?? []}
+        onConfirm={confirmWrite}
+        onCancel={() => {
+          writeConfirm.takePending();
+        }}
+      />
     </CatalogDetail>
   );
 }

--- a/src/v2/pages/models/modelsShared.tsx
+++ b/src/v2/pages/models/modelsShared.tsx
@@ -7,7 +7,13 @@ import { classNames } from "../../shared/design-system/classNames";
 import type { ModelWriteTarget } from "../../shared/features/types";
 import { CatalogDetail } from "../../shared/ui/catalog";
 import { CopyablePath } from "../../shared/ui/CopyablePath";
-import { Badge, Checkbox, Tooltip } from "../../shared/ui/primitives";
+import {
+  Badge,
+  Button,
+  Checkbox,
+  Dialog,
+  Tooltip,
+} from "../../shared/ui/primitives";
 import { FieldFeedback, type Notice } from "./feedback";
 import type {
   ModelProbeResult,
@@ -46,6 +52,30 @@ export function useModelsDraftCommit() {
   };
 }
 
+export function useModelsWriteConfirm<T>() {
+  const [pending, setPending] = useState<T | null>(null);
+  const pendingRef = useRef<T | null>(null);
+
+  const requestConfirm = useCallback((value: T) => {
+    pendingRef.current = value;
+    setPending(value);
+  }, []);
+
+  const takePending = useCallback((): T | null => {
+    const value = pendingRef.current;
+    pendingRef.current = null;
+    setPending(null);
+    return value;
+  }, []);
+
+  return {
+    open: pending !== null,
+    pending,
+    requestConfirm,
+    takePending,
+  };
+}
+
 export function ModelsWriteDisclosure({
   targets,
 }: {
@@ -53,11 +83,7 @@ export function ModelsWriteDisclosure({
 }) {
   if (targets.length === 0) return null;
   return (
-    <section className="fy-models-write-disclosure" aria-label="配置写入与备份">
-      <strong>保存前确认</strong>
-      <p>
-        本次只修改下列配置文件中的相关模型字段，并在写入前保留一份滚动备份。
-      </p>
+    <div className="fy-models-write-disclosure">
       <div className="fy-models-write-targets">
         {targets.map((target) => (
           <div className="fy-models-write-target" key={target.path}>
@@ -80,7 +106,42 @@ export function ModelsWriteDisclosure({
       <p className="fy-models-muted">
         每个文件只保留这一份备份；再次保存会用修改前的最新内容更新它。
       </p>
-    </section>
+    </div>
+  );
+}
+
+export function ModelsWriteConfirmDialog({
+  open,
+  targets,
+  onConfirm,
+  onCancel,
+}: {
+  open: boolean;
+  targets: readonly ModelWriteTarget[];
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onCancel();
+      }}
+      title="保存前确认"
+      description="本次只修改下列配置文件中的相关模型字段，并在写入前保留一份滚动备份。"
+      actions={
+        <>
+          <Button autoFocus onClick={onCancel}>
+            取消
+          </Button>
+          <Button className="fy-control-button-primary" onClick={onConfirm}>
+            确认保存
+          </Button>
+        </>
+      }
+    >
+      <ModelsWriteDisclosure targets={targets} />
+    </Dialog>
   );
 }
 

--- a/src/v2/shared/ui/Collapsible.tsx
+++ b/src/v2/shared/ui/Collapsible.tsx
@@ -1,0 +1,177 @@
+import {
+  Content as CollapsibleContentPrimitive,
+  Root as CollapsibleRootPrimitive,
+  Trigger as CollapsibleTriggerPrimitive,
+} from "@radix-ui/react-collapsible";
+import {
+  useLayoutEffect,
+  useRef,
+  type HTMLAttributes,
+  type ReactNode,
+} from "react";
+
+import { classNames } from "../design-system/classNames";
+import {
+  animate,
+  fyMotionTransition,
+  fySpringTransition,
+  motion,
+  useMotionValue,
+  useReducedMotion,
+} from "./motion";
+
+import "./collapsible.css";
+
+type CollapsibleClosedProps = {
+  inert?: "";
+  "aria-hidden"?: boolean;
+};
+
+export function Collapsible({
+  open,
+  onOpenChange,
+  children,
+  className,
+  asChild,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: ReactNode;
+  className?: string;
+  asChild?: boolean;
+}) {
+  return (
+    <CollapsibleRootPrimitive
+      open={open}
+      onOpenChange={onOpenChange}
+      className={className}
+      asChild={asChild}
+    >
+      {children}
+    </CollapsibleRootPrimitive>
+  );
+}
+
+export const CollapsibleTrigger = CollapsibleTriggerPrimitive;
+
+function CollapsibleMotionPanel({
+  open,
+  children,
+}: {
+  open: boolean;
+  children: ReactNode;
+}) {
+  const reduceMotion = useReducedMotion() === true;
+  const panelRef = useRef<HTMLDivElement>(null);
+  const height = useMotionValue<number | "auto">(open ? "auto" : 0);
+  const lastOpenHeightRef = useRef(0);
+  const hasMountedRef = useRef(false);
+  const generationRef = useRef(0);
+
+  useLayoutEffect(() => {
+    const panel = panelRef.current;
+    if (!panel) {
+      return;
+    }
+
+    if (open) {
+      const measured = panel.scrollHeight;
+      if (measured > 0) {
+        lastOpenHeightRef.current = measured;
+      }
+    }
+
+    if (!hasMountedRef.current) {
+      hasMountedRef.current = true;
+      height.set(open ? "auto" : 0);
+      return;
+    }
+
+    if (reduceMotion) {
+      height.set(open ? "auto" : 0);
+      return;
+    }
+
+    const generation = ++generationRef.current;
+
+    if (open) {
+      const target = panel.scrollHeight || lastOpenHeightRef.current;
+      if (height.get() === "auto") {
+        height.set(0);
+      }
+      const controls = animate(height, target, fySpringTransition);
+      void controls.then(() => {
+        if (generationRef.current !== generation) {
+          return;
+        }
+        height.set("auto");
+      });
+      return () => {
+        controls.stop();
+      };
+    }
+
+    const current = height.get();
+    height.set(current === "auto" ? lastOpenHeightRef.current : current);
+    const controls = animate(height, 0, fySpringTransition);
+    return () => {
+      controls.stop();
+    };
+  }, [height, open, reduceMotion]);
+
+  const closedProps: CollapsibleClosedProps = open
+    ? {}
+    : { inert: "", "aria-hidden": true };
+
+  return (
+    <motion.div
+      ref={panelRef}
+      className="fy-collapsible-panel"
+      style={{ height }}
+      {...closedProps}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+export function CollapsibleContent({
+  open,
+  children,
+  className,
+  ...props
+}: {
+  open: boolean;
+  children: ReactNode;
+  className?: string;
+} & Omit<HTMLAttributes<HTMLDivElement>, "children">) {
+  return (
+    <CollapsibleContentPrimitive forceMount className={className} {...props}>
+      <CollapsibleMotionPanel open={open}>{children}</CollapsibleMotionPanel>
+    </CollapsibleContentPrimitive>
+  );
+}
+
+export function CollapsibleCaret({
+  open,
+  children,
+  className,
+}: {
+  open: boolean;
+  children: ReactNode;
+  className?: string;
+}) {
+  const reduceMotion = useReducedMotion() === true;
+
+  return (
+    <motion.span
+      className={classNames("fy-collapsible-caret", className)}
+      initial={false}
+      animate={{ rotate: open ? 180 : 0 }}
+      transition={fyMotionTransition(reduceMotion)}
+      aria-hidden
+    >
+      {children}
+    </motion.span>
+  );
+}

--- a/src/v2/shared/ui/SelectionLens.tsx
+++ b/src/v2/shared/ui/SelectionLens.tsx
@@ -1,10 +1,4 @@
 import {
-  animate,
-  motion,
-  useMotionValue,
-  useReducedMotion,
-} from "framer-motion";
-import {
   createContext,
   useCallback,
   useContext,
@@ -15,15 +9,17 @@ import {
 } from "react";
 
 import { classNames } from "../design-system/classNames";
+import {
+  animate,
+  fySpringTransition,
+  motion,
+  useMotionValue,
+  useReducedMotion,
+} from "./motion";
 
 import "./selection-lens.css";
 
-export const selectionLensTransition = {
-  type: "spring",
-  stiffness: 520,
-  damping: 42,
-  mass: 0.62,
-} as const;
+export { fySpringTransition as selectionLensTransition };
 
 type LensBox = {
   x: number;
@@ -229,10 +225,10 @@ export function SelectionLensGroup({
     }
 
     const controls = [
-      animate(left, box.x, selectionLensTransition),
-      animate(top, box.y, selectionLensTransition),
-      animate(width, box.width, selectionLensTransition),
-      animate(height, box.height, selectionLensTransition),
+      animate(left, box.x, fySpringTransition),
+      animate(top, box.y, fySpringTransition),
+      animate(width, box.width, fySpringTransition),
+      animate(height, box.height, fySpringTransition),
     ];
     return () => {
       for (const control of controls) {

--- a/src/v2/shared/ui/SelectionLens.tsx
+++ b/src/v2/shared/ui/SelectionLens.tsx
@@ -77,6 +77,61 @@ function observeHiddenAncestors(
   return () => observer.disconnect();
 }
 
+function isSelectionLensOverlay(node: Element): boolean {
+  return node.classList.contains("fy-selection-lens");
+}
+
+function observeLayoutSubtree(
+  root: HTMLElement,
+  observer: ResizeObserver,
+): () => void {
+  const observed = new Set<Element>();
+
+  const observeNode = (node: Element) => {
+    if (isSelectionLensOverlay(node)) {
+      return;
+    }
+    if (!observed.has(node)) {
+      observer.observe(node);
+      observed.add(node);
+    }
+    for (const child of node.children) {
+      observeNode(child);
+    }
+  };
+
+  observeNode(root);
+
+  const mutations = new MutationObserver((records) => {
+    for (const record of records) {
+      for (const added of record.addedNodes) {
+        if (added instanceof Element) {
+          observeNode(added);
+        }
+      }
+      for (const removed of record.removedNodes) {
+        if (removed instanceof Element) {
+          const forget = (node: Element) => {
+            observer.unobserve(node);
+            observed.delete(node);
+            for (const child of node.children) {
+              forget(child);
+            }
+          };
+          forget(removed);
+        }
+      }
+    }
+  });
+  mutations.observe(root, { childList: true, subtree: true });
+
+  return () => {
+    mutations.disconnect();
+    observer.disconnect();
+    observed.clear();
+  };
+}
+
 export function SelectionLensGroup({
   id,
   inset = 0,
@@ -179,14 +234,15 @@ export function SelectionLensGroup({
         : new ResizeObserver(() => {
             syncBox();
           });
-    observer?.observe(scope);
-    observer?.observe(host);
+    const stopLayoutWatch = observer
+      ? observeLayoutSubtree(scope, observer)
+      : () => undefined;
     window.addEventListener("resize", syncBox);
     const stopHiddenWatch = observeHiddenAncestors(scope, syncBox);
     syncBox();
 
     return () => {
-      observer?.disconnect();
+      stopLayoutWatch();
       window.removeEventListener("resize", syncBox);
       stopHiddenWatch();
     };

--- a/src/v2/shared/ui/collapsible.css
+++ b/src/v2/shared/ui/collapsible.css
@@ -1,0 +1,15 @@
+.fy-collapsible-panel {
+  overflow: hidden;
+}
+
+.fy-collapsible-caret {
+  display: inline-flex;
+  transform-origin: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fy-collapsible-panel,
+  .fy-collapsible-caret {
+    transition: none;
+  }
+}

--- a/src/v2/shared/ui/motion.ts
+++ b/src/v2/shared/ui/motion.ts
@@ -1,0 +1,17 @@
+export {
+  animate,
+  motion,
+  useMotionValue,
+  useReducedMotion,
+} from "framer-motion";
+
+export const fySpringTransition = {
+  type: "spring",
+  stiffness: 520,
+  damping: 42,
+  mass: 0.62,
+} as const;
+
+export function fyMotionTransition(reduceMotion: boolean) {
+  return reduceMotion ? { duration: 0 } : fySpringTransition;
+}

--- a/src/v2/widgets/app-shell/SideNavigation.tsx
+++ b/src/v2/widgets/app-shell/SideNavigation.tsx
@@ -7,7 +7,6 @@ import {
   type NavigationItem,
 } from "../../shared/config/navigation";
 import { classNames } from "../../shared/design-system/classNames";
-import { LiquidGlassLens } from "../../shared/ui/LiquidGlassLens";
 import {
   SelectionLens,
   SelectionLensGroup,
@@ -43,13 +42,7 @@ function NavigationLink({
         return (
           <>
             <SelectionLens active={visuallyActive} />
-            {visuallyActive ? (
-              <LiquidGlassLens className="fy-side-navigation-liquid-lens">
-                {label}
-              </LiquidGlassLens>
-            ) : (
-              label
-            )}
+            {label}
           </>
         );
       }}
@@ -202,13 +195,7 @@ export function SideNavigation() {
                 }
               >
                 <SelectionLens active={visuallyActive} />
-                {visuallyActive ? (
-                  <LiquidGlassLens className="fy-side-navigation-liquid-lens">
-                    {content}
-                  </LiquidGlassLens>
-                ) : (
-                  content
-                )}
+                {content}
               </button>
               <ul
                 ref={configurationItemsRef}

--- a/src/v2/widgets/app-shell/SideNavigation.tsx
+++ b/src/v2/widgets/app-shell/SideNavigation.tsx
@@ -8,6 +8,12 @@ import {
 } from "../../shared/config/navigation";
 import { classNames } from "../../shared/design-system/classNames";
 import {
+  Collapsible,
+  CollapsibleCaret,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "../../shared/ui/Collapsible";
+import {
   SelectionLens,
   SelectionLensGroup,
 } from "../../shared/ui/SelectionLens";
@@ -50,12 +56,20 @@ function NavigationLink({
   );
 }
 
+function isExcludedFromKeyboard(control: HTMLElement): boolean {
+  return (
+    control.closest("[hidden]") !== null ||
+    control.closest("[inert]") !== null ||
+    control.closest('[aria-hidden="true"]') !== null
+  );
+}
+
 function visibleNavigationControls(navigation: HTMLElement): HTMLElement[] {
   return Array.from(
     navigation.querySelectorAll<HTMLElement>(
       'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
     ),
-  ).filter((control) => control.closest("[hidden]") === null);
+  ).filter((control) => !isExcludedFromKeyboard(control));
 }
 
 export function SideNavigation() {
@@ -160,60 +174,69 @@ export function SideNavigation() {
           const content = (
             <span className="fy-side-navigation-toggle-content">
               <span>{group.label}</span>
-              <CaretDownIcon
+              <CollapsibleCaret
+                open={configurationExpanded}
                 className="fy-side-navigation-caret"
-                size={16}
-                weight="bold"
-                aria-hidden
-                data-testid="configuration-management-caret"
-              />
+              >
+                <CaretDownIcon
+                  size={16}
+                  weight="bold"
+                  aria-hidden
+                  data-testid="configuration-management-caret"
+                />
+              </CollapsibleCaret>
             </span>
           );
           const visuallyActive = groupActive && !configurationExpanded;
 
           return (
-            <section
-              className="fy-side-navigation-group fy-side-navigation-group-collapsible"
-              aria-labelledby={groupLabelId}
-              data-navigation-group={group.id}
+            <Collapsible
+              asChild
+              open={configurationExpanded}
+              onOpenChange={setConfigurationExpanded}
               key={group.id}
             >
-              <button
-                ref={configurationToggleRef}
-                className={classNames(
-                  "fy-side-navigation-toggle",
-                  groupActive && "fy-side-navigation-toggle-active",
-                )}
-                id={groupLabelId}
-                type="button"
-                aria-expanded={configurationExpanded}
-                aria-controls={configurationItemsId}
-                data-active={groupActive || undefined}
-                data-testid="configuration-management-toggle"
-                onClick={() =>
-                  setConfigurationExpanded((expanded) => !expanded)
-                }
+              <section
+                className="fy-side-navigation-group fy-side-navigation-group-collapsible"
+                aria-labelledby={groupLabelId}
+                data-navigation-group={group.id}
               >
-                <SelectionLens active={visuallyActive} />
-                {content}
-              </button>
-              <ul
-                ref={configurationItemsRef}
-                className="fy-side-navigation-items"
-                id={configurationItemsId}
-                hidden={!configurationExpanded}
-                data-testid="configuration-management-items"
-              >
-                {group.items.map((item) => (
-                  <li key={item.id}>
-                    <NavigationLink
-                      item={item}
-                      visuallyAvailable={configurationExpanded}
-                    />
-                  </li>
-                ))}
-              </ul>
-            </section>
+                <CollapsibleTrigger asChild>
+                  <button
+                    ref={configurationToggleRef}
+                    className={classNames(
+                      "fy-side-navigation-toggle",
+                      groupActive && "fy-side-navigation-toggle-active",
+                    )}
+                    id={groupLabelId}
+                    type="button"
+                    data-active={groupActive || undefined}
+                    data-testid="configuration-management-toggle"
+                  >
+                    <SelectionLens active={visuallyActive} />
+                    {content}
+                  </button>
+                </CollapsibleTrigger>
+                <CollapsibleContent open={configurationExpanded}>
+                  <ul
+                    ref={configurationItemsRef}
+                    className="fy-side-navigation-items"
+                    id={configurationItemsId}
+                    hidden={!configurationExpanded}
+                    data-testid="configuration-management-items"
+                  >
+                    {group.items.map((item) => (
+                      <li key={item.id}>
+                        <NavigationLink
+                          item={item}
+                          visuallyAvailable={configurationExpanded}
+                        />
+                      </li>
+                    ))}
+                  </ul>
+                </CollapsibleContent>
+              </section>
+            </Collapsible>
           );
         })}
       </SelectionLensGroup>

--- a/tests/v2-browser/agents-models.spec.ts
+++ b/tests/v2-browser/agents-models.spec.ts
@@ -63,7 +63,9 @@ test("Agent directory keeps exact native order and accessible configuration entr
   await openV2Page(page, "/agents");
 
   await expect(page.getByTestId("agents-page")).toBeVisible();
-  await expect(agentSelector(page).locator(".fy-agent-directory-card")).toHaveCount(0);
+  await expect(
+    agentSelector(page).locator(".fy-agent-directory-card"),
+  ).toHaveCount(0);
   await page.getByRole("button", { name: "开始扫描" }).click();
   await expect(page.getByRole("button", { name: "重新扫描" })).toBeEnabled();
 
@@ -138,7 +140,9 @@ test("Agent directory and Models keep their responsive 760px boundaries", async 
     const scanBtn = page.getByRole("button", { name: /^(开始扫描|重新扫描)$/ });
     if (await scanBtn.isVisible()) {
       await scanBtn.click();
-      await expect(page.getByRole("button", { name: "重新扫描" })).toBeEnabled();
+      await expect(
+        page.getByRole("button", { name: "重新扫描" }),
+      ).toBeEnabled();
     }
   };
 
@@ -252,13 +256,19 @@ test("Codex configuration loads safely without unsolicited mutation", async ({
 
   await expect(page.getByRole("region", { name: "Codex 配置" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "当前模型" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "进入模型管理" })).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "进入模型管理" }),
+  ).toBeVisible();
   await expect(page.getByRole("button", { name: "返回" })).toBeVisible();
   await expect(page.getByText("单 Agent 配置")).toHaveCount(0);
   await expect(page.getByText("安装、登录与启动能力")).toHaveCount(0);
 
   const calls = await featureFixtureCalls(page);
-  expect(calls.some((call) => call.command.startsWith("codex_desktop_start_install"))).toBe(false);
+  expect(
+    calls.some((call) =>
+      call.command.startsWith("codex_desktop_start_install"),
+    ),
+  ).toBe(false);
   await expectNoHorizontalOverflow(page);
   await expectHealthyPage(page, health);
 });
@@ -458,6 +468,9 @@ test("WorkBuddy save preview uses Change Plan and does not expose overwrite toke
   await page.getByLabel("API Key", { exact: true }).fill(apiKey);
   await page.getByLabel("自定义模型 ID").fill("manual-browser-model");
   await page.getByRole("button", { name: "保存并应用" }).click();
+  await expect(page.getByRole("dialog", { name: "保存前确认" })).toBeVisible();
+  await expect(page.getByText("将修改")).toBeVisible();
+  await page.getByRole("button", { name: "确认保存" }).click();
 
   await expect(page.getByRole("button", { name: "确认应用" })).toBeVisible();
   await expect(
@@ -513,6 +526,7 @@ test("WorkBuddy write failures stay redacted and clear the submitted credential"
   await page.getByLabel("API Key", { exact: true }).fill(apiKey);
   await page.getByLabel("自定义模型 ID").fill("failure-model");
   await page.getByRole("button", { name: "保存并应用" }).click();
+  await page.getByRole("button", { name: "确认保存" }).click();
   await page.getByRole("button", { name: "确认应用" }).click();
 
   await expect(page.locator("body")).toContainText("保存失败，已恢复原配置");
@@ -547,6 +561,7 @@ test("WorkBuddy concurrent modification rereads authority instead of claiming su
     .fill("browser-conflict-secret");
   await page.getByLabel("自定义模型 ID").fill("conflict-model");
   await page.getByRole("button", { name: "保存并应用" }).click();
+  await page.getByRole("button", { name: "确认保存" }).click();
   await page.getByRole("button", { name: "确认应用" }).click();
 
   await expect(page.locator("body")).toContainText("计划已失效");

--- a/tests/v2-browser/agents-models.spec.ts
+++ b/tests/v2-browser/agents-models.spec.ts
@@ -55,6 +55,13 @@ function agentItem(
     .filter({ has: page.getByRole("heading", { name, exact: true }) });
 }
 
+async function confirmSaveDisclosure(page: Parameters<typeof openV2Page>[0]) {
+  const dialog = page.getByRole("dialog", { name: "保存前确认" });
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText("将修改")).toBeVisible();
+  await dialog.getByRole("button", { name: "确认保存" }).click();
+}
+
 test("Agent directory keeps exact native order and accessible configuration entry points", async ({
   page,
 }) => {
@@ -65,8 +72,7 @@ test("Agent directory keeps exact native order and accessible configuration entr
   await expect(page.getByTestId("agents-page")).toBeVisible();
   await expect(
     agentSelector(page).locator(".fy-agent-directory-card"),
-  ).toHaveCount(0);
-  await page.getByRole("button", { name: "开始扫描" }).click();
+  ).toHaveCount(7);
   await expect(page.getByRole("button", { name: "重新扫描" })).toBeEnabled();
 
   const items = agentSelector(page).locator(".fy-agent-directory-card");
@@ -137,13 +143,7 @@ test("Agent directory and Models keep their responsive 760px boundaries", async 
   const health = monitorPageHealth(page);
   await openV2Page(page, "/agents");
   const ensureScanned = async () => {
-    const scanBtn = page.getByRole("button", { name: /^(开始扫描|重新扫描)$/ });
-    if (await scanBtn.isVisible()) {
-      await scanBtn.click();
-      await expect(
-        page.getByRole("button", { name: "重新扫描" }),
-      ).toBeEnabled();
-    }
+    await expect(page.getByRole("button", { name: "重新扫描" })).toBeEnabled();
   };
 
   await ensureScanned();
@@ -236,7 +236,6 @@ test("Agent directory keeps cards clean with no prototype-violating links or dis
   await installRichTauriFeatureFixture(page);
   const health = monitorPageHealth(page);
   await openV2Page(page, "/agents");
-  await page.getByRole("button", { name: "开始扫描" }).click();
   await expect(page.getByRole("button", { name: "重新扫描" })).toBeEnabled();
 
   await expect(page.getByText("查看完整介绍")).toHaveCount(0);
@@ -287,7 +286,6 @@ test("Agent directory does not observe WorkBuddy or Provider summaries before co
   expect(commands).not.toContain("get_workbuddy_status");
   expect(commands).not.toContain("get_providers");
 
-  await page.getByRole("button", { name: "开始扫描" }).click();
   await expect(page.getByRole("button", { name: "重新扫描" })).toBeEnabled();
 
   commands = (await featureFixtureCalls(page)).map((call) => call.command);
@@ -600,11 +598,12 @@ test("Codex quick setup locks duplicate submission and sends exact provider payl
   await page.getByLabel("服务地址").fill("https://codex.example.test/v1");
   await page.getByLabel("API Key", { exact: true }).fill(apiKey);
   await page.getByLabel("模型 ID").fill("gpt-browser");
-  const providerPanel = page.getByRole("region", { name: "Codex 模型配置" });
-  const submit = providerPanel.locator("button.fy-control-button-primary");
+  const submit = page.getByRole("button", { name: "保存并设为当前配置" });
   await submit.click();
-  await expect(submit).toBeDisabled();
-  await submit.dispatchEvent("click");
+  await confirmSaveDisclosure(page);
+  const busySubmit = page.getByRole("button", { name: "配置中…" });
+  await expect(busySubmit).toBeDisabled();
+  await busySubmit.dispatchEvent("click");
   const saveWorkspace = page.getByRole("region", {
     name: "Change Plan Provider 保存",
   });
@@ -750,6 +749,7 @@ test("Claude quick setup updates its reserved row with exact settings and switch
   await page.getByLabel("API Key", { exact: true }).fill(apiKey);
   await page.getByLabel("模型 ID").fill("claude-browser");
   await page.getByRole("button", { name: "保存并设为当前配置" }).click();
+  await confirmSaveDisclosure(page);
   await expect(page.getByLabel("API Key", { exact: true })).toHaveValue("");
 
   await expect
@@ -794,6 +794,7 @@ test("Provider atomic failure reports rollback instead of a partial result", asy
   await page.getByLabel("API Key", { exact: true }).fill("partial-secret");
   await page.getByLabel("模型 ID").fill("partial-model");
   await page.getByRole("button", { name: "保存并设为当前配置" }).click();
+  await confirmSaveDisclosure(page);
   await page
     .getByRole("region", { name: "Change Plan Provider 保存" })
     .getByRole("button", { name: "确认应用" })

--- a/tests/v2-browser/agents-v3.spec.ts
+++ b/tests/v2-browser/agents-v3.spec.ts
@@ -90,7 +90,7 @@ async function installFixture(page: Page): Promise<void> {
   await installAgentV3Overrides(page);
 }
 
-test("Agent V3 scans only on demand and reuses existing Skill and MCP assignments", async ({
+test("Agent V3 shows the full catalog, auto-scans, and reuses existing Skill and MCP assignments", async ({
   page,
 }) => {
   await installFixture(page);
@@ -99,21 +99,7 @@ test("Agent V3 scans only on demand and reuses existing Skill and MCP assignment
 
   const directory = page.getByRole("region", { name: "AI 软件目录" });
   await expect(directory).toBeVisible();
-  // In idle state before scanning, list is empty
-  await expect(directory.getByRole("article")).toHaveCount(0);
-  expect(
-    (await featureFixtureCalls(page)).filter(
-      (call) => call.command === "get_agent_install_readiness",
-    ),
-  ).toEqual([]);
-
-  await directory.getByRole("button", { name: "开始扫描" }).click();
-  await expect(
-    directory.getByRole("button", { name: "扫描中…" }),
-  ).toBeDisabled();
-  await expect(directory.getByRole("button", { name: /取消扫描/ })).toHaveCount(
-    0,
-  );
+  await expect(directory.getByRole("article")).toHaveCount(7);
   await expect
     .poll(
       async () =>
@@ -121,17 +107,18 @@ test("Agent V3 scans only on demand and reuses existing Skill and MCP assignment
           (call) => call.command === "get_agent_install_readiness",
         ).length,
     )
-    .toBe(7);
+    .toBeGreaterThanOrEqual(7);
   await expect(
     directory.getByRole("button", { name: "重新扫描" }),
   ).toBeEnabled();
+  await expect(directory.getByRole("button", { name: /取消扫描/ })).toHaveCount(
+    0,
+  );
 
-  // Completed list only shows installed items (workbuddy, grokbuild, codex, claude-code = 4 items)
-  await expect(directory.getByRole("article")).toHaveCount(4);
   const brandFrames = directory.locator(
     '.fy-agent-directory-card .fy-catalog-brand-frame[data-size="detail"]',
   );
-  await expect(brandFrames).toHaveCount(4);
+  await expect(brandFrames).toHaveCount(7);
   expect(
     await brandFrames.evaluateAll((frames) =>
       frames.map((frame) => ({
@@ -139,10 +126,25 @@ test("Agent V3 scans only on demand and reuses existing Skill and MCP assignment
         height: frame.getBoundingClientRect().height,
       })),
     ),
-  ).toEqual([0, 1, 2, 3].map(() => ({ width: 64, height: 64 })));
+  ).toEqual([0, 1, 2, 3, 4, 5, 6].map(() => ({ width: 64, height: 64 })));
 
-  // Negative assertions
-  await expect(directory.getByText("未确认", { exact: true })).toHaveCount(0);
+  const configurable = ["workbuddy", "grokbuild", "codex", "claude-code"];
+  const blocked = ["qoderwork", "trae-work", "opencode"];
+  for (const agentId of configurable) {
+    await expect(
+      directory.locator(`[data-agent-id="${agentId}"]`).getByRole("button", {
+        name: "进行配置",
+      }),
+    ).toBeEnabled();
+  }
+  for (const agentId of blocked) {
+    await expect(
+      directory.locator(`[data-agent-id="${agentId}"]`).getByRole("button", {
+        name: "进行配置",
+      }),
+    ).toBeDisabled();
+  }
+
   await expect(directory.getByText(/“未确认”不等于“未安装”/)).toHaveCount(0);
   await expect(directory.getByText(/上次扫描：/)).toHaveCount(0);
   await expect(directory.getByText("查看完整介绍")).toHaveCount(0);

--- a/tests/v2-browser/features.spec.ts
+++ b/tests/v2-browser/features.spec.ts
@@ -123,6 +123,25 @@ for (const feature of [
         }),
       );
     expect(assignmentOverflow).toEqual([]);
+    const copyOverflow = await page
+      .locator(".fy-feature-info-card .fy-feature-path .fy-control-button")
+      .evaluateAll((buttons) =>
+        buttons.flatMap((button) => {
+          const card = button.closest(".fy-feature-info-card");
+          if (!(card instanceof HTMLElement)) {
+            return ["copy action is missing an info card"];
+          }
+          const buttonBox = button.getBoundingClientRect();
+          const cardBox = card.getBoundingClientRect();
+          return buttonBox.left < cardBox.left - 1 ||
+            buttonBox.right > cardBox.right + 1 ||
+            buttonBox.top < cardBox.top - 1 ||
+            buttonBox.bottom > cardBox.bottom + 1
+            ? ["copy action overflows info card"]
+            : [];
+        }),
+      );
+    expect(copyOverflow).toEqual([]);
     await expectNoHorizontalOverflow(page);
     await expectHealthyPage(page, health);
   });

--- a/tests/v2-browser/shell.spec.ts
+++ b/tests/v2-browser/shell.spec.ts
@@ -233,6 +233,44 @@ test("keeps hash, selected link, and aria-current aligned for every route", asyn
   await expectHealthyPage(page, health);
 });
 
+test("keeps the memory lens on the memory link after expanding configuration", async ({
+  page,
+}) => {
+  const health = monitorPageHealth(page);
+  await openV2Page(page, "/memory");
+
+  const navigation = page.getByRole("navigation", { name: "主导航" });
+  const toggle = navigation.getByRole("button", { name: "配置管理" });
+  const memory = routeLink(navigation, "记忆模块");
+  await expect(memory).toHaveAttribute("aria-current", "page");
+
+  await toggle.click();
+  await expect(toggle).toHaveAttribute("aria-expanded", "false");
+  await toggle.click();
+  await expect(toggle).toHaveAttribute("aria-expanded", "true");
+  await expect(
+    navigation.getByRole("link", { name: "模型管理" }),
+  ).toBeVisible();
+
+  const selectedLens = navigation.getByTestId("selection-lens");
+  await expect(selectedLens).toHaveCount(1);
+  await expect
+    .poll(async () => {
+      const memoryBox = await memory.boundingBox();
+      const lensBox = await selectedLens.boundingBox();
+      if (!memoryBox || !lensBox) {
+        return false;
+      }
+      return (
+        Math.abs(memoryBox.x - lensBox.x) < 4 &&
+        Math.abs(memoryBox.y - lensBox.y) < 4
+      );
+    })
+    .toBe(true);
+
+  await expectHealthyPage(page, health);
+});
+
 test("reaches every primary control with the keyboard in document order", async ({
   page,
 }) => {

--- a/tests/v2-browser/shell.spec.ts
+++ b/tests/v2-browser/shell.spec.ts
@@ -155,7 +155,7 @@ test("keeps the complete shell visible, separate, and overflow-free", async ({
     expect(box.y + box.height).toBeLessThanOrEqual(viewportSize!.height + 1);
   }
 
-  await expect(page.getByTestId("liquid-glass-lens")).toHaveCount(1);
+  await expect(page.getByTestId("liquid-glass-lens")).toHaveCount(0);
 
   const contentViewport = page.getByTestId("content-viewport");
   const contentBox = await requiredBox(contentViewport, "content viewport");
@@ -192,8 +192,8 @@ test("keeps hash, selected link, and aria-current aligned for every route", asyn
     await expect(selectedLinks).toHaveCount(1);
     await expect(selectedLinks).toHaveText(label);
     const lenses = page.getByTestId("liquid-glass-lens");
-    await expect(lenses).toHaveCount(1);
-    await expect(link.getByTestId("liquid-glass-lens")).toHaveCount(1);
+    await expect(lenses).toHaveCount(0);
+    await expect(link.getByTestId("liquid-glass-lens")).toHaveCount(0);
     await expect(link).toHaveClass(/fy-side-navigation-item-selected/);
     await expect(page.getByTestId("content-viewport")).not.toHaveText("");
 

--- a/tests/v2/app/architecture.test.ts
+++ b/tests/v2/app/architecture.test.ts
@@ -280,11 +280,12 @@ describe("FyAgent V2 architecture boundary", () => {
     ).toEqual([]);
   });
 
-  it("keeps framer-motion behind the selection-lens adapter", () => {
-    const adapterPath = "shared/ui/SelectionLens.tsx";
+  it("keeps framer-motion behind reviewed shared motion owners", () => {
+    const allowedOwners = new Set(["shared/ui/motion.ts"]);
     const violations = parsedModules.flatMap(({ references }) =>
       references.flatMap(({ file, line, specifier }) =>
-        specifier === "framer-motion" && relativeV2Path(file) !== adapterPath
+        specifier === "framer-motion" &&
+        !allowedOwners.has(relativeV2Path(file))
           ? [`${relativeV2Path(file)}:${line} imports ${specifier}`]
           : [],
       ),
@@ -292,7 +293,7 @@ describe("FyAgent V2 architecture boundary", () => {
 
     expect(
       violations,
-      `framer-motion escaped its V2 adapter:\n${violations.join("\n")}`,
+      `framer-motion escaped reviewed shared motion owners:\n${violations.join("\n")}`,
     ).toEqual([]);
   });
 

--- a/tests/v2/app/router-shell.test.tsx
+++ b/tests/v2/app/router-shell.test.tsx
@@ -93,7 +93,7 @@ describe("FyAgent V2 routing", () => {
       expect(
         screen.getByRole("link", { name: "AI软件配置", current: "page" }),
       ).toHaveAttribute("href", "/agents");
-      expect(screen.getAllByTestId("liquid-glass-lens")).toHaveLength(1);
+      expect(screen.queryByTestId("liquid-glass-lens")).not.toBeInTheDocument();
       expect(within(navigation).getAllByTestId("selection-lens")).toHaveLength(
         1,
       );
@@ -116,10 +116,10 @@ describe("FyAgent V2 routing", () => {
 
       expect(activeLink).toHaveAttribute("aria-current", "page");
       expect(selectedLinks).toEqual([activeLink]);
-      expect(within(activeLink).getByTestId("liquid-glass-lens")).toBeVisible();
+      expect(within(activeLink).queryByTestId("liquid-glass-lens")).toBeNull();
       expect(
-        within(navigation).getAllByTestId("liquid-glass-lens"),
-      ).toHaveLength(1);
+        within(navigation).queryByTestId("liquid-glass-lens"),
+      ).not.toBeInTheDocument();
       expect(within(navigation).getByTestId("selection-lens")).toBeVisible();
       expect(within(navigation).getAllByTestId("selection-lens")).toHaveLength(
         1,

--- a/tests/v2/pages/agents/AgentInstallReadinessSection.test.tsx
+++ b/tests/v2/pages/agents/AgentInstallReadinessSection.test.tsx
@@ -14,7 +14,6 @@ import type {
   AgentActionResult,
   AgentInstallReadiness,
   AgentInstallReadinessPort,
-  StartAgentActionRequest,
 } from "@/v2/shared/features/agent-install-readiness";
 
 function readiness(agentId: "qoderwork" | "codex"): AgentInstallReadiness {
@@ -123,40 +122,32 @@ describe("AgentInstallReadinessSection", () => {
     let stage: AgentActionJobStage = "downloading";
     const port: AgentInstallReadinessPort = {
       get: vi.fn(async () => (stage === "succeeded" ? current : available)),
-      startAction: vi.fn(
-        async (
-          _request: StartAgentActionRequest,
-        ): Promise<AgentActionResult> => ({
-          contractVersion: 1,
-          agentId: "qoderwork",
-          action: "update",
-          jobId: "job-1",
-          stage: "checking",
-          reasonCode: null,
-        }),
-      ),
-      cancelAction: vi.fn(
-        async (_jobId: string): Promise<AgentActionJobSnapshot> => ({
-          contractVersion: 1,
-          jobId: "job-1",
-          agentId: "qoderwork",
-          action: "update",
-          stage: "cancelled",
-          cancellable: false,
-          reasonCode: "cancelled",
-        }),
-      ),
-      getActionJob: vi.fn(
-        async (_jobId: string): Promise<AgentActionJobSnapshot> => ({
-          contractVersion: 1,
-          jobId: "job-1",
-          agentId: "qoderwork",
-          action: "update",
-          stage,
-          cancellable: true,
-          reasonCode: null,
-        }),
-      ),
+      startAction: vi.fn(async (): Promise<AgentActionResult> => ({
+        contractVersion: 1,
+        agentId: "qoderwork",
+        action: "update",
+        jobId: "job-1",
+        stage: "checking",
+        reasonCode: null,
+      })),
+      cancelAction: vi.fn(async (): Promise<AgentActionJobSnapshot> => ({
+        contractVersion: 1,
+        jobId: "job-1",
+        agentId: "qoderwork",
+        action: "update",
+        stage: "cancelled",
+        cancellable: false,
+        reasonCode: "cancelled",
+      })),
+      getActionJob: vi.fn(async (): Promise<AgentActionJobSnapshot> => ({
+        contractVersion: 1,
+        jobId: "job-1",
+        agentId: "qoderwork",
+        action: "update",
+        stage,
+        cancellable: true,
+        reasonCode: null,
+      })),
     };
     render(<AgentInstallReadinessSection agentId="qoderwork" port={port} />);
     fireEvent.click(

--- a/tests/v2/pages/agents/Page.test.tsx
+++ b/tests/v2/pages/agents/Page.test.tsx
@@ -5,6 +5,8 @@ import { describe, expect, it, vi } from "vitest";
 
 import { AgentsPage } from "@/v2/pages/agents/Page";
 import type {
+  AgentActionJobSnapshot,
+  AgentActionResult,
   AgentInstallReadiness,
   AgentInstallState,
 } from "@/v2/shared/features/agent-install-readiness";
@@ -121,21 +123,26 @@ function catalog(): AgentCatalogResult {
 function readiness(
   agentId: AgentCatalogId,
   installState: AgentInstallState = "installed",
+  overrides: Partial<AgentInstallReadiness> = {},
 ): AgentInstallReadiness {
   return {
     contractVersion: 2,
-    agentId,
     reviewedAt: "2026-08-26",
-    installState,
     updateState: installState === "installed" ? "up_to_date" : "unknown",
     releaseId: null,
-    localVersion: installState === "installed" ? "1.0.0" : null,
+    localVersion:
+      installState === "installed" || installState === "installed_not_runnable"
+        ? "1.0.0"
+        : null,
     remoteVersion: null,
     authOwnership: "agent_owned",
     authState: "unknown",
     sourceKind: "managed_desktop",
     allowedActions: [],
     reasonCodes: ["auth_state_unknown"],
+    ...overrides,
+    agentId,
+    installState,
   };
 }
 
@@ -275,22 +282,28 @@ function configuredPorts(): FeaturePorts {
     currentId: "current",
     writeTargets: [],
   }));
+  const codexPlatformVersion = {
+    kind: "windows_msix" as const,
+    major: 1,
+    minor: 2,
+    build: 3,
+    revision: 4,
+  };
   ports.codexDesktop = {
     getLocalStatus: async () => ({
-      state: "not_installed",
-      platform: "windows",
-      architecture: "x86_64",
+      state: "installed",
+      application: {
+        stableIdentity: "codex-desktop",
+        displayName: "Codex",
+        displayVersion: "1.2.3.4",
+        platformVersion: codexPlatformVersion,
+        architecture: "x86_64",
+      },
     }),
     checkLatest: async () => ({
       releaseId: `v1:${"a".repeat(64)}`,
       displayVersion: "1.2.3.4",
-      platformVersion: {
-        kind: "windows_msix",
-        major: 1,
-        minor: 2,
-        build: 3,
-        revision: 4,
-      },
+      platformVersion: codexPlatformVersion,
       downloadSizeHint: 4096,
       checkedAt: "2026-08-26T00:00:00.000Z",
     }),
@@ -335,9 +348,33 @@ function deferred<T>() {
   return { promise, resolve, reject };
 }
 
+const CATALOG_NAMES = [
+  "QoderWork CN",
+  "TRAE Work CN",
+  "WorkBuddy",
+  "Grok Build",
+  "Codex",
+  "Claude Code",
+  "OpenCode",
+] as const;
+
+function directoryArticle(name: (typeof CATALOG_NAMES)[number]) {
+  const heading = screen.getByRole("heading", { name });
+  const article = heading.closest("article");
+  if (!article) {
+    throw new Error(`missing article for ${name}`);
+  }
+  return article;
+}
+
+function configureButton(name: (typeof CATALOG_NAMES)[number]) {
+  return within(directoryArticle(name)).getByRole("button", {
+    name: "进行配置",
+  });
+}
+
 describe("V3 Agent directory and configuration shell", () => {
-  it("aggregates seven readiness queries with progress and filters completed list to installed only", async () => {
-    const user = userEvent.setup();
+  it("shows all catalog rows immediately and settles readiness progressively", async () => {
     const ports = configuredPorts();
     const reads = {} as Record<
       AgentCatalogId,
@@ -352,53 +389,80 @@ describe("V3 Agent directory and configuration shell", () => {
     renderPage(ports);
 
     expect(
-      await screen.findByRole("button", { name: "开始扫描" }),
+      await screen.findByRole("heading", { name: "我的 AI 软件" }),
     ).toBeVisible();
     expect(screen.getByTestId("agents-page")).toHaveAttribute(
       "data-view",
       "directory",
     );
-    // In idle state, list is empty before scan
-    expect(screen.queryByRole("article")).not.toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: "开始扫描" }));
+    const articles = await screen.findAllByRole("article");
+    expect(articles).toHaveLength(7);
+    expect(
+      articles.map(
+        (item) => within(item).getByRole("heading", { level: 2 }).textContent,
+      ),
+    ).toEqual([...CATALOG_NAMES]);
     expect(screen.getByRole("button", { name: "扫描中…" })).toBeDisabled();
     expect(screen.getByText("正在扫描本机 AI 软件")).toBeVisible();
     expect(screen.getByText("已发现 0 个")).toBeVisible();
     expect(
       screen.queryByRole("button", { name: /取消扫描/ }),
     ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("未发现已安装的 AI 软件"),
+    ).not.toBeInTheDocument();
+    expect(ports.agentInstallReadiness.get).toHaveBeenCalled();
+
+    for (const name of CATALOG_NAMES) {
+      expect(configureButton(name)).toBeDisabled();
+      expect(
+        within(directoryArticle(name)).getByText("正在扫描"),
+      ).toBeVisible();
+    }
 
     reads.qoderwork.resolve(readiness("qoderwork", "installed"));
-    await waitFor(() =>
-      expect(screen.getByText("已发现 1 个")).toBeVisible(),
-    );
+    await waitFor(() => expect(screen.getByText("已发现 1 个")).toBeVisible());
+    await waitFor(() => expect(configureButton("QoderWork CN")).toBeEnabled());
+    expect(configureButton("Codex")).toBeDisabled();
+    expect(
+      within(directoryArticle("Codex")).getByText("正在扫描"),
+    ).toBeVisible();
+
     reads["trae-work"].resolve(readiness("trae-work", "unknown"));
-    for (const agentId of AGENT_CATALOG_IDS.slice(2)) {
+    reads.workbuddy.resolve(readiness("workbuddy", "installed_not_runnable"));
+    for (const agentId of AGENT_CATALOG_IDS.slice(3)) {
       reads[agentId].resolve(readiness(agentId, "not_installed"));
     }
 
     expect(
       await screen.findByRole("button", { name: "重新扫描" }),
     ).toBeEnabled();
-
-    // Only installed agents enter the completed list
-    const articles = screen.getAllByRole("article");
-    expect(articles).toHaveLength(1);
+    expect(screen.getAllByRole("article")).toHaveLength(7);
+    expect(configureButton("QoderWork CN")).toBeEnabled();
+    expect(configureButton("WorkBuddy")).toBeEnabled();
+    expect(configureButton("TRAE Work CN")).toBeDisabled();
+    expect(configureButton("Grok Build")).toBeDisabled();
+    expect(configureButton("Codex")).toBeDisabled();
+    expect(configureButton("Claude Code")).toBeDisabled();
+    expect(configureButton("OpenCode")).toBeDisabled();
     expect(
-      within(articles[0]).getByRole("heading", { level: 2 }).textContent,
-    ).toBe("QoderWork CN");
-
-    // Negative assertions for prototype-violating elements
-    expect(screen.queryByText("未确认")).not.toBeInTheDocument();
-    expect(screen.queryByText("未安装")).not.toBeInTheDocument();
-    expect(screen.queryByText(/“未确认”不等于“未安装”/)).not.toBeInTheDocument();
+      within(directoryArticle("TRAE Work CN")).getByText("状态未知"),
+    ).toBeVisible();
+    expect(
+      screen.queryByRole("button", { name: "一键安装" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "一键更新" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/“未确认”不等于“未安装”/),
+    ).not.toBeInTheDocument();
     expect(screen.queryByText(/上次扫描：/)).not.toBeInTheDocument();
     expect(screen.queryByText("查看完整介绍")).not.toBeInTheDocument();
     expect(ports.agentInstallReadiness.get).toHaveBeenCalledTimes(7);
   });
 
-  it("shows a true empty result and preserves the last success when a rescan fails", async () => {
+  it("keeps all rows after a complete not-installed scan and retains results when a rescan fails", async () => {
     const user = userEvent.setup();
     const ports = configuredPorts();
     ports.agentInstallReadiness.get = vi.fn(async (agentId) =>
@@ -406,10 +470,14 @@ describe("V3 Agent directory and configuration shell", () => {
     );
     renderPage(ports);
 
-    await user.click(await screen.findByRole("button", { name: "开始扫描" }));
-    expect(await screen.findByText("未发现已安装的 AI 软件")).toBeVisible();
-    expect(screen.queryByRole("article")).not.toBeInTheDocument();
-    expect(screen.queryByText("未安装")).not.toBeInTheDocument();
+    expect(await screen.findAllByRole("article")).toHaveLength(7);
+    expect(
+      await screen.findByRole("button", { name: "重新扫描" }),
+    ).toBeEnabled();
+    expect(
+      screen.queryByText("未发现已安装的 AI 软件"),
+    ).not.toBeInTheDocument();
+    expect(configureButton("QoderWork CN")).toBeDisabled();
 
     vi.mocked(ports.agentInstallReadiness.get).mockRejectedValue(
       new Error("readiness offline"),
@@ -418,7 +486,266 @@ describe("V3 Agent directory and configuration shell", () => {
     expect(
       await screen.findByText(/本次扫描未能读取任何软件状态/),
     ).toHaveTextContent("已保留上次成功结果");
+    expect(screen.getAllByRole("article")).toHaveLength(7);
+    expect(configureButton("QoderWork CN")).toBeDisabled();
+    expect(
+      within(directoryArticle("QoderWork CN")).getByText("读取失败"),
+    ).toBeVisible();
     expect(screen.getByRole("button", { name: "重新扫描" })).toBeEnabled();
+  });
+
+  it("offers 一键安装 only when not_installed and backend allows it, then waits for readback", async () => {
+    const user = userEvent.setup();
+    const ports = configuredPorts();
+    const actionJob = deferred<AgentActionJobSnapshot>();
+    const postActionRead = deferred<AgentInstallReadiness>();
+    let scanComplete = false;
+    ports.agentInstallReadiness.get = vi.fn(async (agentId: AgentCatalogId) => {
+      if (scanComplete && agentId === "qoderwork") {
+        return postActionRead.promise;
+      }
+      if (agentId === "qoderwork") {
+        return readiness("qoderwork", "not_installed", {
+          allowedActions: ["install"],
+          releaseId: `v1:${"a".repeat(64)}`,
+        });
+      }
+      return readiness(agentId, "installed");
+    });
+    ports.agentInstallReadiness.startAction = vi.fn(
+      async (): Promise<AgentActionResult> => ({
+        contractVersion: 1,
+        agentId: "qoderwork",
+        action: "install",
+        jobId: "job-1",
+        stage: "checking",
+        reasonCode: null,
+      }),
+    );
+    ports.agentInstallReadiness.getActionJob = vi.fn(
+      async () => actionJob.promise,
+    );
+    renderPage(ports);
+
+    expect(
+      await screen.findByRole("button", { name: "重新扫描" }),
+    ).toBeEnabled();
+    scanComplete = true;
+    expect(
+      within(directoryArticle("QoderWork CN")).getByRole("button", {
+        name: "一键安装",
+      }),
+    ).toBeVisible();
+    expect(
+      within(directoryArticle("WorkBuddy")).queryByRole("button", {
+        name: "一键安装",
+      }),
+    ).not.toBeInTheDocument();
+    expect(configureButton("QoderWork CN")).toBeDisabled();
+
+    await user.click(
+      within(directoryArticle("QoderWork CN")).getByRole("button", {
+        name: "一键安装",
+      }),
+    );
+    expect(
+      await within(directoryArticle("QoderWork CN")).findByText("正在检查来源"),
+    ).toBeVisible();
+    expect(configureButton("QoderWork CN")).toBeDisabled();
+    expect(ports.agentInstallReadiness.startAction).toHaveBeenCalledWith({
+      agentId: "qoderwork",
+      action: "install",
+      expectedReleaseId: `v1:${"a".repeat(64)}`,
+    });
+
+    actionJob.resolve({
+      contractVersion: 1,
+      jobId: "job-1",
+      agentId: "qoderwork",
+      action: "install",
+      stage: "succeeded",
+      cancellable: false,
+      reasonCode: null,
+    });
+    expect(
+      await within(directoryArticle("QoderWork CN")).findByText(
+        "正在读取安装结果",
+      ),
+    ).toBeVisible();
+    expect(configureButton("QoderWork CN")).toBeDisabled();
+
+    postActionRead.resolve(
+      readiness("qoderwork", "installed", { allowedActions: [] }),
+    );
+    await waitFor(() => expect(configureButton("QoderWork CN")).toBeEnabled());
+    expect(
+      within(directoryArticle("QoderWork CN")).queryByRole("button", {
+        name: "一键安装",
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not enable configure after a succeeded job until readback proves installation", async () => {
+    const user = userEvent.setup();
+    const ports = configuredPorts();
+    const postActionRead = deferred<AgentInstallReadiness>();
+    let scanComplete = false;
+    ports.agentInstallReadiness.get = vi.fn(async (agentId: AgentCatalogId) => {
+      if (scanComplete && agentId === "qoderwork")
+        return postActionRead.promise;
+      if (agentId === "qoderwork") {
+        return readiness("qoderwork", "not_installed", {
+          allowedActions: ["install"],
+          releaseId: `v1:${"b".repeat(64)}`,
+        });
+      }
+      return readiness(agentId, "installed");
+    });
+    ports.agentInstallReadiness.startAction = vi.fn(
+      async (): Promise<AgentActionResult> => ({
+        contractVersion: 1,
+        agentId: "qoderwork",
+        action: "install",
+        jobId: "job-2",
+        stage: "checking",
+        reasonCode: null,
+      }),
+    );
+    ports.agentInstallReadiness.getActionJob = vi.fn(
+      async (): Promise<AgentActionJobSnapshot> => ({
+        contractVersion: 1,
+        jobId: "job-2",
+        agentId: "qoderwork",
+        action: "install",
+        stage: "succeeded",
+        cancellable: false,
+        reasonCode: null,
+      }),
+    );
+    renderPage(ports);
+    expect(
+      await screen.findByRole("button", { name: "重新扫描" }),
+    ).toBeEnabled();
+    scanComplete = true;
+
+    await user.click(
+      within(directoryArticle("QoderWork CN")).getByRole("button", {
+        name: "一键安装",
+      }),
+    );
+    expect(
+      await within(directoryArticle("QoderWork CN")).findByText(
+        "正在读取安装结果",
+      ),
+    ).toBeVisible();
+    expect(configureButton("QoderWork CN")).toBeDisabled();
+
+    postActionRead.resolve(
+      readiness("qoderwork", "not_installed", { allowedActions: ["install"] }),
+    );
+    await waitFor(() =>
+      expect(
+        within(directoryArticle("QoderWork CN")).getByRole("button", {
+          name: "一键安装",
+        }),
+      ).toBeVisible(),
+    );
+    expect(configureButton("QoderWork CN")).toBeDisabled();
+  });
+
+  it("offers 一键更新 only when installed, update_available, and backend allows it", async () => {
+    const ports = configuredPorts();
+    ports.agentInstallReadiness.get = vi.fn(async (agentId: AgentCatalogId) => {
+      if (agentId === "workbuddy") {
+        return readiness("workbuddy", "installed", {
+          updateState: "update_available",
+          allowedActions: ["update"],
+        });
+      }
+      if (agentId === "qoderwork") {
+        return readiness("qoderwork", "installed", {
+          updateState: "update_available",
+          allowedActions: [],
+        });
+      }
+      return readiness(agentId, "installed");
+    });
+    renderPage(ports);
+
+    expect(
+      await screen.findByRole("button", { name: "重新扫描" }),
+    ).toBeEnabled();
+    expect(
+      within(directoryArticle("WorkBuddy")).getByRole("button", {
+        name: "一键更新",
+      }),
+    ).toBeVisible();
+    expect(configureButton("WorkBuddy")).toBeEnabled();
+    expect(
+      within(directoryArticle("QoderWork CN")).queryByRole("button", {
+        name: "一键更新",
+      }),
+    ).not.toBeInTheDocument();
+    expect(configureButton("QoderWork CN")).toBeEnabled();
+  });
+
+  it("routes Codex install through the desktop installer owner", async () => {
+    const user = userEvent.setup();
+    const ports = configuredPorts();
+    ports.codexDesktop.getLocalStatus = vi.fn(async () => ({
+      state: "not_installed" as const,
+      platform: "windows" as const,
+      architecture: "x86_64" as const,
+    }));
+    ports.codexDesktop.startInstall = vi.fn(async (releaseId: string) => ({
+      jobId: "11111111-1111-4111-8111-111111111111",
+      sequence: 1,
+      stage: "checking" as const,
+      release: {
+        releaseId,
+        displayVersion: "1.2.3.4",
+        platformVersion: {
+          kind: "windows_msix" as const,
+          major: 1,
+          minor: 2,
+          build: 3,
+          revision: 4,
+        },
+        downloadSizeHint: 4096,
+        checkedAt: "2026-08-26T00:00:00.000Z",
+      },
+      startedAt: "2026-08-26T00:00:00.000Z",
+      updatedAt: "2026-08-26T00:00:01.000Z",
+      progress: null,
+      cancellable: true,
+      result: null,
+      error: null,
+    }));
+    ports.agentInstallReadiness.get = vi.fn(async (agentId: AgentCatalogId) =>
+      readiness(agentId, agentId === "codex" ? "not_installed" : "installed", {
+        allowedActions: [],
+        reasonCodes:
+          agentId === "codex"
+            ? ["managed_by_codex_desktop"]
+            : ["auth_state_unknown"],
+        sourceKind: agentId === "codex" ? "codex_desktop" : "managed_desktop",
+      }),
+    );
+    renderPage(ports);
+
+    expect(
+      await screen.findByRole("button", { name: "重新扫描" }),
+    ).toBeEnabled();
+    const install = await within(directoryArticle("Codex")).findByRole(
+      "button",
+      { name: "一键安装" },
+    );
+    expect(configureButton("Codex")).toBeDisabled();
+    await user.click(install);
+    await waitFor(() =>
+      expect(ports.codexDesktop.startInstall).toHaveBeenCalledTimes(1),
+    );
+    expect(ports.agentInstallReadiness.startAction).not.toHaveBeenCalled();
   });
 
   it("restores target and section from the query, supports back, and enters global management", async () => {

--- a/tests/v2/pages/agents/codexDirectoryActionProjection.test.ts
+++ b/tests/v2/pages/agents/codexDirectoryActionProjection.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+
+import type { InstallerErrorDto } from "@/shared/codex-desktop";
+
+import {
+  projectCodexDirectoryAction,
+  type CodexDirectoryActionSource,
+} from "@/v2/pages/agents/codexDirectoryActionProjection";
+
+function source(
+  overrides: Partial<CodexDirectoryActionSource> = {},
+): CodexDirectoryActionSource {
+  return {
+    primaryAction: null,
+    primaryDisabled: true,
+    isActing: false,
+    state: "checking",
+    progress: undefined,
+    error: null,
+    canCancel: false,
+    operationFailed: false,
+    ...overrides,
+  };
+}
+
+const sampleError: InstallerErrorDto = {
+  code: "DOWNLOAD_FAILED",
+  stage: "downloading",
+  messageKey: "codexDesktop.error.network",
+  retryable: true,
+  suggestedAction: "retry",
+  details: {
+    endpointKind: null,
+    attempt: 1,
+    maxAttempts: 3,
+    httpStatus: null,
+    platformErrorCode: null,
+    redactedMessage: null,
+    context: {},
+  },
+};
+
+describe("projectCodexDirectoryAction", () => {
+  it("copies percent from the existing view model and never invents one", () => {
+    expect(projectCodexDirectoryAction(source()).percent).toBeNull();
+    expect(
+      projectCodexDirectoryAction(
+        source({
+          progress: {
+            current: 50,
+            total: 100,
+            percent: null,
+            bytesPerSecond: 12,
+          },
+        }),
+      ).percent,
+    ).toBeNull();
+    expect(
+      projectCodexDirectoryAction(
+        source({
+          progress: {
+            current: 512,
+            total: 1024,
+            percent: 41,
+            bytesPerSecond: 8,
+          },
+        }),
+      ).percent,
+    ).toBe(41);
+    expect(
+      projectCodexDirectoryAction(
+        source({
+          progress: {
+            current: 0,
+            total: 100,
+            percent: 0,
+            bytesPerSecond: null,
+          },
+        }),
+      ).percent,
+    ).toBe(0);
+  });
+
+  it("derives install/update only from the view model primaryAction", () => {
+    expect(
+      projectCodexDirectoryAction(
+        source({
+          primaryAction: "install",
+          primaryDisabled: false,
+          state: "ready_install",
+        }),
+      ).primaryAction,
+    ).toBe("install");
+    expect(
+      projectCodexDirectoryAction(
+        source({
+          primaryAction: "update",
+          primaryDisabled: false,
+          state: "ready_update",
+        }),
+      ).primaryAction,
+    ).toBe("update");
+    expect(
+      projectCodexDirectoryAction(
+        source({
+          primaryAction: "launch",
+          primaryDisabled: false,
+          state: "ready_launch",
+        }),
+      ).primaryAction,
+    ).toBeNull();
+    expect(
+      projectCodexDirectoryAction(
+        source({
+          primaryAction: "retry",
+          state: "failed",
+          operationFailed: true,
+        }),
+      ),
+    ).toMatchObject({
+      primaryAction: null,
+      canRetry: true,
+    });
+    expect(
+      projectCodexDirectoryAction(
+        source({
+          primaryAction: "refresh",
+          state: "remote_unavailable",
+        }),
+      ).primaryAction,
+    ).toBeNull();
+  });
+
+  it("projects busy, cancel, and error from the existing owner", () => {
+    expect(
+      projectCodexDirectoryAction(
+        source({ isActing: true, state: "ready_install" }),
+      ).busy,
+    ).toBe(true);
+    expect(
+      projectCodexDirectoryAction(
+        source({
+          state: "job_downloading",
+          progress: {
+            current: 10,
+            total: 40,
+            percent: 25,
+            bytesPerSecond: 3,
+          },
+          canCancel: true,
+        }),
+      ),
+    ).toMatchObject({
+      busy: true,
+      percent: 25,
+      canCancel: true,
+      state: "job_downloading",
+    });
+    expect(
+      projectCodexDirectoryAction(
+        source({
+          state: "failed",
+          error: sampleError,
+          primaryAction: "retry",
+        }),
+      ),
+    ).toMatchObject({
+      busy: false,
+      error: sampleError,
+      canRetry: true,
+      percent: null,
+    });
+  });
+
+  it("does not enable run when the view model disabled the primary action", () => {
+    expect(
+      projectCodexDirectoryAction(
+        source({
+          primaryAction: "install",
+          primaryDisabled: true,
+          state: "ready_install",
+        }),
+      ).canRun,
+    ).toBe(false);
+    expect(
+      projectCodexDirectoryAction(
+        source({
+          primaryAction: "install",
+          primaryDisabled: false,
+          state: "ready_install",
+        }),
+      ).canRun,
+    ).toBe(true);
+  });
+});

--- a/tests/v2/pages/agents/useAgentDirectoryScan.test.ts
+++ b/tests/v2/pages/agents/useAgentDirectoryScan.test.ts
@@ -1,0 +1,617 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AgentInstallReadiness } from "@/v2/shared/features/agent-install-readiness";
+import { useAgentInstallReadiness } from "@/v2/shared/features/queries";
+import {
+  AGENT_CATALOG_IDS,
+  type AgentCatalogId,
+} from "@/v2/shared/features/types";
+
+vi.mock("@/v2/shared/features/queries", () => ({
+  useAgentInstallReadiness: vi.fn(),
+}));
+
+import {
+  observeAgentDirectoryRow,
+  scanReducer,
+  useAgentDirectoryScan,
+  type AgentDirectoryScanState,
+} from "@/v2/pages/agents/useAgentDirectoryScan";
+
+type RefetchResult = {
+  data?: AgentInstallReadiness;
+  error?: unknown;
+};
+
+function readiness(
+  agentId: AgentCatalogId,
+  installState: AgentInstallReadiness["installState"],
+): AgentInstallReadiness {
+  return {
+    contractVersion: 2,
+    agentId,
+    reviewedAt: "2026-08-26",
+    installState,
+    updateState: installState === "installed" ? "up_to_date" : "unknown",
+    releaseId: null,
+    localVersion: installState === "installed" ? "1.0.0" : null,
+    remoteVersion: null,
+    authOwnership: "agent_owned",
+    authState: "unknown",
+    sourceKind: "managed_desktop",
+    allowedActions: [],
+    reasonCodes: ["auth_state_unknown"],
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function idleScanState(
+  overrides: Partial<AgentDirectoryScanState> = {},
+): AgentDirectoryScanState {
+  return {
+    status: "idle",
+    requestId: 0,
+    settledIds: [],
+    currentSuccessIds: [],
+    currentFailureIds: [],
+    results: {},
+    lastSuccessfulScanAt: null,
+    ...overrides,
+  };
+}
+
+function mockRefetchMap(
+  refetchById: Record<AgentCatalogId, () => Promise<RefetchResult>>,
+) {
+  vi.mocked(useAgentInstallReadiness).mockImplementation((agentId) => {
+    return {
+      refetch: refetchById[agentId],
+    } as ReturnType<typeof useAgentInstallReadiness>;
+  });
+}
+
+function resolvingRefetch(
+  installState: AgentInstallReadiness["installState"] = "not_installed",
+) {
+  const refetchById = {} as Record<
+    AgentCatalogId,
+    ReturnType<typeof vi.fn<() => Promise<RefetchResult>>>
+  >;
+  for (const agentId of AGENT_CATALOG_IDS) {
+    refetchById[agentId] = vi.fn(async () => ({
+      data: readiness(agentId, installState),
+      error: null,
+    }));
+  }
+  mockRefetchMap(refetchById);
+  return refetchById;
+}
+
+describe("observeAgentDirectoryRow", () => {
+  it("treats idle and in-flight rows without results as pending, not missing", () => {
+    const idle = observeAgentDirectoryRow("codex", idleScanState());
+    expect(idle).toMatchObject({
+      kind: "pending",
+      scanning: false,
+      refreshing: false,
+      configurable: false,
+      readFailed: false,
+    });
+
+    const scanning = observeAgentDirectoryRow(
+      "codex",
+      idleScanState({ status: "scanning", requestId: 1 }),
+    );
+    expect(scanning).toMatchObject({
+      kind: "pending",
+      scanning: true,
+      configurable: false,
+    });
+  });
+
+  it("marks installed and installed_not_runnable as configurable existence", () => {
+    const installed = observeAgentDirectoryRow(
+      "codex",
+      idleScanState({
+        status: "complete",
+        requestId: 1,
+        settledIds: ["codex"],
+        currentSuccessIds: ["codex"],
+        results: { codex: readiness("codex", "installed") },
+        lastSuccessfulScanAt: 1,
+      }),
+    );
+    expect(installed).toMatchObject({
+      kind: "installed",
+      configurable: true,
+      scanning: false,
+    });
+
+    const notRunnable = observeAgentDirectoryRow(
+      "opencode",
+      idleScanState({
+        status: "complete",
+        requestId: 1,
+        settledIds: ["opencode"],
+        currentSuccessIds: ["opencode"],
+        results: { opencode: readiness("opencode", "installed_not_runnable") },
+        lastSuccessfulScanAt: 1,
+      }),
+    );
+    expect(notRunnable).toMatchObject({
+      kind: "installed",
+      configurable: true,
+    });
+  });
+
+  it("marks a settled technical failure as error while other rows are still scanning", () => {
+    const observation = observeAgentDirectoryRow(
+      "codex",
+      idleScanState({
+        status: "scanning",
+        requestId: 1,
+        settledIds: ["codex"],
+        currentFailureIds: ["codex"],
+      }),
+    );
+    expect(observation).toMatchObject({
+      kind: "error",
+      scanning: false,
+      configurable: false,
+      readFailed: true,
+    });
+  });
+
+  it("keeps not_installed, unknown, and unavailable distinct from read failure", () => {
+    const base = {
+      status: "complete" as const,
+      requestId: 1,
+      lastSuccessfulScanAt: 1,
+    };
+
+    expect(
+      observeAgentDirectoryRow(
+        "qoderwork",
+        idleScanState({
+          ...base,
+          settledIds: ["qoderwork"],
+          currentSuccessIds: ["qoderwork"],
+          results: { qoderwork: readiness("qoderwork", "not_installed") },
+        }),
+      ),
+    ).toMatchObject({ kind: "not_installed", configurable: false });
+
+    expect(
+      observeAgentDirectoryRow(
+        "trae-work",
+        idleScanState({
+          ...base,
+          settledIds: ["trae-work"],
+          currentSuccessIds: ["trae-work"],
+          results: { "trae-work": readiness("trae-work", "unknown") },
+        }),
+      ),
+    ).toMatchObject({ kind: "unknown", configurable: false });
+
+    expect(
+      observeAgentDirectoryRow(
+        "workbuddy",
+        idleScanState({
+          ...base,
+          settledIds: ["workbuddy"],
+          currentSuccessIds: ["workbuddy"],
+          results: { workbuddy: readiness("workbuddy", "unavailable") },
+        }),
+      ),
+    ).toMatchObject({ kind: "unavailable", configurable: false });
+
+    expect(
+      observeAgentDirectoryRow(
+        "grokbuild",
+        idleScanState({
+          ...base,
+          settledIds: ["grokbuild"],
+          currentFailureIds: ["grokbuild"],
+        }),
+      ),
+    ).toMatchObject({
+      kind: "error",
+      configurable: false,
+      readFailed: true,
+      readiness: undefined,
+    });
+  });
+
+  it("retains configurability while a previous installed result is refreshing", () => {
+    const observation = observeAgentDirectoryRow(
+      "codex",
+      idleScanState({
+        status: "scanning",
+        requestId: 2,
+        results: { codex: readiness("codex", "installed") },
+        lastSuccessfulScanAt: 1,
+      }),
+    );
+    expect(observation).toMatchObject({
+      kind: "installed",
+      scanning: true,
+      refreshing: true,
+      configurable: true,
+      readFailed: false,
+    });
+  });
+
+  it("does not convert a later technical failure into not-installed", () => {
+    const observation = observeAgentDirectoryRow(
+      "codex",
+      idleScanState({
+        status: "complete",
+        requestId: 2,
+        settledIds: ["codex"],
+        currentFailureIds: ["codex"],
+        results: { codex: readiness("codex", "installed") },
+        lastSuccessfulScanAt: 1,
+      }),
+    );
+    expect(observation.kind).toBe("installed");
+    expect(observation.kind).not.toBe("not_installed");
+    expect(observation.configurable).toBe(true);
+    expect(observation.readFailed).toBe(true);
+    expect(observation.readiness?.installState).toBe("installed");
+  });
+});
+
+describe("scanReducer", () => {
+  it("ignores settled completions from a previous requestId", () => {
+    let state = scanReducer(idleScanState(), { type: "start", requestId: 1 });
+    state = scanReducer(state, {
+      type: "settled",
+      requestId: 1,
+      agentId: "codex",
+      data: readiness("codex", "installed"),
+    });
+    state = scanReducer(state, {
+      type: "finish",
+      requestId: 1,
+      finishedAt: 10,
+    });
+    state = scanReducer(state, { type: "start", requestId: 2 });
+
+    const ignored = scanReducer(state, {
+      type: "settled",
+      requestId: 1,
+      agentId: "codex",
+      data: readiness("codex", "not_installed"),
+    });
+
+    expect(ignored).toBe(state);
+    expect(ignored.results.codex?.installState).toBe("installed");
+    expect(ignored.settledIds).toEqual([]);
+  });
+
+  it("patches readiness without resetting scan status or request identity", () => {
+    const started = scanReducer(idleScanState(), {
+      type: "start",
+      requestId: 3,
+    });
+    const patched = scanReducer(started, {
+      type: "applyReadiness",
+      agentId: "qoderwork",
+      data: readiness("qoderwork", "installed"),
+    });
+
+    expect(patched.status).toBe("scanning");
+    expect(patched.requestId).toBe(3);
+    expect(patched.settledIds).toEqual([]);
+    expect(patched.results.qoderwork?.installState).toBe("installed");
+    expect(observeAgentDirectoryRow("qoderwork", patched).configurable).toBe(
+      true,
+    );
+  });
+});
+
+describe("useAgentDirectoryScan", () => {
+  beforeEach(() => {
+    resolvingRefetch("not_installed");
+  });
+
+  it("does not refetch when autoStart is false", () => {
+    const refetchById = resolvingRefetch("not_installed");
+    const { result } = renderHook(() => useAgentDirectoryScan());
+
+    expect(result.current.state.status).toBe("idle");
+    for (const agentId of AGENT_CATALOG_IDS) {
+      expect(refetchById[agentId]).not.toHaveBeenCalled();
+      expect(observeAgentDirectoryRow(agentId, result.current.state).kind).toBe(
+        "pending",
+      );
+    }
+  });
+
+  it("auto-starts once and ignores start() while scanning", async () => {
+    const pending = deferred<AgentInstallReadiness>();
+    const refetchById = {} as Record<
+      AgentCatalogId,
+      ReturnType<typeof vi.fn<() => Promise<RefetchResult>>>
+    >;
+    for (const agentId of AGENT_CATALOG_IDS) {
+      refetchById[agentId] = vi.fn(() =>
+        pending.promise.then((data) => ({
+          data: { ...data, agentId },
+          error: null,
+        })),
+      );
+    }
+    mockRefetchMap(refetchById);
+
+    const { result } = renderHook(() =>
+      useAgentDirectoryScan({ autoStart: true }),
+    );
+
+    await waitFor(() => expect(result.current.state.status).toBe("scanning"));
+    expect(refetchById.codex).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.start();
+    });
+    expect(refetchById.codex).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      pending.resolve(readiness("codex", "installed"));
+    });
+    await waitFor(() => expect(result.current.state.status).toBe("complete"));
+  });
+
+  it("updates a settled row before the rest of the scan finishes", async () => {
+    const pendingById = {} as Record<
+      AgentCatalogId,
+      ReturnType<typeof deferred<AgentInstallReadiness>>
+    >;
+    const refetchById = {} as Record<
+      AgentCatalogId,
+      ReturnType<typeof vi.fn<() => Promise<RefetchResult>>>
+    >;
+    for (const agentId of AGENT_CATALOG_IDS) {
+      pendingById[agentId] = deferred<AgentInstallReadiness>();
+      refetchById[agentId] = vi.fn(() =>
+        pendingById[agentId].promise.then((data) => ({
+          data,
+          error: null,
+        })),
+      );
+    }
+    mockRefetchMap(refetchById);
+
+    const { result } = renderHook(() => useAgentDirectoryScan());
+    act(() => {
+      result.current.start();
+    });
+
+    await waitFor(() => expect(result.current.state.status).toBe("scanning"));
+
+    await act(async () => {
+      pendingById.qoderwork.resolve(readiness("qoderwork", "installed"));
+    });
+
+    await waitFor(() => {
+      const row = observeAgentDirectoryRow("qoderwork", result.current.state);
+      expect(row.kind).toBe("installed");
+      expect(row.configurable).toBe(true);
+      expect(row.scanning).toBe(false);
+    });
+
+    expect(result.current.state.status).toBe("scanning");
+    expect(observeAgentDirectoryRow("codex", result.current.state).kind).toBe(
+      "pending",
+    );
+    expect(
+      observeAgentDirectoryRow("codex", result.current.state).scanning,
+    ).toBe(true);
+
+    await act(async () => {
+      for (const agentId of AGENT_CATALOG_IDS.slice(1)) {
+        pendingById[agentId].resolve(readiness(agentId, "not_installed"));
+      }
+    });
+    await waitFor(() => expect(result.current.state.status).toBe("complete"));
+  });
+
+  it("marks a failed row as error before the remaining queries settle", async () => {
+    const pendingById = {} as Record<
+      AgentCatalogId,
+      ReturnType<typeof deferred<AgentInstallReadiness>>
+    >;
+    const refetchById = {} as Record<
+      AgentCatalogId,
+      ReturnType<typeof vi.fn<() => Promise<RefetchResult>>>
+    >;
+    for (const agentId of AGENT_CATALOG_IDS) {
+      pendingById[agentId] = deferred<AgentInstallReadiness>();
+      refetchById[agentId] = vi.fn(() =>
+        pendingById[agentId].promise.then((data) => ({
+          data,
+          error: null,
+        })),
+      );
+    }
+    mockRefetchMap(refetchById);
+
+    const { result } = renderHook(() => useAgentDirectoryScan());
+    act(() => {
+      result.current.start();
+    });
+    await waitFor(() => expect(result.current.state.status).toBe("scanning"));
+
+    await act(async () => {
+      pendingById.codex.reject(new Error("readiness offline"));
+    });
+
+    await waitFor(() => {
+      const row = observeAgentDirectoryRow("codex", result.current.state);
+      expect(row.kind).toBe("error");
+      expect(row.kind).not.toBe("not_installed");
+      expect(row.readFailed).toBe(true);
+      expect(row.scanning).toBe(false);
+    });
+    expect(
+      observeAgentDirectoryRow("qoderwork", result.current.state).kind,
+    ).toBe("pending");
+
+    await act(async () => {
+      for (const agentId of AGENT_CATALOG_IDS) {
+        if (agentId === "codex") continue;
+        pendingById[agentId].resolve(readiness(agentId, "not_installed"));
+      }
+    });
+    await waitFor(() => expect(result.current.state.status).toBe("complete"));
+  });
+
+  it("distinguishes a partial technical failure from not-installed", async () => {
+    const refetchById = {} as Record<
+      AgentCatalogId,
+      ReturnType<typeof vi.fn<() => Promise<RefetchResult>>>
+    >;
+    for (const agentId of AGENT_CATALOG_IDS) {
+      refetchById[agentId] = vi.fn(async () => {
+        if (agentId === "codex") {
+          throw new Error("readiness offline");
+        }
+        return {
+          data: readiness(
+            agentId,
+            agentId === "qoderwork" ? "not_installed" : "installed",
+          ),
+          error: null,
+        };
+      });
+    }
+    mockRefetchMap(refetchById);
+
+    const { result } = renderHook(() => useAgentDirectoryScan());
+    await act(async () => {
+      result.current.start();
+    });
+    await waitFor(() => expect(result.current.state.status).toBe("complete"));
+
+    const failed = observeAgentDirectoryRow("codex", result.current.state);
+    expect(failed.kind).toBe("error");
+    expect(failed.kind).not.toBe("not_installed");
+    expect(failed.readFailed).toBe(true);
+    expect(failed.configurable).toBe(false);
+    expect(result.current.state.results.codex).toBeUndefined();
+
+    const missing = observeAgentDirectoryRow("qoderwork", result.current.state);
+    expect(missing.kind).toBe("not_installed");
+    expect(missing.readFailed).toBe(false);
+    expect(result.current.state.currentFailureIds).toEqual(["codex"]);
+  });
+
+  it("retains previous successful results when a later scan fails entirely", async () => {
+    const refetchById = resolvingRefetch("installed");
+    const { result } = renderHook(() => useAgentDirectoryScan());
+
+    await act(async () => {
+      result.current.start();
+    });
+    await waitFor(() => expect(result.current.state.status).toBe("complete"));
+    expect(
+      observeAgentDirectoryRow("codex", result.current.state).configurable,
+    ).toBe(true);
+
+    for (const agentId of AGENT_CATALOG_IDS) {
+      refetchById[agentId].mockRejectedValueOnce(new Error("offline"));
+    }
+
+    await act(async () => {
+      result.current.start();
+    });
+    await waitFor(() => expect(result.current.state.status).toBe("complete"));
+
+    expect(result.current.state.currentSuccessIds).toEqual([]);
+    expect(result.current.state.currentFailureIds).toEqual([
+      ...AGENT_CATALOG_IDS,
+    ]);
+    for (const agentId of AGENT_CATALOG_IDS) {
+      const row = observeAgentDirectoryRow(agentId, result.current.state);
+      expect(row.kind).toBe("installed");
+      expect(row.kind).not.toBe("not_installed");
+      expect(row.configurable).toBe(true);
+      expect(row.readFailed).toBe(true);
+      expect(row.readiness?.installState).toBe("installed");
+    }
+  });
+
+  it("keeps a retained installed result visible during rescan", async () => {
+    const refetchById = resolvingRefetch("installed");
+    const { result } = renderHook(() => useAgentDirectoryScan());
+
+    await act(async () => {
+      result.current.start();
+    });
+    await waitFor(() => expect(result.current.state.status).toBe("complete"));
+
+    const pending = deferred<AgentInstallReadiness>();
+    for (const agentId of AGENT_CATALOG_IDS) {
+      refetchById[agentId].mockImplementation(() =>
+        pending.promise.then((data) => ({
+          data: { ...data, agentId },
+          error: null,
+        })),
+      );
+    }
+
+    act(() => {
+      result.current.start();
+    });
+
+    await waitFor(() => expect(result.current.state.status).toBe("scanning"));
+    const row = observeAgentDirectoryRow("codex", result.current.state);
+    expect(row).toMatchObject({
+      kind: "installed",
+      scanning: true,
+      refreshing: true,
+      configurable: true,
+    });
+
+    await act(async () => {
+      pending.resolve(readiness("codex", "installed"));
+    });
+    await waitFor(() => expect(result.current.state.status).toBe("complete"));
+  });
+
+  it("lets applyReadiness write an authoritative reread into retained results", async () => {
+    const refetchById = resolvingRefetch("not_installed");
+    const { result } = renderHook(() => useAgentDirectoryScan());
+
+    await act(async () => {
+      result.current.start();
+    });
+    await waitFor(() => expect(result.current.state.status).toBe("complete"));
+    expect(
+      observeAgentDirectoryRow("qoderwork", result.current.state).configurable,
+    ).toBe(false);
+
+    act(() => {
+      result.current.applyReadiness(
+        "qoderwork",
+        readiness("qoderwork", "installed"),
+      );
+    });
+
+    const row = observeAgentDirectoryRow("qoderwork", result.current.state);
+    expect(row.kind).toBe("installed");
+    expect(row.configurable).toBe(true);
+    expect(result.current.state.status).toBe("complete");
+    expect(refetchById.qoderwork).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/v2/pages/agents/useAgentLifecycleAction.test.tsx
+++ b/tests/v2/pages/agents/useAgentLifecycleAction.test.tsx
@@ -1,0 +1,559 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+  AgentActionJobSnapshot,
+  AgentActionJobStage,
+  AgentActionResult,
+  AgentInstallReadiness,
+  AgentInstallReadinessPort,
+  AgentInstallState,
+  AgentReasonCode,
+} from "@/v2/shared/features/agent-install-readiness";
+import {
+  AGENT_LIFECYCLE_INCOMPLETE_COPY,
+  AGENT_LIFECYCLE_SUCCEEDED_COPY,
+  AGENT_LIFECYCLE_TIMEOUT_COPY,
+  deriveAgentLifecyclePrimaryAction,
+  useAgentLifecycleAction,
+} from "@/v2/pages/agents/useAgentLifecycleAction";
+
+function readiness(
+  overrides: Partial<AgentInstallReadiness> = {},
+): AgentInstallReadiness {
+  return {
+    contractVersion: 2,
+    agentId: "qoderwork",
+    reviewedAt: "2026-08-25",
+    installState: "not_installed",
+    updateState: "latest_unknown",
+    releaseId: `v1:${"a".repeat(64)}`,
+    localVersion: null,
+    remoteVersion: null,
+    authOwnership: "agent_owned",
+    authState: "unknown",
+    sourceKind: "managed_desktop",
+    allowedActions: ["install"],
+    reasonCodes: ["auth_state_unknown"],
+    ...overrides,
+  };
+}
+
+function jobSnapshot(
+  stage: AgentActionJobStage,
+  overrides: Partial<AgentActionJobSnapshot> = {},
+): AgentActionJobSnapshot {
+  return {
+    contractVersion: 1,
+    jobId: "job-1",
+    agentId: "qoderwork",
+    action: "install",
+    stage,
+    cancellable: stage === "downloading" || stage === "checking",
+    reasonCode: null,
+    ...overrides,
+  };
+}
+
+function actionResult(
+  overrides: Partial<AgentActionResult> = {},
+): AgentActionResult {
+  return {
+    contractVersion: 1,
+    agentId: "qoderwork",
+    action: "install",
+    jobId: "job-1",
+    stage: "checking",
+    reasonCode: null,
+    ...overrides,
+  };
+}
+
+function createPort(
+  overrides: Partial<AgentInstallReadinessPort> = {},
+): AgentInstallReadinessPort {
+  return {
+    get: vi.fn(async () => readiness()),
+    startAction: vi.fn(),
+    cancelAction: vi.fn(),
+    getActionJob: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("deriveAgentLifecyclePrimaryAction", () => {
+  it("offers install only when scan confirmed not_installed and backend allows it", () => {
+    expect(
+      deriveAgentLifecyclePrimaryAction(
+        readiness({
+          installState: "not_installed",
+          allowedActions: ["install"],
+        }),
+      ),
+    ).toBe("install");
+    expect(
+      deriveAgentLifecyclePrimaryAction(
+        readiness({
+          installState: "not_installed",
+          allowedActions: ["launch"],
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      deriveAgentLifecyclePrimaryAction(
+        readiness({ installState: "unknown", allowedActions: ["install"] }),
+      ),
+    ).toBeNull();
+    expect(
+      deriveAgentLifecyclePrimaryAction(
+        readiness({
+          installState: "unavailable",
+          allowedActions: ["install"],
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("offers update only when installed, update_available, and backend allows it", () => {
+    expect(
+      deriveAgentLifecyclePrimaryAction(
+        readiness({
+          installState: "installed",
+          updateState: "update_available",
+          allowedActions: ["update", "launch"],
+        }),
+      ),
+    ).toBe("update");
+    expect(
+      deriveAgentLifecyclePrimaryAction(
+        readiness({
+          installState: "installed_not_runnable",
+          updateState: "update_available",
+          allowedActions: ["update"],
+        }),
+      ),
+    ).toBe("update");
+    expect(
+      deriveAgentLifecyclePrimaryAction(
+        readiness({
+          installState: "installed",
+          updateState: "up_to_date",
+          allowedActions: ["install", "launch"],
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      deriveAgentLifecyclePrimaryAction(
+        readiness({
+          installState: "installed",
+          updateState: "update_available",
+          allowedActions: ["launch"],
+        }),
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("useAgentLifecycleAction", () => {
+  it("shows real job stages and only applies the reread readiness", async () => {
+    const stages: AgentActionJobStage[] = [
+      "downloading",
+      "installing",
+      "succeeded",
+    ];
+    const after: AgentInstallReadiness = readiness({
+      installState: "installed",
+      updateState: "up_to_date",
+      allowedActions: ["launch"],
+    });
+    const port = createPort({
+      get: vi.fn(async () => after),
+      startAction: vi.fn(async () => actionResult()),
+      getActionJob: vi.fn(async () =>
+        jobSnapshot(stages.shift() ?? "succeeded"),
+      ),
+    });
+    const onReadinessChange = vi.fn();
+    const { result } = renderHook(() =>
+      useAgentLifecycleAction({
+        agentId: "qoderwork",
+        port,
+        readiness: readiness(),
+        onReadinessChange,
+        pollIntervalMs: 5,
+      }),
+    );
+
+    expect(result.current.primaryAction).toBe("install");
+    expect(result.current.percent).toBeNull();
+
+    await act(async () => {
+      await result.current.run("install");
+    });
+
+    expect(port.startAction).toHaveBeenCalledWith({
+      agentId: "qoderwork",
+      action: "install",
+      expectedReleaseId: readiness().releaseId,
+    });
+    expect(port.getActionJob).toHaveBeenCalled();
+    expect(port.get).toHaveBeenCalledWith("qoderwork");
+    expect(onReadinessChange).toHaveBeenCalledWith(after);
+    expect(result.current.success).toBe(AGENT_LIFECYCLE_SUCCEEDED_COPY);
+    expect(result.current.busy).toBe(false);
+    expect(result.current.stage).toBeNull();
+    expect(result.current.percent).toBeNull();
+    expect(result.current.primaryAction).toBe("install");
+  });
+
+  it("does not set an optimistic installed flag before authoritative get", async () => {
+    const stillMissing = readiness({ installState: "not_installed" });
+    const observed: AgentInstallState[] = [];
+    const port = createPort({
+      get: vi.fn(async () => stillMissing),
+      startAction: vi.fn(async () =>
+        actionResult({ jobId: "job-1", stage: "succeeded" }),
+      ),
+      getActionJob: vi.fn(async () => jobSnapshot("succeeded")),
+    });
+    const { result } = renderHook(() =>
+      useAgentLifecycleAction({
+        agentId: "qoderwork",
+        port,
+        readiness: readiness(),
+        onReadinessChange: (data) => {
+          observed.push(data.installState);
+        },
+        pollIntervalMs: 5,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.run("install");
+    });
+
+    expect(observed).toEqual(["not_installed"]);
+    expect(result.current.percent).toBeNull();
+    expect(port.get).toHaveBeenCalled();
+  });
+
+  it("runs an immediate CLI action then rereads without polling a job", async () => {
+    const after = readiness({
+      installState: "installed",
+      allowedActions: ["launch"],
+    });
+    const port = createPort({
+      get: vi.fn(async () => after),
+      startAction: vi.fn(async () =>
+        actionResult({ jobId: null, stage: "succeeded", action: "install" }),
+      ),
+    });
+    const { result } = renderHook(() =>
+      useAgentLifecycleAction({
+        agentId: "qoderwork",
+        port,
+        readiness: readiness(),
+        pollIntervalMs: 5,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.runPrimary();
+    });
+
+    expect(port.getActionJob).not.toHaveBeenCalled();
+    expect(port.get).toHaveBeenCalledWith("qoderwork");
+    expect(result.current.success).toBe(AGENT_LIFECYCLE_SUCCEEDED_COPY);
+    expect(result.current.percent).toBeNull();
+  });
+
+  it("surfaces operation_conflict and still rereads", async () => {
+    const port = createPort({
+      get: vi.fn(async () => readiness()),
+      startAction: vi.fn(async () => {
+        const error = new Error("busy") as Error & {
+          reasonCode: AgentReasonCode;
+        };
+        error.reasonCode = "operation_conflict";
+        throw error;
+      }),
+    });
+    const { result } = renderHook(() =>
+      useAgentLifecycleAction({
+        agentId: "qoderwork",
+        port,
+        readiness: readiness(),
+      }),
+    );
+
+    await act(async () => {
+      await result.current.run("install");
+    });
+
+    expect(result.current.error).toBe(
+      "已有安装任务进行中，请等待当前任务结束。",
+    );
+    expect(result.current.reasonCode).toBe("operation_conflict");
+    expect(result.current.success).toBeNull();
+    expect(port.get).toHaveBeenCalledWith("qoderwork");
+    expect(result.current.canRetry).toBe(true);
+  });
+
+  it("surfaces refresh_required from a failed job snapshot", async () => {
+    const port = createPort({
+      get: vi.fn(async () => readiness()),
+      startAction: vi.fn(async () => actionResult()),
+      getActionJob: vi.fn(async () =>
+        jobSnapshot("failed", {
+          reasonCode: "refresh_required",
+          cancellable: false,
+        }),
+      ),
+    });
+    const { result } = renderHook(() =>
+      useAgentLifecycleAction({
+        agentId: "qoderwork",
+        port,
+        readiness: readiness(),
+        pollIntervalMs: 5,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.run("install");
+    });
+
+    expect(result.current.error).toBe("来源已变化，请刷新后再试。");
+    expect(result.current.reasonCode).toBe("refresh_required");
+    expect(result.current.success).toBeNull();
+    expect(port.get).toHaveBeenCalled();
+  });
+
+  it("times out without treating the job as success or failure", async () => {
+    const port = createPort({
+      get: vi.fn(async () => readiness()),
+      startAction: vi.fn(async () => actionResult()),
+      getActionJob: vi.fn(async () => jobSnapshot("downloading")),
+    });
+    const { result } = renderHook(() =>
+      useAgentLifecycleAction({
+        agentId: "qoderwork",
+        port,
+        readiness: readiness(),
+        pollIntervalMs: 1,
+        maxPolls: 1,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.run("install");
+    });
+
+    expect(result.current.error).toBe(AGENT_LIFECYCLE_TIMEOUT_COPY);
+    expect(result.current.success).toBeNull();
+    expect(result.current.reasonCode).toBeNull();
+    expect(port.get).toHaveBeenCalledWith("qoderwork");
+    expect(result.current.percent).toBeNull();
+  });
+
+  it("does not claim success when the authoritative reread fails", async () => {
+    const port = createPort({
+      get: vi.fn(async () => {
+        throw new Error("offline");
+      }),
+      startAction: vi.fn(async () =>
+        actionResult({ jobId: null, stage: "succeeded" }),
+      ),
+    });
+    const onReadinessChange = vi.fn();
+    const { result } = renderHook(() =>
+      useAgentLifecycleAction({
+        agentId: "qoderwork",
+        port,
+        readiness: readiness(),
+        onReadinessChange,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.run("install");
+    });
+
+    expect(onReadinessChange).not.toHaveBeenCalled();
+    expect(result.current.success).toBeNull();
+    expect(result.current.error).toBe(AGENT_LIFECYCLE_INCOMPLETE_COPY);
+  });
+
+  it("ignores actions the backend omitted from allowedActions", async () => {
+    const port = createPort();
+    const { result } = renderHook(() =>
+      useAgentLifecycleAction({
+        agentId: "qoderwork",
+        port,
+        readiness: readiness({ allowedActions: ["launch"] }),
+      }),
+    );
+
+    expect(result.current.primaryAction).toBeNull();
+    await act(async () => {
+      await result.current.run("install");
+      await result.current.run("update");
+    });
+    expect(port.startAction).not.toHaveBeenCalled();
+  });
+
+  it("runs update when that is the derived primary action", async () => {
+    const installed = readiness({
+      installState: "installed",
+      updateState: "update_available",
+      allowedActions: ["update"],
+    });
+    const port = createPort({
+      get: vi.fn(async () => installed),
+      startAction: vi.fn(async () =>
+        actionResult({ action: "update", jobId: null, stage: "succeeded" }),
+      ),
+    });
+    const { result } = renderHook(() =>
+      useAgentLifecycleAction({
+        agentId: "qoderwork",
+        port,
+        readiness: installed,
+      }),
+    );
+
+    expect(result.current.primaryAction).toBe("update");
+    await act(async () => {
+      await result.current.runPrimary();
+    });
+    expect(port.startAction).toHaveBeenCalledWith({
+      agentId: "qoderwork",
+      action: "update",
+      expectedReleaseId: installed.releaseId,
+    });
+  });
+
+  it("retries the last allowed action after a failure", async () => {
+    const startAction = vi
+      .fn<AgentInstallReadinessPort["startAction"]>()
+      .mockRejectedValueOnce(
+        Object.assign(new Error("conflict"), {
+          reasonCode: "operation_conflict",
+        }),
+      )
+      .mockResolvedValueOnce(actionResult({ jobId: null, stage: "succeeded" }));
+    const port = createPort({
+      get: vi.fn(async () => readiness()),
+      startAction,
+    });
+    const { result } = renderHook(() =>
+      useAgentLifecycleAction({
+        agentId: "qoderwork",
+        port,
+        readiness: readiness(),
+      }),
+    );
+
+    await act(async () => {
+      await result.current.run("install");
+    });
+    expect(result.current.canRetry).toBe(true);
+
+    await act(async () => {
+      await result.current.retry();
+    });
+    expect(startAction).toHaveBeenCalledTimes(2);
+    expect(result.current.success).toBe(AGENT_LIFECYCLE_SUCCEEDED_COPY);
+  });
+
+  it("cancels a cancellable job and rereads after the poll observes it", async () => {
+    let cancelled = false;
+    const port = createPort({
+      get: vi.fn(async () => readiness()),
+      startAction: vi.fn(async () => actionResult()),
+      getActionJob: vi.fn(async () =>
+        cancelled
+          ? jobSnapshot("cancelled", {
+              reasonCode: "cancelled",
+              cancellable: false,
+            })
+          : jobSnapshot("downloading"),
+      ),
+      cancelAction: vi.fn(async () => {
+        cancelled = true;
+        return jobSnapshot("cancelled", {
+          reasonCode: "cancelled",
+          cancellable: false,
+        });
+      }),
+    });
+    const { result } = renderHook(() =>
+      useAgentLifecycleAction({
+        agentId: "qoderwork",
+        port,
+        readiness: readiness(),
+        pollIntervalMs: 10,
+        maxPolls: 20,
+      }),
+    );
+
+    let finished: Promise<void> | undefined;
+    act(() => {
+      finished = result.current.run("install");
+    });
+
+    await waitFor(() => {
+      expect(result.current.stage).toBe("downloading");
+      expect(result.current.canCancel).toBe(true);
+      expect(result.current.percent).toBeNull();
+    });
+
+    await act(async () => {
+      await result.current.cancel();
+    });
+    await act(async () => {
+      await finished;
+    });
+
+    expect(port.cancelAction).toHaveBeenCalledWith("job-1");
+    expect(result.current.error).toBe("操作已取消。");
+    expect(result.current.reasonCode).toBe("cancelled");
+    expect(result.current.success).toBeNull();
+    expect(port.get).toHaveBeenCalled();
+  });
+
+  it("keeps percent null through every generic job stage", async () => {
+    const seen: Array<number | null> = [];
+    const stages: AgentActionJobStage[] = [
+      "checking",
+      "downloading",
+      "installing",
+      "verifying_installation",
+      "succeeded",
+    ];
+    const port = createPort({
+      get: vi.fn(async () => readiness()),
+      startAction: vi.fn(async () => actionResult()),
+      getActionJob: vi.fn(async () =>
+        jobSnapshot(stages.shift() ?? "succeeded"),
+      ),
+    });
+    const { result } = renderHook(() => {
+      const view = useAgentLifecycleAction({
+        agentId: "qoderwork",
+        port,
+        readiness: readiness(),
+        pollIntervalMs: 5,
+      });
+      seen.push(view.percent);
+      return view;
+    });
+
+    await act(async () => {
+      await result.current.run("install");
+    });
+
+    expect(seen.length).toBeGreaterThan(1);
+    expect(seen.every((value) => value === null)).toBe(true);
+  });
+});

--- a/tests/v2/pages/models/Page.test.tsx
+++ b/tests/v2/pages/models/Page.test.tsx
@@ -41,6 +41,15 @@ function renderPage(ports: FeaturePorts, target?: string) {
   );
 }
 
+async function confirmWriteDisclosure(
+  user: ReturnType<typeof userEvent.setup>,
+) {
+  const dialog = await screen.findByRole("dialog", { name: "保存前确认" });
+  expect(within(dialog).getByText("将修改")).toBeVisible();
+  expect(within(dialog).getByText("备份位置")).toBeVisible();
+  await user.click(within(dialog).getByRole("button", { name: "确认保存" }));
+}
+
 function succeededCodexJob(): ChangeJobSnapshot {
   return {
     ...changeJobWire,
@@ -417,6 +426,7 @@ describe("V2 Models page", () => {
     expect(screen.getByLabelText("API Key")).toHaveValue(secret);
     expect(await screen.findByText("gpt-4o")).toBeVisible();
     await user.click(screen.getByRole("button", { name: "保存并应用" }));
+    await confirmWriteDisclosure(user);
     await waitFor(() =>
       expect(ports.opencodeModels.saveModels).toHaveBeenCalledWith({
         providerName: "Gateway",
@@ -483,6 +493,7 @@ describe("V2 Models page", () => {
     await user.click(
       screen.getByRole("button", { name: "保存并设为当前配置" }),
     );
+    await confirmWriteDisclosure(user);
     await waitFor(() =>
       expect(ports.providers.applyQuickSetupWithResult).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -539,10 +550,9 @@ describe("V2 Models page", () => {
     await user.type(screen.getByLabelText("API Key"), "first-secret");
     await user.type(screen.getByLabelText("自定义模型 ID"), "manual-model");
     await user.click(screen.getByRole("button", { name: "保存并应用" }));
+    await confirmWriteDisclosure(user);
 
-    expect(
-      await screen.findByText("WorkBuddy 模型保存并应用"),
-    ).toBeVisible();
+    expect(await screen.findByText("WorkBuddy 模型保存并应用")).toBeVisible();
     expect(screen.queryByRole("button", { name: "确认覆盖" })).toBeNull();
     expect(screen.queryByRole("button", { name: "取消" })).toBeNull();
     expect(document.body).not.toHaveTextContent("first-secret");
@@ -700,6 +710,7 @@ describe("V2 Models page", () => {
     await user.type(screen.getByLabelText("API Key"), "conflict-secret");
     await user.type(screen.getByLabelText("自定义模型 ID"), "conflict-model");
     await user.click(screen.getByRole("button", { name: "保存并应用" }));
+    await confirmWriteDisclosure(user);
     await user.click(await screen.findByRole("button", { name: "确认应用" }));
 
     expect(
@@ -728,12 +739,11 @@ describe("V2 Models page", () => {
     await user.type(screen.getByLabelText("API Key"), "expired-secret");
     await user.type(screen.getByLabelText("自定义模型 ID"), "expired-model");
     await user.click(screen.getByRole("button", { name: "保存并应用" }));
+    await confirmWriteDisclosure(user);
     await user.click(await screen.findByRole("button", { name: "确认应用" }));
 
     expect(await screen.findByText("计划已失效")).toBeVisible();
-    expect(
-      screen.getByRole("button", { name: "重新生成计划" }),
-    ).toBeVisible();
+    expect(screen.getByRole("button", { name: "重新生成计划" })).toBeVisible();
     expect(screen.queryByRole("button", { name: "确认覆盖" })).toBeNull();
     expect(ports.workbuddy.saveModels).not.toHaveBeenCalled();
     expect(screen.getByLabelText("API Key")).toHaveValue("expired-secret");
@@ -970,6 +980,7 @@ describe("V2 Models page", () => {
       screen.getByRole("button", { name: "移除模型 gemini-2.5-pro" }),
     );
     await user.click(screen.getByRole("button", { name: "保存并应用" }));
+    await confirmWriteDisclosure(user);
     await user.click(await screen.findByRole("button", { name: "确认应用" }));
 
     await screen.findByText("WorkBuddy 模型配置已保存");
@@ -1046,10 +1057,13 @@ describe("V2 Models page", () => {
     expect(
       within(codexHeader as HTMLElement).getByText("待保存"),
     ).toBeVisible();
-    expect(screen.getByText("将修改")).toBeVisible();
-    expect(screen.getByText("备份位置")).toBeVisible();
+    expect(screen.queryByText("将修改")).not.toBeInTheDocument();
     const submit = screen.getByRole("button", { name: "保存并设为当前配置" });
     await user.click(submit);
+    expect(
+      ports.changePlans.createCodexProviderUpsertPlan,
+    ).not.toHaveBeenCalled();
+    await confirmWriteDisclosure(user);
     expect(submit).toBeDisabled();
     fireEvent.click(submit);
     expect(
@@ -1101,6 +1115,50 @@ describe("V2 Models page", () => {
     expect(screen.queryByRole("button", { name: "取消" })).toBeNull();
   });
 
+  it("keeps write targets in a save-confirm dialog instead of the page layout", async () => {
+    const user = userEvent.setup();
+    const ports = createBrowserFeaturePorts();
+    ports.providers.getSummary = vi.fn(async () => ({
+      providers: {},
+      currentId: "",
+      writeTargets: [...TEST_PROVIDER_WRITE_TARGETS],
+    }));
+    stubCodexSavePlan(ports);
+    renderPage(ports, "codex");
+
+    await screen.findByTestId("provider-status");
+    expect(
+      screen.queryByRole("dialog", { name: "保存前确认" }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("将修改")).not.toBeInTheDocument();
+    await user.clear(screen.getByLabelText("配置名称"));
+    await user.type(screen.getByLabelText("配置名称"), "Codex Gateway");
+    await user.type(
+      screen.getByLabelText("服务地址"),
+      "https://codex.example/v1",
+    );
+    await user.type(screen.getByLabelText("API Key"), "codex-secret");
+    await user.type(screen.getByLabelText("模型 ID"), "gpt-5");
+    await user.click(
+      screen.getByRole("button", { name: "保存并设为当前配置" }),
+    );
+
+    const dialog = await screen.findByRole("dialog", { name: "保存前确认" });
+    expect(within(dialog).getByText("将修改")).toBeVisible();
+    expect(within(dialog).getByText("备份位置")).toBeVisible();
+    expect(
+      ports.changePlans.createCodexProviderUpsertPlan,
+    ).not.toHaveBeenCalled();
+    await user.click(within(dialog).getByRole("button", { name: "取消" }));
+    expect(
+      screen.queryByRole("dialog", { name: "保存前确认" }),
+    ).not.toBeInTheDocument();
+    expect(
+      ports.changePlans.createCodexProviderUpsertPlan,
+    ).not.toHaveBeenCalled();
+    expect(ports.providers.applyQuickSetupWithResult).not.toHaveBeenCalled();
+  });
+
   it("sends Codex image-extension and websocket toggles in the quick setup payload", async () => {
     const user = userEvent.setup();
     const ports = createBrowserFeaturePorts();
@@ -1132,6 +1190,7 @@ describe("V2 Models page", () => {
     await user.click(
       screen.getByRole("button", { name: "保存并设为当前配置" }),
     );
+    await confirmWriteDisclosure(user);
 
     await waitFor(() =>
       expect(
@@ -1178,6 +1237,7 @@ describe("V2 Models page", () => {
     await user.click(
       screen.getByRole("button", { name: "保存并设为当前配置" }),
     );
+    await confirmWriteDisclosure(user);
 
     await screen.findByText("无法确认当前设置");
     expect(ports.providers.applyQuickSetupWithResult).toHaveBeenCalledTimes(1);
@@ -1235,6 +1295,7 @@ describe("V2 Models page", () => {
     await user.click(
       screen.getByRole("button", { name: "保存并设为当前配置" }),
     );
+    await confirmWriteDisclosure(user);
     await user.click(await screen.findByRole("button", { name: "确认应用" }));
 
     await screen.findByText("无法确认当前设置");
@@ -1315,6 +1376,7 @@ describe("V2 Models page", () => {
     await user.click(
       screen.getByRole("button", { name: "保存并设为当前配置" }),
     );
+    await confirmWriteDisclosure(user);
     expect(ports.providers.applyQuickSetupWithResult).not.toHaveBeenCalled();
     expect(
       ports.changePlans.createCodexProviderUpsertPlan,
@@ -1369,6 +1431,7 @@ describe("V2 Models page", () => {
     await user.click(
       screen.getByRole("button", { name: "保存并设为当前配置" }),
     );
+    await confirmWriteDisclosure(user);
     expect(
       await screen.findByText("当前模型可能与此连接方式不兼容，请确认后使用。"),
     ).toBeVisible();
@@ -1403,6 +1466,7 @@ describe("V2 Models page", () => {
     await user.click(
       screen.getByRole("button", { name: "保存并设为当前配置" }),
     );
+    await confirmWriteDisclosure(user);
     await user.click(await screen.findByRole("button", { name: "确认应用" }));
 
     expect(await screen.findByText("模型设置已保存，待确认")).toBeVisible();

--- a/tests/v2/shared/FeatureChrome.test.tsx
+++ b/tests/v2/shared/FeatureChrome.test.tsx
@@ -130,6 +130,22 @@ describe("FeatureList", () => {
       /\.fy-feature-list\s*\{[^}]*display:\s*grid;/s,
     );
   });
+
+  it("keeps copy-only path actions inside compact info cards", () => {
+    const featuresCss = readFileSync(
+      path.resolve(process.cwd(), "src", "v2", "app", "styles", "features.css"),
+      "utf8",
+    );
+    const definitionBlock =
+      featuresCss.match(/\.fy-feature-definition\s*\{[^}]*\}/s)?.[0] ?? "";
+    expect(definitionBlock).toMatch(
+      /grid-template-columns:\s*minmax\(0,\s*max-content\)\s+minmax\(0,\s*1fr\)/,
+    );
+    expect(definitionBlock).not.toMatch(/minmax\(90px/);
+    expect(featuresCss).toMatch(
+      /\.fy-feature-definition\s+dd:has\(\s*>\s*\.fy-feature-path:not\(:has\(\.fy-feature-path-value\)\)\s*\)\s*\{[^}]*min-width:\s*min-content;/s,
+    );
+  });
 });
 
 describe("buildFeaturePaginationItems", () => {

--- a/tests/v2/shared/SelectionLens.test.tsx
+++ b/tests/v2/shared/SelectionLens.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 import { describe, expect, it } from "vitest";
 
+import { fySpringTransition } from "@/v2/shared/ui/motion";
 import {
   SelectionLens,
   SelectionLensGroup,
@@ -13,6 +14,7 @@ import {
 
 describe("SelectionLens", () => {
   it("keeps the source L1 control spring", () => {
+    expect(selectionLensTransition).toBe(fySpringTransition);
     expect(selectionLensTransition).toEqual({
       type: "spring",
       stiffness: 520,

--- a/tests/v2/shared/SelectionLens.test.tsx
+++ b/tests/v2/shared/SelectionLens.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { fySpringTransition } from "@/v2/shared/ui/motion";
 import {
@@ -105,6 +105,118 @@ describe("SelectionLens", () => {
         "1",
       );
     });
+  });
+
+  it("observes in-scope descendants so sibling reflow can retarget the pill", () => {
+    const observed = new Set<Element>();
+
+    class RecordingResizeObserver {
+      observe(element: Element) {
+        observed.add(element);
+      }
+      unobserve(element: Element) {
+        observed.delete(element);
+      }
+      disconnect() {}
+    }
+
+    vi.stubGlobal("ResizeObserver", RecordingResizeObserver);
+
+    try {
+      render(
+        <SelectionLensGroup id="reflow-track" data-testid="reflow-scope">
+          <div data-testid="reflow-spacer" />
+          <button type="button" data-testid="reflow-host">
+            <SelectionLens active />
+            Current
+          </button>
+        </SelectionLensGroup>,
+      );
+
+      expect(observed.has(screen.getByTestId("reflow-scope"))).toBe(true);
+      expect(observed.has(screen.getByTestId("reflow-spacer"))).toBe(true);
+      expect(observed.has(screen.getByTestId("reflow-host"))).toBe(true);
+      expect(observed.has(screen.getByTestId("selection-lens"))).toBe(false);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("retargets the pill when a sibling resizes and the host translates", async () => {
+    const callbacks = new Set<ResizeObserverCallback>();
+
+    class FlushableResizeObserver {
+      constructor(callback: ResizeObserverCallback) {
+        callbacks.add(callback);
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {
+        callbacks.clear();
+      }
+    }
+
+    vi.stubGlobal("ResizeObserver", FlushableResizeObserver);
+
+    const mockBox = (
+      element: Element,
+      box: { x: number; y: number; width: number; height: number },
+    ) => {
+      vi.spyOn(element, "getBoundingClientRect").mockReturnValue({
+        x: box.x,
+        y: box.y,
+        top: box.y,
+        left: box.x,
+        bottom: box.y + box.height,
+        right: box.x + box.width,
+        width: box.width,
+        height: box.height,
+        toJSON() {
+          return {};
+        },
+      } as DOMRect);
+    };
+
+    try {
+      render(
+        <SelectionLensGroup id="translate-track" data-testid="translate-scope">
+          <div data-testid="translate-spacer" />
+          <button type="button" data-testid="translate-host">
+            <SelectionLens active />
+            Current
+          </button>
+        </SelectionLensGroup>,
+      );
+
+      const scope = screen.getByTestId("translate-scope");
+      const host = screen.getByTestId("translate-host");
+      const lens = screen.getByTestId("selection-lens");
+
+      mockBox(scope, { x: 0, y: 0, width: 200, height: 240 });
+      mockBox(host, { x: 8, y: 40, width: 184, height: 36 });
+      act(() => {
+        for (const callback of callbacks) {
+          callback([], {} as ResizeObserver);
+        }
+      });
+
+      await waitFor(() => {
+        expect(lens).toHaveStyle({ top: "40px" });
+      });
+
+      mockBox(host, { x: 8, y: 120, width: 184, height: 36 });
+      act(() => {
+        for (const callback of callbacks) {
+          callback([], {} as ResizeObserver);
+        }
+      });
+
+      await waitFor(() => {
+        expect(lens).toHaveStyle({ top: "120px" });
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it("keeps the same overlay node when the active option changes", async () => {

--- a/tests/v2/widgets/app-shell/SideNavigation.test.tsx
+++ b/tests/v2/widgets/app-shell/SideNavigation.test.tsx
@@ -126,4 +126,102 @@ describe("SideNavigation", () => {
     expect(within(navigation).getAllByTestId("selection-lens")).toHaveLength(1);
     expect(within(navigation).queryByTestId("liquid-glass-lens")).toBeNull();
   });
+
+  it("supports expand, collapse, and vertical keyboard focus", async () => {
+    const user = userEvent.setup();
+    renderNavigation("/agents");
+
+    const navigation = screen.getByRole("navigation", { name: "主导航" });
+    const toggle = within(navigation).getByRole("button", { name: "配置管理" });
+    const items = screen.getByTestId("configuration-management-items");
+
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(items).toBeVisible();
+
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(items).not.toBeVisible();
+    expect(items).toHaveAttribute("hidden");
+    expect(
+      within(navigation).queryByRole("link", { name: "模型管理" }),
+    ).not.toBeInTheDocument();
+
+    toggle.focus();
+    await user.keyboard("{ArrowRight}");
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    await user.keyboard("{ArrowRight}");
+    expect(
+      within(navigation).getByRole("link", { name: "模型管理" }),
+    ).toHaveFocus();
+    await user.keyboard("{ArrowDown}");
+    expect(
+      within(navigation).getByRole("link", { name: "Skills 管理" }),
+    ).toHaveFocus();
+    await user.keyboard("{Escape}");
+    expect(toggle).toHaveFocus();
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("omits closing and closed leaves from arrow and tab order", async () => {
+    const user = userEvent.setup();
+    renderNavigation("/agents");
+
+    const navigation = screen.getByRole("navigation", { name: "主导航" });
+    const toggle = within(navigation).getByRole("button", { name: "配置管理" });
+    const memory = within(navigation).getByRole("link", { name: "记忆模块" });
+    const agents = within(navigation).getByRole("link", { name: "AI软件配置" });
+
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    toggle.focus();
+    await user.keyboard("{ArrowDown}");
+    expect(memory).toHaveFocus();
+    await user.keyboard("{ArrowUp}");
+    expect(toggle).toHaveFocus();
+    await user.keyboard("{Home}");
+    expect(agents).toHaveFocus();
+    await user.keyboard("{End}");
+    expect(memory).toHaveFocus();
+
+    toggle.focus();
+    await user.tab();
+    expect(memory).toHaveFocus();
+  });
+
+  it("collapses instantly when the user prefers reduced motion", async () => {
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = ((query: string) =>
+      ({
+        matches: query.includes("prefers-reduced-motion"),
+        media: query,
+        onchange: null,
+        addEventListener() {},
+        removeEventListener() {},
+        addListener() {},
+        removeListener() {},
+        dispatchEvent() {
+          return false;
+        },
+      })) as typeof window.matchMedia;
+
+    try {
+      const user = userEvent.setup();
+      renderNavigation("/agents");
+
+      const toggle = screen.getByRole("button", { name: "配置管理" });
+      const items = screen.getByTestId("configuration-management-items");
+
+      await user.click(toggle);
+
+      expect(toggle).toHaveAttribute("aria-expanded", "false");
+      expect(items).not.toBeVisible();
+      expect(items).toHaveAttribute("hidden");
+      expect(
+        screen.queryByRole("link", { name: "模型管理" }),
+      ).not.toBeInTheDocument();
+    } finally {
+      window.matchMedia = originalMatchMedia;
+    }
+  });
 });

--- a/tests/v2/widgets/app-shell/SideNavigation.test.tsx
+++ b/tests/v2/widgets/app-shell/SideNavigation.test.tsx
@@ -115,9 +115,7 @@ describe("SideNavigation", () => {
 
     expect(modelsLink).toHaveAttribute("aria-current", "page");
     expect(within(navigation).getAllByTestId("selection-lens")).toHaveLength(1);
-    expect(within(navigation).getAllByTestId("liquid-glass-lens")).toHaveLength(
-      1,
-    );
+    expect(within(navigation).queryByTestId("liquid-glass-lens")).toBeNull();
 
     await user.click(toggle);
 
@@ -126,6 +124,6 @@ describe("SideNavigation", () => {
     expect(items).not.toBeVisible();
     expect(modelsLink).toHaveAttribute("aria-current", "page");
     expect(within(navigation).getAllByTestId("selection-lens")).toHaveLength(1);
-    expect(within(toggle).getByTestId("liquid-glass-lens")).toBeVisible();
+    expect(within(navigation).queryByTestId("liquid-glass-lens")).toBeNull();
   });
 });

--- a/tests/v2/widgets/app-shell/SideNavigation.test.tsx
+++ b/tests/v2/widgets/app-shell/SideNavigation.test.tsx
@@ -127,6 +127,31 @@ describe("SideNavigation", () => {
     expect(within(navigation).queryByTestId("liquid-glass-lens")).toBeNull();
   });
 
+  it("keeps one memory lens after collapsing then expanding configuration", async () => {
+    const user = userEvent.setup();
+    renderNavigation("/memory");
+
+    const navigation = screen.getByRole("navigation", { name: "主导航" });
+    const toggle = within(navigation).getByRole("button", {
+      name: "配置管理",
+    });
+    const memory = within(navigation).getByRole("link", { name: "记忆模块" });
+
+    expect(memory).toHaveAttribute("aria-current", "page");
+    expect(within(navigation).getAllByTestId("selection-lens")).toHaveLength(1);
+
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(memory).toHaveAttribute("aria-current", "page");
+    expect(within(navigation).getAllByTestId("selection-lens")).toHaveLength(1);
+
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(memory).toHaveAttribute("aria-current", "page");
+    expect(within(navigation).getAllByTestId("selection-lens")).toHaveLength(1);
+    expect(memory.querySelector("[data-selection-lens-target]")).not.toBeNull();
+  });
+
   it("supports expand, collapse, and vertical keyboard focus", async () => {
     const user = userEvent.setup();
     renderNavigation("/agents");
@@ -191,19 +216,18 @@ describe("SideNavigation", () => {
 
   it("collapses instantly when the user prefers reduced motion", async () => {
     const originalMatchMedia = window.matchMedia;
-    window.matchMedia = ((query: string) =>
-      ({
-        matches: query.includes("prefers-reduced-motion"),
-        media: query,
-        onchange: null,
-        addEventListener() {},
-        removeEventListener() {},
-        addListener() {},
-        removeListener() {},
-        dispatchEvent() {
-          return false;
-        },
-      })) as typeof window.matchMedia;
+    window.matchMedia = ((query: string) => ({
+      matches: query.includes("prefers-reduced-motion"),
+      media: query,
+      onchange: null,
+      addEventListener() {},
+      removeEventListener() {},
+      addListener() {},
+      removeListener() {},
+      dispatchEvent() {
+        return false;
+      },
+    })) as typeof window.matchMedia;
 
     try {
       const user = userEvent.setup();


### PR DESCRIPTION
## Summary
- Show every supported agent in the directory immediately, with install/update progress from the existing readiness owners instead of a second scanner.
- Confirm model write targets before saving, and keep selected nav labels as CSS text so they stay sharp.
- Keep source-card **复制** buttons inside the info card, and retarget the nav lens when expanding **配置管理** while **记忆模块** is selected.

## Test plan
- [ ] Open Agents: all seven catalog entries appear without waiting for install scans; install/update still follow existing owners.
- [ ] Save a model change: the write-target confirm dialog appears before the write.
- [ ] Select a nav leaf: the label stays sharp (no liquid-glass smear) and one overlay pill tracks the active item.
- [ ] Skills/MCP installed detail at a wide viewport: **复制** stays inside **下载来源** / **安装来源**.
- [ ] Select **记忆模块**, collapse then expand **配置管理**: the overlay stays on **记忆模块**, not between 模型管理 and Skills 管理.


Made with [Cursor](https://cursor.com)