### PR TITLE
ci: use the public star-history Action

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron: "17 */3 * * *"
   workflow_dispatch:
+  watch:
+    types: [started]
 
 permissions:
   contents: read

--- a/.trellis/spec/backend/github-ci-workflow.md
+++ b/.trellis/spec/backend/github-ci-workflow.md
@@ -148,8 +148,13 @@ Classification invariants:
   duplicate flags, and option injection fail closed.
 
 `star-history.yml` is repository automation rather than Required CI authority.
-Its scheduled refresh runs every three hours at minute 17, avoiding the
-top-of-hour scheduling peak while keeping the README chart reasonably fresh.
+New stars refresh the README chart through the `watch` `started` event, which
+runs the default-branch workflow when the repository is starred. GitHub's
+`schedule` trigger is best-effort and can skip slots, especially right after
+the workflow is added or its cron changes, so it is only the periodic
+reconciliation path (including unstars) rather than the freshness guarantee.
+The scheduled refresh still runs every three hours at minute 17, avoiding the
+top-of-hour scheduling peak. Manual `workflow_dispatch` remains available.
 GitHub's built-in `GITHUB_TOKEN` is not an owner/collaborator credential for the
 restricted stargazer timeline endpoint, so exact chart generation uses the
 repository secret `STAR_HISTORY_TOKEN`. Keep that credential out of the

--- a/tests/githubWorkflowTriggers.test.ts
+++ b/tests/githubWorkflowTriggers.test.ts
@@ -170,6 +170,8 @@ describe("GitHub workflow trigger policy", () => {
         "  schedule:",
         '    - cron: "17 */3 * * *"',
         "  workflow_dispatch:",
+        "  watch:",
+        "    types: [started]",
       ].join("\n"),
     );
     expect(source).toContain("permissions:\n  contents: read");


### PR DESCRIPTION
## Summary
- The public `api.star-history.com` embed is not usable: GitHub's June 2026 stargazers restriction makes it render *GitHub restricted access to star data*. Putting an encrypted contents-write token in the README is worse.
- Replace the local clone/`go run` workflow with the reviewed public Action `xpzouying/star-history@8b1f26dc5e9a17caa75da9351b688509ef312811`, using its documented `branch: star-history` publish path.
- Refresh on new stars (`watch: started`), keep the 3-hour cron as reconciliation, and keep `workflow_dispatch`. Prefer `STAR_HISTORY_TOKEN`, fall back to `github.token`. README image URLs stay on the existing data branch.

## Test plan
- [x] `mise run test:unit tests/githubWorkflowTriggers.test.ts`
- [x] YAML parse + `git diff --check`
- [ ] After merge, starring the repo creates a Star History run and republishes `star-history/assets/star-history.svg`
- [ ] Manual `workflow_dispatch` still updates the chart when stars are unchanged except for the latest count