### PR TITLE
docs: restore FyAgent product positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 <div align="center">
   <img src="assets/brand/github/for-you-gate.svg" width="104" alt="FyAgent For You Gate">
   <h1>FyAgent</h1>
-  <p>在一个本地桌面应用中管理 AI 软件的模型、Skills、MCP、提示词和记忆文件。</p>
+  <p><strong>For You Agent</strong>——AI 时代的个人随身数字人格。</p>
+  <p>把你的模型、AI 账号、技能、提示词和工作方式，带到每一个 AI 工具里。</p>
   <p><a href="README_EN.md">English</a> · <a href="README_JA.md">日本語</a></p>
   <p>
     <a href="https://github.com/fy-agent/fyagent/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/fy-agent/fyagent?style=flat-square&label=release&color=0B66FF"></a>
@@ -17,13 +18,13 @@
   </p>
 </div>
 
-## FyAgent 是什么
+## AI 时代的个人智能控制中心
 
-FyAgent 是一款本地桌面配置工具。它把多款 AI 软件分散在文件和命令行中的常用设置放到一个界面里，并在写入前展示将要修改的内容。
+FyAgent 面向正在使用 AI Agent、AI Worker 和智能助手的人。它把模型从哪里来、能连接哪些工具、会哪些技能、遵循什么指令、保存怎样的配置，集中到一个本地桌面应用里。
 
-当前生产界面包含六个区域：AI 软件配置、模型管理、Skills 管理、MCP 管理、提示词管理和记忆模块。不同软件开放的能力不同，FyAgent 只显示当前集成实际支持的操作。
+你不需要先弄懂 Provider、MCP 或 Prompt 这些术语。对用户来说，它们分别是 AI 的大脑来源、工具连接和行为指令。FyAgent 要做的，是把原本散落、隐蔽、容易改错的选择变得可见、可改，也能跟着你走。
 
-> **当前状态：** FyAgent 仍在开发中。升级前请备份重要配置，并阅读对应版本的发布说明。
+> **发布状态：** FyAgent 仍在持续开发。升级前请备份重要配置，并在安装前阅读当次发布的可信度说明。
 
 ## 当前功能
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,7 +1,8 @@
 <div align="center">
   <img src="assets/brand/github/for-you-gate.svg" width="104" alt="FyAgent For You Gate">
   <h1>FyAgent</h1>
-  <p>Manage models, Skills, MCP servers, prompts, and memory files for AI software from one local desktop app.</p>
+  <p><strong>Own your AI.</strong></p>
+  <p>A personal desktop control center that keeps you in charge of the AI Workers and Agents you use.</p>
   <p><a href="README.md">简体中文</a> · <a href="README_JA.md">日本語</a></p>
   <p>
     <a href="https://github.com/fy-agent/fyagent/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/fy-agent/fyagent?style=flat-square&label=release&color=0B66FF"></a>
@@ -17,13 +18,13 @@
   </p>
 </div>
 
-## What FyAgent is
+## A personal control center for the AI era
 
-FyAgent is a local desktop configuration tool. It brings commonly used settings from multiple AI applications into one interface and shows the affected files and settings before a write.
+FyAgent is for people who use AI Agents, AI Workers, and assistants. It brings the choices that shape an AI—where its models come from, which tools it can reach, what skills it has, which instructions it follows, and how it is configured—into one local desktop app.
 
-The current production interface has six areas: AI software configuration, Models, Skills, MCP, Prompts, and Memory. Each application exposes a different set of controls; FyAgent shows only the actions supported by its current integration.
+You do not need to begin with terms such as Provider, MCP, or Prompt. To a person using the product, they are an AI's source of intelligence, its tool connections, and its working instructions. FyAgent makes those choices visible, editable, and easier to carry between tools.
 
-> **Current status:** FyAgent is under active development. Back up important configuration before an upgrade and read the release notes for the version you install.
+> **Release status:** FyAgent is under active development. Back up important configuration before upgrading, and review the trust information for each release before installing it.
 
 ## Current features
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -1,7 +1,8 @@
 <div align="center">
   <img src="assets/brand/github/for-you-gate.svg" width="104" alt="FyAgent For You Gate">
   <h1>FyAgent</h1>
-  <p>AI ソフトウェアのモデル、Skills、MCP、プロンプト、メモリーファイルを、ローカルのデスクトップアプリで管理します。</p>
+  <p><strong>自分の AI を、自分のものに。</strong></p>
+  <p>AI Worker と AI Agent を自分で管理するための、パーソナル・デスクトップコントロールセンター。</p>
   <p><a href="README_EN.md">English</a> · <a href="README.md">简体中文</a></p>
   <p>
     <a href="https://github.com/fy-agent/fyagent/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/fy-agent/fyagent?style=flat-square&label=release&color=0B66FF"></a>
@@ -17,13 +18,13 @@
   </p>
 </div>
 
-## FyAgent とは
+## AI 時代のパーソナルコントロールセンター
 
-FyAgent は、ローカルで動作するデスクトップ設定ツールです。複数の AI アプリに分散している設定をひとつの画面にまとめ、書き込み前に変更対象を表示します。
+FyAgent は、AI Agent、AI Worker、AI アシスタントを利用する人のためのアプリです。モデルの入手先、接続できるツール、利用するスキル、従う指示、各種設定といった AI を形づくる選択を、ローカルのデスクトップアプリにまとめます。
 
-現在の画面は、AI ソフトウェア設定、モデル管理、Skills 管理、MCP 管理、プロンプト管理、メモリーモジュールの 6 つで構成されています。アプリごとに利用できる操作が異なるため、FyAgent は現在の連携で対応している操作だけを表示します。
+Provider、MCP、Prompt といった用語を先に理解する必要はありません。利用者にとっては、AI の知能の供給元、ツールとの接続、仕事の指示に当たります。FyAgent は、分散して見えにくかった選択を、確認・変更しやすい形にします。
 
-> **現在の状況:** FyAgent は開発中です。更新前に重要な設定をバックアップし、インストールするバージョンのリリースノートを確認してください。
+> **リリース状況:** FyAgent は現在も継続的に開発されています。更新前に大切な設定をバックアップし、インストール前に各リリースの信頼情報を確認してください。
 
 ## 現在の機能
 


### PR DESCRIPTION
## Summary
- restore the original FyAgent brand positioning in the Chinese, English, and Japanese READMEs
- restore the product-focused introduction while keeping the current feature tables
- intentionally omit the old concrete supported-tool paragraph and WorkBuddy scope note

## Validation
- `git diff --check`
- targeted assertions for required and intentionally excluded copy in all three READMEs