### PR TITLE
ci: move CodeQL off the pull request hot path

### DIFF
--- a/.github/workflows/codeql-security.yml
+++ b/.github/workflows/codeql-security.yml
@@ -1,0 +1,47 @@
+name: CodeQL Security / Scheduled
+
+on:
+  schedule:
+    - cron: "17 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-security-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+          - language: rust
+            build-mode: none
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.trellis/spec/backend/codex-provider-configuration.md
+++ b/.trellis/spec/backend/codex-provider-configuration.md
@@ -9,14 +9,19 @@ the Codex Provider Change Plan ledger/readback path.
 It owns the Codex provider configuration domain only. Trusted Codex Desktop
 discovery, installation, process restart, and launch are owned by
 [Codex Desktop Installer](./codex-desktop-installer.md); application version and
-release metadata are owned by their dedicated contracts. Managed ChatGPT
-OAuth accounts, `credential_id` vs `chatgpt_account_id` routing identity,
-and native `auth.json` projection are owned with
-[Managed Auth Core](./managed-auth.md) and
-[External Agent P0 Safety](./external-agent-p0.md).
+release metadata are owned by their dedicated contracts. Managed ChatGPT OAuth
+account identity, refresh ownership and JSON-to-vault migration are owned by
+[Managed Auth Core](./managed-auth.md). Managed Codex connection admission and
+its production projection gate are owned by
+[Managed Auth Consumers](./managed-auth-consumers.md). This contract owns only
+the Codex Provider binding boundary plus the existing Codex config/auth writer
+semantics; Agent install/launch remains in the focused lifecycle contracts.
 The unsealed Codex JSON manager remains a compatibility store until
 migration seals that source. Provider rows store
 `ProviderMeta.authBinding.accountId` as an opaque account/credential id only.
+Legacy binding remap runs only after `CodexOAuthManager` reports a successful
+store load. A parse or I/O failure is not an empty account set and must leave
+every existing Provider binding unchanged.
 Native file projection is allowed only when live `cli_auth_credentials_store`
 is explicitly `file`; `keyring`, `auto`, `ephemeral`, unset, and unknown fail
 closed. Workspace/account IDs are never HashMap keys.
@@ -251,6 +256,7 @@ CODEX_WEBSOCKET_PROXY_MAY_BE_UNSUPPORTED
 | Two ChatGPT users share one workspace/account routing ID                                             | Store two `credential_id` rows; never use the workspace ID as the HashMap key.                                          |
 | Provider `authBinding.accountId` still holds a v1 workspace ID that maps to exactly one credential   | Remap that binding to the new `credential_id`.                                                                          |
 | Provider `authBinding.accountId` is missing, already a credential, or maps to multiple credentials   | Unbind; never guess the default or another account.                                                                     |
+| Codex compatibility OAuth store parse/I/O load fails before binding remap                            | Skip remap and preserve every existing Provider binding; empty memory is not evidence of an empty store.                |
 | Bound managed credential is missing/expired during proxy forwarding                                  | Fail closed; do not send another account's token.                                                                       |
 | Live `cli_auth_credentials_store` is `keyring`, `auto`, `ephemeral`, unset, invalid, or unknown      | `native_projection_available=false`; do not write `auth.json` to fake a switch.                                         |
 | Native projection writes `auth.json` because the file already exists                                 | Contract regression; file existence is not a store hint.                                                                |
@@ -317,7 +323,8 @@ CODEX_WEBSOCKET_PROXY_MAY_BE_UNSUPPORTED
   [Change Plan Typed Executor](./change-plan-executor.md).
 - Codex OAuth store tests cover v2 `credential_id` keys, same-workspace two
   users, v1 backup + idempotent migrate, unique vs ambiguous Provider binding
-  remap, bound-missing fail-closed forwarding, leftover `auth_*` mutations
+  remap, corrupt/I/O load failure keeping `store_loaded=false` and preserving
+  all bindings, bound-missing fail-closed forwarding, leftover `auth_*` mutations
   returning `legacy_auth_mutation_disabled`, Debug/DTO token redaction, explicit `file`
   native projection, and fail-closed `keyring`/`auto`/`ephemeral`/unset/unknown
   without consulting `auth.json` existence.
@@ -350,6 +357,8 @@ managed ChatGPT account map key = credential_id
   + chatgpt_account_id is routing metadata only
   + Provider.authBinding.accountId = credential_id
 native projection only when cli_auth_credentials_store = "file"
+successful OAuth store load -> remap legacy Provider bindings
+OAuth store load failure -> preserve all bindings; do not treat memory as empty authority
 ```
 
 ## Scenario: V2 Codex Quick Setup targeted live write
@@ -556,224 +565,3 @@ stored auth.OPENAI_API_KEY = apiKey
 live config.toml experimental_bearer_token = apiKey
 live auth.json unchanged
 ```
-
-## Scenario: Codex managed credential identity and native projection
-
-### 1. Scope / Trigger
-
-- Trigger: the managed ChatGPT OAuth store, Provider binding IDs, proxy
-  routing headers, leftover read-only status DTO, and native `auth.json`
-  projection all changed together. This is a persisted-schema plus
-  cross-layer command contract, so code-spec depth is mandatory.
-- Owner: live token and Credential Session authority is
-  [Managed Auth Core](./managed-auth.md). `proxy/providers/codex_oauth_auth.rs`
-  remains the unsealed JSON compatibility store until that source is migrated.
-  `ProviderMeta.authBinding` stores IDs only. Native file projection is
-  `codex_config/credential_store.rs` plus existing
-  `codex_config/{auth,storage}.rs` writers. Agent Catalog install actions
-  are owned by [External Agent P0 Safety](./external-agent-p0.md).
-
-### 2. Signatures
-
-```text
-CodexOAuthStore v2 {
-  version: 2,
-  accounts: HashMap<credential_id, CodexAccountData>,
-  default_account_id?: credential_id
-}
-
-CodexAccountData {
-  credential_id,            // FyAgent UUID; map key; never workspace id
-  chatgpt_account_id,       // upstream routing/workspace identity only
-  email?,
-  refresh_token,            // disk only; never DTO/log/Debug
-  authenticated_at
-}
-
-ManagedAuthAccount {
-  id,                       // credential_id
-  provider, login, avatar_url?, authenticated_at,
-  is_default, github_domain, requires_reauth,
-  chatgpt_account_id?       // routing metadata for display; not a key
-}
-
-ManagedAuthStatus {
-  provider, authenticated, default_account_id?,
-  migration_error?, accounts,
-  native_projection_available?   // Codex only; true only for explicit file
-}
-
-auth_list_accounts(authProvider)
-auth_get_status(authProvider)          // read-only leftover compatibility
-auth_start_login / auth_poll_for_account / auth_remove_account /
-auth_set_default_account / auth_logout / auth_cancel_login
-  -> always `legacy_auth_mutation_disabled`
-                                       // leftover Device Code/remove/default
-                                       // are not a second owner; use
-                                       // managed_auth_* + impact preview
-
-parse_cli_auth_credentials_store(config_toml)
-  -> File | Keyring | Auto | Ephemeral | Unset | Unknown | ConfigInvalid
-
-native_file_projection_allowed(config_toml) -> bool
-overlay_cli_auth_credentials_store(outgoing, current_live) -> toml
-```
-
-`authProvider` remains `github_copilot | codex_oauth | xai_oauth`. No second
-leftover Auth Center login owner. No environment key.
-
-### 3. Contracts
-
-- Credential identity and ChatGPT workspace/account identity are different
-  fields. Login completion generates a random `credential_id`. Duplicate
-  rows from repeated logins are accepted; merging people by workspace ID is
-  forbidden until a verified stable user claim exists.
-- Provider rows keep `authBinding.authProvider = "codex_oauth"` and
-  `authBinding.accountId = credential_id`. They never copy access/refresh
-  tokens.
-- Proxy `ChatGPT-Account-Id` is the routing id looked up from the bound
-  credential. Missing/empty routing id fails closed. A bound credential that
-  disappears does not fall back to default or another account.
-- v1→v2 migration: backup `codex_oauth_auth.json.v1.bak` once (keep it),
-  assign a new UUID per row, preserve the old workspace id as
-  `chatgpt_account_id`, remap a Provider binding only when the old id maps
-  to exactly one new credential, otherwise unbind. Lost collision data is
-  not reconstructed. Re-running on an already-v2 store is a no-op.
-  Remap runs only after a successful store load (`store_loaded=true`); a
-  parse/IO failure must not treat the empty in-memory map as “no accounts”
-  and clear every Codex `authBinding`.
-- Credential source and upstream destination stay independent. Official vs
-  custom endpoint, proxy takeover, and managed-account binding must not be
-  collapsed into one `is_official` boolean.
-- Native Codex projection writes `auth.json` only when live
-  `cli_auth_credentials_store` is the string `file`. `keyring`, `auto`,
-  source-visible `ephemeral`, unset, non-string, and future values set
-  `native_projection_available=false` and tell the user to use Codex login.
-  Existence of `auth.json` is never a store selector.
-- Empty official snapshots that omit `cli_auth_credentials_store` must
-  overlay the current live value so a later switch cannot silently drop
-  file-mode projection.
-- Leftover `auth_cancel_login` / `auth_start_login` / `auth_poll_for_account`
-  and leftover Copilot login/remove/default/logout IPC always return
-  `legacy_auth_mutation_disabled`. Live OpenAI Device Code cancel belongs
-  on `managed_auth_cancel_login`, which bumps session generation so a late
-  poll cannot save a credential.
-- Leftover Provider forms distinguish “managed account usable for FyAgent
-  routing” from “native Codex projection available” via the read-only
-  status DTO. They must not start leftover login or display workspace
-  routing IDs. Refresh-token remaining source of truth is the managed
-  store once that source is sealed; unsealed JSON remains a read-only
-  compatibility store until migration. Reconciling a Codex-rotated refresh
-  token into that store before file-mode projection is still residual:
-  identity must match first; production file/keyring projection stays
-  fail-closed without matching-host HIL. OAuth HTTP errors may include the
-  status code and must not echo the response body.
-
-### 4. Validation & Error Matrix
-
-| Condition | Required result |
-| --- | --- |
-| Store keyed by `chatgpt_account_id` | Schema/test fails |
-| Bound credential missing during forward | Auth error; no other account |
-| Ambiguous v1 workspace binding | Unbind; do not pick default |
-| Non-file credential store | No `auth.json` write; UI shows native projection unavailable |
-| Invalid `config.toml` while resolving store | Treat as not-file; do not guess |
-| Token in DTO, log, Debug, ledger, DOM | Security regression |
-| OAuth HTTP failure embeds response body | Security regression; errors may include status only |
-| Store load failed (`store_loaded=false`) then remap bindings | Forbidden; empty in-memory map must not unbind every Provider |
-| leftover `auth_start_login` / `auth_cancel_login` starts or continues Device Code | Contract regression; must return `legacy_auth_mutation_disabled` |
-
-### 5. Good/Base/Bad Cases
-
-- Good: Alice and Bob in workspace `ws-shared` persist as two UUID keys
-  with the same `chatgpt_account_id`.
-- Base: a file-store user can project the selected managed credential
-  through the existing atomic `auth.json` + `config.toml` writer.
-- Bad: CC Switch-style unconditional `auth.json` overwrite under `keyring`,
-  or infer file mode because `auth.json` exists.
-
-### 6. Tests Required
-
-- `same_workspace_two_users_coexist_under_distinct_credential_ids`
-- v1 fixture migrates, writes `.v1.bak` once, and is idempotent on v2
-- unique vs many-to-one Provider `authBinding` remap
-- forwarder fail-closed when routing id is missing
-- `only_explicit_file_allows_native_projection` plus
-  `auth_json_existence_is_not_consulted`
-- overlay preserves live `cli_auth_credentials_store` when outgoing omits it
-- Debug redacts `refresh_token`
-- Leftover status DTO has `id` + optional `chatgpt_account_id` and no
-  token fields; leftover login/remove IPC is fail-closed
-
-### 7. Wrong vs Correct
-
-#### Wrong
-
-```rust
-accounts.insert(chatgpt_account_id, account);
-if Path::new("~/.codex/auth.json").exists() {
-    write_auth_json(token_package)?;
-}
-```
-
-#### Correct
-
-```rust
-accounts.insert(credential_id, CodexAccountData { credential_id, chatgpt_account_id, .. });
-if parse_cli_auth_credentials_store(&live_toml)? == CodexCredentialStore::File {
-    project_auth_json_for_credential(&credential_id)?;
-} else {
-    return native_projection_unavailable();
-}
-```
-
-### Design Decision: credential UUID instead of workspace map key
-
-**Context**: ChatGPT Team/Business `chatgpt_account_id` is a workspace routing
-id. Two people in one workspace collided when it was the store key
-(CC Switch #5885 class). OpenAI tokens do not currently prove a stable user
-claim we can use as identity.
-
-**Options Considered**:
-
-1. Keep workspace id as the map key
-2. Deduplicate on email
-3. Generate a FyAgent `credential_id` UUID at login
-
-**Decision**: Option 3. Duplicate rows from repeated logins are safer than
-merging distinct people. Provider bindings store that UUID only.
-
-**Example**:
-
-```text
-accounts[credential_uuid] = { credential_id, chatgpt_account_id: "ws-shared", refresh_token }
-ProviderMeta.authBinding.accountId = credential_uuid
-```
-
-**Extensibility**: Later dedup requires positive identity evidence, not
-workspace or email heuristics.
-
-### Common Mistake: 存储没加载成功就 remap binding
-
-**Symptom**: Codex OAuth JSON is unreadable, then every Provider
-`authBinding` disappears.
-
-**Cause**: remap saw an empty in-memory map and treated every old workspace
-id as ambiguous/missing.
-
-**Fix**: set `store_loaded` only after a successful read; skip remap otherwise.
-
-**Prevention**: tests must cover corrupt/missing store without mutating
-Provider bindings.
-
-### Common Mistake: 用 auth.json 是否存在判断 Codex store
-
-**Symptom**: `keyring`/`auto` users appear to switch native Codex accounts,
-then Codex ignores `auth.json`.
-
-**Cause**: File existence is not `cli_auth_credentials_store`.
-
-**Fix**: Parse the live TOML field. Only explicit `file` may project.
-
-**Prevention**: `native_file_projection_allowed` must not take a filesystem
-path to `auth.json`.

--- a/.trellis/spec/backend/external-agent-auth.md
+++ b/.trellis/spec/backend/external-agent-auth.md
@@ -76,7 +76,9 @@ verified | handoff_complete | failed | cancelled | timed_out
   closed unsupported/executor reason without launching a session.
 - Codex Auth remains `fyagent_managed` and routes the user to the V2 `/auth`
   page owned by [V2 Managed Accounts](../frontend/v2-managed-auth.md). Native
-  account/secret ownership is [Managed Auth Core](./managed-auth.md). This
+  account/secret ownership is [Managed Auth Core](./managed-auth.md), provider
+  login is [Managed Auth Login](./managed-auth-login.md), and connection
+  projection is [Managed Auth Consumers](./managed-auth-consumers.md). This
   façade does not add a second Codex OAuth flow.
 - Auth session state is process-local, bounded and single-flight per Agent.
   Terminal snapshots are immutable and can be polled safely.
@@ -91,8 +93,9 @@ verified | handoff_complete | failed | cancelled | timed_out
   reach the requested state. Launching a terminal/browser alone remains
   `awaiting_user`.
 - OpenCode observation is Desktop-first. The Agent Auth façade reads
-  sanitized provider metadata produced by the Managed Auth OpenCode
-  consumer from official `Global.Path.data/auth.json`. A missing PATH
+  sanitized provider metadata produced by
+  [Managed Auth Consumers](./managed-auth-consumers.md) from official
+  `Global.Path.data/auth.json`. A missing PATH
   `opencode` CLI must not yield `AuthObserverUnavailable`. Connect
   launches a trusted Desktop target; logout removes one `auth.json`
   key through that consumer. Tokens, keys, paths and sidecar ports
@@ -107,7 +110,8 @@ verified | handoff_complete | failed | cancelled | timed_out
   hold a vault `purpose=grok_native` session, but this façade still returns
   `handoff_only` and must not treat vault metadata as a verified Grok
   CLI/Desktop login. Native Grok `auth.json` and `auth_provider_command`
-  writes stay production-disabled in Managed Auth.
+  writes stay production-disabled under
+  [Managed Auth Consumers](./managed-auth-consumers.md).
 - QoderWork, TRAE Work and WorkBuddy open one selected trusted desktop target
   and are also handoff-only. Opening the application does not prove account
   state.

--- a/.trellis/spec/backend/external-agent-lifecycle.md
+++ b/.trellis/spec/backend/external-agent-lifecycle.md
@@ -148,6 +148,18 @@ command, argument vector, token, hash, package format, signer or bypass flags.
 | Claude Desktop | Desktop only; use the reviewed source and closed bundle identity on supported hosts. No public Claude CLI installer. |
 | OpenCode Desktop | Desktop only; use reviewed stable desktop artifacts and closed bundle identity on supported hosts. No public OpenCode CLI installer. |
 
+- Grok npm optional-package admission is resolved by the signed product on the
+  product host. The closed mappings are Darwin x64/arm64 and Windows x64/arm64;
+  an unsupported architecture produces no install plan, while a product build
+  for an operating system other than macOS/Windows is rejected at compile time.
+  The bundled manifest contains no Linux optional package and no generic
+  `std::env::consts::OS` fallback.
+- Before execution, the product matches both `@xai-official/grok` and the
+  current platform package SHA-512 against one allowed registry. On formal
+  Windows it then sends only the compact exact-version/registry/allow-scripts
+  control to the ordinary-user helper. The helper validates and executes that
+  closed control; it does not resolve registry metadata, choose a platform
+  package, or invent `@latest`.
 - Qoder display version comes only from an unindented top-level `version:` in
   bounded same-host `latest.yml`/`latest-mac.yml`. The feed ZIP and `sha512`
   are metadata, not admitted artifacts. Windows ARM64 remains unsupported
@@ -294,6 +306,9 @@ leaf:
 | OpenCode Uninstall DisplayName is `OpenCode Dev`, `OpenCodeAI`, or a prerelease version | Skip that ARP entry. |
 | OpenCode KnownPath relative is missing | Drop the observation; do not retain KnownPath Missing. |
 | Grok default install has no native expected owner | Plan official npm from the bundled exact-version manifest; never `@latest`. |
+| Grok macOS/Windows architecture has no closed platform package or manifest integrity | Produce no npm plan/action; do not fall back to Linux or another product package. |
+| Grok product is compiled for a non-macOS/non-Windows target | Compile-time rejection; do not add a generic OS fallback. |
+| Grok registry metadata does not match both root and current-platform SHA-512 | Skip that registry; fail with source exhaustion when none match. |
 | Cancel after `launching_installer`/`installing` | `operation_conflict`; do not kill external/commit operation. |
 | Secret/path/raw native identity reaches DTO/log/DOM | Security regression. |
 
@@ -357,7 +372,10 @@ Assertion points:
 - job single-flight, terminal slot release, transfer monotonicity, unknown
   total, cancel refusal after side-effect boundary and unknown job ID;
 - Grok owner-preserving lifecycle and ordinary-user helper with no elevated
-  fallback;
+  fallback; product-host cfg maps only Darwin/Windows x64/arm64, the bundled
+  manifest has no Linux optional package, registry admission matches both
+  package integrities, and the helper receives only the compact host-selected
+  plan;
 - renderer polls until a terminal native stage and does not paint a poll cap
   as failure while a job remains active. Browser fixtures do not prove native
   inventory, installer or signing behavior.

--- a/.trellis/spec/backend/github-ci-workflow.md
+++ b/.trellis/spec/backend/github-ci-workflow.md
@@ -4,10 +4,11 @@
 
 This contract owns `.github/workflows/ci.yml`,
 `.github/workflows/commit-convention-push.yml`,
-`scripts/ci/classify-changes.mjs`, `scripts/ci/required-gate.mjs`,
-`scripts/ci/verify-commit-messages.mjs`, and their fixture suites. It applies to
-pull requests, merge queue candidates, lightweight branch-push commit policy,
-and manual diagnostics.
+`.github/workflows/codeql-security.yml`, `scripts/ci/classify-changes.mjs`,
+`scripts/ci/required-gate.mjs`, `scripts/ci/verify-commit-messages.mjs`, and their
+fixture suites. It applies to pull requests, merge queue candidates, lightweight
+branch-push commit policy, scheduled/manual security scanning, and manual
+diagnostics.
 
 This workflow owns scheduling and aggregation, not the underlying product
 behavior. Windows installer/runtime review guidance is recorded in
@@ -51,6 +52,19 @@ It checks only Conventional Commit history and emits `Commit Convention / Push`.
 It does not classify domains, install frontend/Python/Rust dependencies, run
 product tests, or emit `CI / Required`. Queue-ref pushes are excluded because
 `merge_group` is the sole Required CI authority for Merge Queue candidates.
+
+Security CodeQL is deliberately outside the PR/merge-queue hot path. The
+repository-owned advanced workflow runs only on a weekly schedule and explicit
+`workflow_dispatch`; it has no `pull_request`, `push`, or `merge_group` trigger
+and never emits `CI / Required`. GitHub CodeQL default setup and GitHub Code
+Quality repository setup remain disabled while this workflow owns scanning,
+because either managed setup would independently create dynamic PR analyses.
+The scheduled matrix scans `rust`, `javascript-typescript`, and `actions` using
+no-build mode on Linux. Swift is intentionally excluded from this low-frequency
+workflow because its CodeQL analysis requires macOS autobuild/manual build,
+which is materially more expensive and is not part of merge-readiness evidence.
+Existing code-scanning findings remain security-review inputs; moving scanning
+off the hot path does not reclassify or dismiss those findings.
 
 Repository branch protection, rulesets, merge methods, and the Trellis
 merge-readiness lifecycle are outside this workflow and are owned by

--- a/.trellis/spec/backend/index.md
+++ b/.trellis/spec/backend/index.md
@@ -14,9 +14,11 @@ error matrices, tests, paths, and security rules belong in the linked owner.
    [Database Persistence](./database-persistence.md) when changing shared
    runtime or repository infrastructure.
 3. Read the focused feature contract that owns the data, filesystem, process,
-   network, secret, or IPC behavior being changed. Account metadata, OAuth
-   secret bundles, and JSON-to-vault migration are
-   [Managed Auth Core](./managed-auth.md).
+   network, secret, or IPC behavior being changed. Managed Auth is split into
+   [core/vault/migration](./managed-auth.md),
+   [provider login sessions](./managed-auth-login.md), and
+   [consumer projection](./managed-auth-consumers.md); cite only the owner of
+   the behavior being changed.
 4. For platform or delivery work, also read the matching Windows/macOS and
    CI/release governance contracts.
 
@@ -41,6 +43,8 @@ error matrices, tests, paths, and security rules belong in the linked owner.
 | --- | --- |
 | [SecretRef Native Backend](./secretref-backend.md) | Secret storage, opaque references, DTO redaction, and native evidence. |
 | [Managed Auth Core](./managed-auth.md) | Account metadata, Credential Sessions, SecretRef vault admission, JSON migration, refresh ownership, and Proxy token resolution. |
+| [Managed Auth Login](./managed-auth-login.md) | Backend login sessions, OpenAI browser/Device Code, xAI Device Code, cancellation, reopen, and grant admission. |
+| [Managed Auth Consumers](./managed-auth-consumers.md) | Codex/Grok/OpenCode connection observation, native projection gates, readback, ownership transfer, and restart evidence. |
 | [Deep-Link Import Security](./deeplink-import-security.md) | Untrusted deep-link parsing, confirmation, import capabilities, and side-effect limits. |
 | [Change Plan Typed Executor](./change-plan-executor.md) | Typed plans, idempotency, execution phases, compensation, and partial results. |
 | [Codex Provider Configuration](./codex-provider-configuration.md) | Codex provider/auth projection, writer serialization, backup, rollback, and readback. |

--- a/.trellis/spec/backend/managed-auth-consumers.md
+++ b/.trellis/spec/backend/managed-auth-consumers.md
@@ -1,0 +1,268 @@
+# Managed Auth Consumer Projection Contract
+
+## 1. Scope / Trigger
+
+Read this contract before changing managed account connections to Codex, Grok
+Build, or OpenCode Desktop; connection observation; native auth-file
+projection; refresh-owner transfer; pending-restart behavior; or
+`managed_auth_apply_connection_action`.
+
+Primary owners:
+
+- `src-tauri/src/services/managed_auth/consumers/codex.rs`
+- `src-tauri/src/services/managed_auth/consumers/grok.rs`
+- `src-tauri/src/services/managed_auth/consumers/opencode.rs`
+- consumer orchestration in `services/managed_auth/{login,service,providers/xai}.rs`
+- the connection action in `commands/managed_auth.rs`
+
+[Managed Auth Core](./managed-auth.md) owns account/credential metadata,
+SecretRef material and refresh CAS. [Managed Auth Login](./managed-auth-login.md)
+owns provider grants and backend login sessions. Codex Provider TOML and its
+config-only third-party writer are owned by
+[Codex Provider Configuration](./codex-provider-configuration.md). Agent-card
+observation and handoff semantics remain in
+[External Agent Auth](./external-agent-auth.md).
+
+## 2. Signatures
+
+```text
+managed_auth_apply_connection_action({
+  connectionId: mc1:<32-lowercase-hex>,
+  expectedRevision: mr1:<64-lowercase-hex>,
+  action: connect_account | switch_account | disconnect | refresh |
+          restart | open_consumer | switch_to_official,
+  accountId?: ma1:<32-lowercase-hex>
+}) -> ManagedAuthMutationResult | ManagedAuthErrorDto
+```
+
+`accountId` is required only for `connect_account` and `switch_account`.
+Every positive result contains a freshly reread overview; the renderer does not
+patch a connection optimistically.
+
+Consumer boundaries:
+
+```text
+codex::observe_codex_home(path) -> CodexObservation
+codex::file_projection_enabled() -> false until matching-host HIL
+
+grok::project_grok_native(home, store) -> Result<(), GrokStoreError>
+grok::auth_provider_command_enabled() -> false until matching-host HIL
+grok::file_projection_enabled() -> false until matching-host HIL
+
+opencode::observe_auth_store(path) -> OpencodeAuthObservation
+opencode::upsert_projection(path, provider, entry, expectedRevision?)
+  -> AuthJsonWriteReceipt | OpencodeAuthError
+opencode::remove_file_key(path, officialKey, expectedRevision?)
+  -> AuthJsonWriteReceipt | OpencodeAuthError
+opencode::remove_capability(path, capabilityId, expectedRevision?)
+  -> AuthJsonWriteReceipt | OpencodeAuthError
+opencode::connection_summaries(
+  observation, credentialRows, connectionRows, checkedAt
+) -> ManagedAuthConnectionSummary[]
+OPENCODE_EXTERNAL_WRITE_HOT_RELOAD_PROVEN = false
+```
+
+## 3. Contracts
+
+### Shared connection boundary
+
+- A managed account and a software connection are separate resources. A ready
+  credential does not prove that the consumer has accepted or is using it.
+- Every connection request carries a syntactically valid `expectedRevision`,
+  but enforcement is consumer-specific. OpenCode connect/switch/disconnect
+  compares the current `auth.json` revision under its process-wide writer lock,
+  and restart acknowledgement compares the latest observation before updating
+  metadata. Codex/Grok metadata-only refresh/connect/disconnect paths do not yet
+  independently compare the current connection revision. Their production
+  vendor-file gates remain closed, so this residual cannot authorize a native
+  file write, but it must not be described as full cross-consumer CAS.
+- Consumer adapters receive secret material only inside native code. Tokens,
+  SecretRef, raw auth-file bytes, paths, helper output and provider sidecar
+  details never cross IPC.
+- Credential purpose and refresh owner are explicit. Never copy one refresh
+  lineage among Proxy, Codex, Grok, OpenCode, or Copilot to simulate a
+  connection.
+- A successful file API call is not enough. Readback, owner transfer, external
+  pickup evidence and recovery state jointly determine connection status and
+  mutation outcome. A completed mutation may still truthfully require
+  `pending_restart`; a partial mutation is not a connected state.
+
+### Known Codex/Grok summary residual
+
+- `service.rs::build_connection_summaries` currently passes the first ready
+  `codex_native` / `grok_native` credential to the slot summary independently
+  of whether a connection row names that credential.
+- `consumers/codex.rs::connection_summary` currently maps credential presence
+  to `authStatus=connected` even while the production projection gate is false;
+  it also emits `native_projection_unavailable`. Grok maps the equivalent
+  credential-only state to `unavailable`. Neither shape proves native consumer
+  pickup, and the Codex shape is an explicit evidence mismatch.
+- Do not cite these summaries as proof that account/connection separation is
+  fully enforced. Before strengthening the contract, derive the selected
+  account from the explicit connection row, require projection/pickup evidence
+  for `connected`, and add regression coverage for the credential-only state.
+
+### Codex managed connection
+
+- `CODEX_FILE_PROJECTION_PRODUCTION_ENABLED` remains `false` until signed,
+  matching-host file-store HIL proves write/readback and Codex pickup.
+- Without that evidence, connect or login-to-connect stores the managed
+  credential but ends `partial` with `native_projection_unavailable` and writes
+  no vendor `auth.json`. The current summary may nevertheless report
+  `connected` from credential presence as described above; that value is not
+  live Codex evidence.
+- Codex Provider third-party API-key switches remain config-only under the
+  Codex Provider contract. They do not become evidence for a managed ChatGPT
+  connection.
+- A future projection may run only when the live Codex credential store is
+  explicitly `file`; `keyring`, `auto`, `ephemeral`, unset, invalid, unknown,
+  or mere `auth.json` existence are not admission evidence.
+
+### Grok fail-closed consumer
+
+- `GROK_AUTH_PROVIDER_COMMAND_ENABLED` and
+  `GROK_FILE_PROJECTION_PRODUCTION_ENABLED` remain `false` until matching-host
+  helper/file-lock/home-selection HIL exists.
+- A Grok connection uses a separate `purpose=grok_native` credential. It is
+  never Proxy-resolved and is not copied from `purpose=proxy_upstream`.
+- `project_grok_native` returns `Unsupported` while the gate is closed and
+  writes no `auth.json`. Connect or login-to-connect remains `partial` with
+  `native_projection_unavailable`.
+- When Grok tooling is available, Agent Auth observation stays
+  `handoff_only`; unavailable tooling yields an unavailable observation. In
+  neither case are CLI installation, a vault row, or opening a vendor page
+  verified Grok login evidence.
+
+### OpenCode Desktop `auth.json`
+
+- Resolve the official Desktop data path through
+  `opencode_config::get_opencode_auth_json_path`; observation and Path B writes
+  do not require a PATH `opencode` CLI.
+- Closed file keys are `openai`, `xai`, and `github-copilot`. Preserve every
+  unrelated provider, undecodable value, `wellknown` entry, and extra official
+  field not owned by the replacement operation.
+- Environment/`OPENCODE_AUTH_CONTENT` providers are not file rows. Do not
+  invent, delete, or claim to observe them through `auth.json`.
+- The private Desktop sidecar and `OPENCODE_SERVER_PASSWORD` are not a control
+  plane. Do not scan, guess, persist, or probe loopback ports/passwords.
+- Writes use the existing atomic file owner, apply `0600` on Unix, and require
+  byte/semantic readback. A mismatch restores the exact preimage or deletes a
+  newly created file; success is never inferred from `atomic_write` alone.
+- `consumer=opencode` creates an independent
+  `purpose=opencode_provider` credential. Proxy/Codex/Grok/Copilot purposes are
+  rejected rather than copied. After successful file readback, the service
+  attempts to transfer refresh ownership to `opencode`.
+- External-write hot reload is not proven. A successful FyAgent write remains
+  `pending_restart`; do not also emit `native_projection_unavailable`, which
+  means the write itself was unavailable.
+- Owner transfer occurs after file readback. A CAS miss (`Ok(false)`) records
+  the connection with `pending_restart` evidence and returns `partial` /
+  `partial_completion`. A hard repository error currently returns before that
+  connection metadata upsert even though the official file may already have
+  changed. This is a known recovery residual, not an atomic rollback: do not
+  claim that this branch proved FyAgent ownership or live Desktop pickup, and
+  require compensation/reconciliation before strengthening the contract.
+- Copilot login is not provided by Managed Auth. A legacy Copilot row without
+  stable identity remains blocked and must not be projected.
+
+## 4. Validation & Error Matrix
+
+| Condition | Required result |
+| --- | --- |
+| connection/account/revision is malformed | reject before dispatch; no file or metadata mutation |
+| OpenCode write/delete/restart sees a stale revision | reject; leave the official file and connection metadata unchanged |
+| Codex/Grok metadata action carries a stale-but-well-formed revision | current path does not independently compare it; trust only the returned reread overview and retain this as hardening residual |
+| OpenCode is offered Proxy/Codex/Grok/Copilot lineage | `provider_not_supported`; do not copy lineage |
+| Codex/Grok has no purpose-compatible ready credential | `native_projection_unavailable`; no vendor file write |
+| Codex projection gate is false | `partial` + `native_projection_unavailable`; no vendor file write |
+| Codex has a ready `codex_native` credential while projection is unavailable | current summary may contain `connected` + `native_projection_unavailable`; known evidence mismatch, not native pickup |
+| Grok has a ready `grok_native` credential while projection is unavailable | current summary is `unavailable` + `native_projection_unavailable`; not native pickup |
+| credential exists but no connection row names it | current Codex/Grok overview may still expose that account; do not treat it as an explicit connection |
+| Grok helper/file gate is false | `Unsupported` / `partial`; no vendor file write |
+| Proxy tries to resolve `purpose=grok_native` | conflict; no refresh |
+| OpenCode data dir exists but PATH CLI does not | observe `auth.json`; not `AuthObserverUnavailable` |
+| OpenCode `auth.json` is missing | empty provider set; not observer failure |
+| OpenCode readback differs | restore exact preimage or remove new file; report failure/recovery |
+| OpenCode write succeeds while hot reload is unproven | `pending_restart`; not `connected` and not `native_projection_unavailable` |
+| OpenCode connect is offered only a Proxy/Codex/Grok/Copilot credential | `provider_not_supported`; no write |
+| OpenCode refresh-owner CAS returns false after readback | retain pending-restart connection evidence; return `partial_completion` |
+| OpenCode refresh-owner repository call errors after readback | return error; file may already be changed and requires recovery/reconciliation |
+| sidecar port/password is supplied, scanned, or logged | security regression; no probe |
+| token, SecretRef, auth bytes, native path, or raw helper output reaches DTO/log/DOM | security regression |
+
+## 5. Good / Base / Bad Cases
+
+- **Good:** OpenCode replaces only the `openai` entry, preserves unknown keys,
+  writes atomically with `0600`, rereads equal bytes, transfers ownership, and
+  reports `pending_restart` until Desktop pickup is HIL-proven.
+- **Base:** OpenCode has no `auth.json`; observation returns an empty provider
+  set without requiring a CLI.
+- **Base:** Codex or Grok login stores a valid credential while projection
+  gates remain closed, so the mutation result is partial. Grok stays
+  unavailable; Codex's current credential-presence `connected` summary remains
+  a named evidence mismatch rather than a live native-login claim.
+- **Bad:** infer Codex file mode from file existence, copy a Proxy refresh token
+  into OpenCode/Grok, treat CLI installation as auth evidence, or paint a file
+  write as a live connection without readback and pickup evidence.
+
+## 6. Tests Required
+
+```bash
+mise run rust:fmt:check
+mise run rust:check
+mise run rust:clippy
+mise run rust:test -- managed_auth
+mise run rust:test -- opencode
+mise run typecheck:v2
+mise run test:v2 -- tests/v2/features/managed-auth.test.ts \
+  tests/v2/pages/agents/AgentAuthStatusPanel.test.tsx
+```
+
+Required assertions:
+
+- exact connection request shape and consumer-specific revision behavior:
+  OpenCode stale file revisions reject under the writer lock; Codex/Grok tests
+  must not claim full CAS until their metadata paths compare current revision;
+- Codex and Grok production gates remain false and write zero vendor bytes;
+- credential-only Codex/Grok summaries are not used as HIL evidence; before
+  resolving the named Codex mismatch, add a regression that derives account
+  linkage from the connection row and gates `connected` on projection/pickup;
+- Proxy rejects `grok_native` even while FyAgent temporarily owns refresh;
+- OpenCode observation has no PATH CLI dependency and missing file is empty;
+- closed-key RMW preserves unknown/undecodable/`wellknown` values and extra
+  fields; Unix mode is `0600`;
+- stale revision and readback mismatch leave/restore the authoritative file;
+- OpenAI/xAI `consumer=opencode` creates `opencode_provider`, never copies
+  another purpose, and transfers owner only after readback;
+- owner-transfer CAS miss returns partial with retained pending-restart
+  metadata; repository-error-after-write remains explicit recovery coverage;
+- `OPENCODE_EXTERNAL_WRITE_HOT_RELOAD_PROVEN=false` yields
+  `pending_restart` after a successful write;
+- Agent Auth remains sanitized, OpenCode provider-scoped, and Grok handoff-only;
+- matching-host connect/refresh/disconnect/external-change/restart HIL remains
+  required before enabling a gate or claiming live pickup.
+
+## 7. Wrong vs Correct
+
+Wrong:
+
+```text
+select any ready account -> copy its refresh token into consumer auth.json
+atomic_write Ok -> connected
+missing PATH opencode -> observer unavailable
+installed Grok CLI -> logged in
+```
+
+Correct:
+
+```text
+OpenCode selects a purpose-compatible credential under auth.json revision
+consumer-specific write -> readback -> refresh-owner transfer
+external pickup unproven -> pending_restart
+closed production gate -> partial/native_projection_unavailable with zero write
+Desktop auth.json observation is independent of PATH CLI
+Codex/Grok metadata actions use the returned overview; full stale-revision CAS
+is not claimed until their service paths enforce it
+Codex connected + native_projection_unavailable -> known evidence mismatch,
+not proof that native Codex accepted the credential
+```

--- a/.trellis/spec/backend/managed-auth-login.md
+++ b/.trellis/spec/backend/managed-auth-login.md
@@ -1,0 +1,238 @@
+# Managed Auth Login Session and Provider Protocol Contract
+
+## 1. Scope / Trigger
+
+Read this contract before changing `managed_auth_start_login`, login-session
+recovery/cancellation/reopen/switch behavior, OpenAI browser loopback PKCE,
+OpenAI Device Code, xAI Device Code, or the point at which a provider grant is
+allowed to become a Managed Auth credential.
+
+Primary owners:
+
+- `src-tauri/src/services/managed_auth/login.rs`
+- `src-tauri/src/services/managed_auth/login_sessions.rs`
+- `src-tauri/src/services/managed_auth/providers/openai.rs`
+- `src-tauri/src/services/managed_auth/providers/xai.rs`
+- the login-session methods in `src-tauri/src/commands/managed_auth.rs`
+
+[Managed Auth Core](./managed-auth.md) owns SecretRef admission, credential
+metadata, refresh CAS, and legacy migration. [Managed Auth Consumers](./managed-auth-consumers.md)
+owns Codex/Grok/OpenCode connection projection after a login grant has been
+stored. [V2 Managed Accounts](../frontend/v2-managed-auth.md) owns renderer
+polling and presentation. Do not duplicate provider protocol state in either
+consumer adapters or the renderer.
+
+## 2. Signatures
+
+```text
+managed_auth_start_login({ request })
+  -> ManagedAuthLoginSessionSnapshot | ManagedAuthErrorDto
+managed_auth_get_login_session({ sessionId })
+  -> ManagedAuthLoginSessionSnapshot | ManagedAuthErrorDto
+managed_auth_cancel_login({ sessionId })
+  -> ManagedAuthLoginSessionSnapshot | ManagedAuthErrorDto
+managed_auth_reopen_login({ sessionId })
+  -> ManagedAuthLoginSessionSnapshot | ManagedAuthErrorDto
+managed_auth_switch_login_method({ sessionId, method })
+  -> ManagedAuthLoginSessionSnapshot | ManagedAuthErrorDto
+```
+
+```text
+StartManagedAuthLoginRequest {
+  provider: openai | xai | github_copilot,
+  purpose: save_only | connect_consumer | reauthenticate,
+  consumer?: codex | grokbuild | opencode | fyagent_proxy,
+  method: browser_loopback | device_code,
+  accountId?: ma1:<32-lowercase-hex>
+}
+```
+
+Request shape is closed:
+
+- `save_only` has no consumer;
+- `connect_consumer` requires a consumer and has no account ID;
+- `reauthenticate` requires a valid account ID;
+- browser loopback is accepted only for OpenAI;
+- GitHub Copilot with the only otherwise admissible method (`device_code`) is
+  currently `provider_not_supported`; browser loopback is rejected earlier by
+  the method/provider validator.
+
+The advertised `connect_consumer` pairs are also closed:
+
+| Provider | Admitted consumers |
+| --- | --- |
+| `openai` | `codex`, `opencode`, `fyagent_proxy` |
+| `xai` | `grokbuild`, `opencode`, `fyagent_proxy` |
+| `github_copilot` | none; provider login is unavailable |
+
+The renderer derives these choices from `ManagedAuthProviderSummary`; it must
+not synthesize a cross-provider pair. xAI repeats this compatibility check in
+native admission. OpenAI's fallback purpose mapping is reserved for the
+advertised `fyagent_proxy` pair, not a generic authorization for every consumer
+enum. Do not widen this matrix without adding provider-side admission, purpose
+mapping, projection behavior, and negative tests together.
+
+The backend-generated snapshot contains only:
+
+```text
+contractVersion, sessionId, provider, purpose, consumer?, method, stage,
+canCancel, canRetry, canSwitchToDeviceCode, officialHost,
+userCode?, verificationUri?, expiresAt?, accountId?, connectionId?,
+reasonCode?, terminal
+```
+
+It never contains an authorization URL, callback URL, verifier, state,
+`device_code`, authorization code, token, SecretRef, native path, or raw HTTP
+body. Session IDs are backend-generated UUIDs; command admission rejects a
+malformed or zero-version UUID.
+
+## 3. Contracts
+
+### Backend-owned session lifecycle
+
+- `LoginSessionStore` is process-private, holds at most eight retained
+  snapshots, and admits at most one non-terminal session per provider. OpenAI
+  and xAI sessions may coexist; a second session for the same provider returns
+  `operation_conflict`. The renderer receives opaque snapshots and never runs
+  OAuth polling.
+- Cancel and browser-to-device switching bump the session generation. A late
+  callback or poll result from an older generation must not create or replace a
+  credential.
+- Terminal snapshots are stable. `reopen_login` on a terminal session is a
+  read-only no-op. For a non-terminal session it may reopen only the
+  process-private official URL already owned by that session.
+- Login success is published only after Managed Auth reserves metadata, writes
+  the versioned bundle to the OS vault, performs typed readback, and marks the
+  credential ready. Opening a browser or receiving a provider grant is not
+  success by itself.
+- After account storage, an unavailable Codex/Grok native projection ends
+  `partial` with its consumer-owned reason. A successful OpenCode file write
+  and readback may instead end `completed` with `pending_restart`, because the
+  write is proven while live Desktop pickup is not.
+
+### OpenAI browser loopback and Device Code
+
+- Browser loopback is the default OpenAI method. Bind only the first-party
+  registered ports `1455`, then `1457`; do not terminate an unknown listener.
+  When both are busy, start Device Code instead of choosing an arbitrary port.
+- The callback path is `/auth/callback`. Validate loopback host, bound port,
+  method/path, OAuth state, PKCE exchange, body bounds, and callback deadline
+  before accepting a code.
+- Device Code polling is backend-owned and follows the server interval and
+  expiry. The public snapshot may expose the bounded user code and the
+  query-free HTTPS verification URI for `auth.openai.com`, but not the provider
+  `device_code`.
+- Browser reopen uses the process-private official authorize URL. That URL
+  never crosses IPC or enters Query/route state.
+
+### xAI Device Code
+
+- xAI accepts Device Code only. A browser-loopback request is rejected before
+  a session is created.
+- Discovery, device, token, and refresh endpoints must remain HTTPS on
+  `auth.x.ai:443` with empty user information. Redirected or discovered
+  endpoints outside that origin are rejected.
+- Polling classifies `authorization_pending`, `slow_down`, `access_denied`, and
+  `expired_token`. `slow_down` increases the interval by five seconds within
+  the existing cap; it does not spin or reset expiry.
+- `purpose=grok_native` and `purpose=proxy_upstream` are distinct credential
+  sessions. A Grok login must not copy or retag a Proxy refresh lineage.
+
+### Error and redaction boundary
+
+- Provider HTTP errors may expose a bounded status classification, never the
+  response body, token payload, callback query, or authorization code.
+- Vault unavailable and migration blocked fail before a provider worker starts.
+- Unknown enum values, malformed request shapes, and invalid provider/method
+  combinations fail before browser open, device request, session worker, or
+  credential write. Consumer compatibility follows the closed advertised
+  matrix above; do not claim a wider pair from a fallback mapping.
+
+## 4. Validation & Error Matrix
+
+| Condition | Required result |
+| --- | --- |
+| vault unavailable | `secret_unavailable`; no provider worker |
+| migration blocks admission | `migration_blocked`; no provider worker |
+| OpenAI loopback ports `1455` and `1457` are busy | switch to Device Code; do not kill listeners or bind an arbitrary port |
+| callback host/path/state/PKCE/body/deadline is invalid | fail the session; store no grant |
+| user cancels while callback/poll is in flight | generation changes; late result is discarded |
+| switch method is not OpenAI browser-loopback → Device Code | `invalid_response`; session unchanged |
+| xAI requests browser loopback | reject before session creation |
+| xAI discovery or token endpoint leaves `auth.x.ai:443` | fail closed; send no credential request to that endpoint |
+| GitHub Copilot + Device Code | `provider_not_supported` |
+| renderer is offered a consumer outside the provider summary | contract regression; do not submit the request |
+| second non-terminal session for the same provider | `operation_conflict`; return no new session |
+| OpenAI and xAI each have one non-terminal session | both may coexist; retain unique backend UUIDs |
+| grant is received but SecretRef readback fails | never publish `completed`; retain the core recovery state |
+| Codex/Grok native projection is unavailable after storage | `partial` with the consumer-owned reason |
+| OpenCode file write/readback succeeds but live pickup is unproven | `completed` + `pending_restart`; do not relabel the write unavailable |
+| snapshot/error/log contains URL secrets, codes, tokens, verifier, SecretRef, or HTTP body | security regression |
+
+## 5. Good / Base / Bad Cases
+
+- **Good:** an OpenAI `save_only` login binds `1455`, validates state and PKCE,
+  stores the bundle, rereads it, and only then publishes a completed account
+  ID.
+- **Good:** both registered loopback ports are occupied, so the same request
+  becomes a Device Code session without touching either process.
+- **Base:** a valid xAI Device Code flow stores a separate `grok_native`
+  credential, then finishes partial because Grok projection is not HIL-proven.
+- **Base:** cancel succeeds while an HTTP poll is outstanding; the later grant
+  is ignored because its generation is stale.
+- **Bad:** return the authorize URL to React, let React poll the token endpoint,
+  reuse a Proxy credential for Grok, or mark completion before vault readback.
+
+## 6. Tests Required
+
+```bash
+mise run rust:fmt:check
+mise run rust:check
+mise run rust:clippy
+mise run rust:test -- managed_auth
+mise run typecheck:v2
+mise run test:v2 -- tests/v2/features/managed-auth.test.ts \
+  tests/v2/platform/managedAuthPort.test.ts
+```
+
+Required assertions:
+
+- exact request combinations, the advertised provider/consumer matrix, and
+  closed DTO keys/enums; xAI rejects a cross-provider pair and renderer tests
+  prove that options come only from the provider summary;
+- maximum-eight retention, per-provider single-flight, cross-provider
+  coexistence, UUID/session lookup rejection and terminal-session stability;
+- OpenAI callback host/path/state/PKCE/body/deadline validation;
+- `1455` → `1457` → Device Code fallback without process cancellation;
+- Device Code interval/expiry plus cancel/switch generation races;
+- reopen uses the process-private official URL and the snapshot has no URL;
+- xAI origin allowlist and pending/slow-down/deny/expiry classification;
+- `grok_native` versus `proxy_upstream` isolation;
+- SecretRef readback gates success and a failed consumer projection remains
+  partial rather than completed;
+- DTO/Debug/log leak scans cover callback/code/state/verifier/device/token and
+  raw HTTP body fields.
+
+Provider protocol mocks prove parser/state behavior only. Real browser,
+keychain/Credential Manager, callback, and consumer pickup claims require the
+matching-host HIL named by the owning contracts.
+
+## 7. Wrong vs Correct
+
+Wrong:
+
+```text
+renderer receives authorizeUrl + verifier
+renderer polls token endpoint
+grant received -> completed
+cancel only changes visible UI state
+```
+
+Correct:
+
+```text
+backend owns URL, callback, polling, verifier, and generation
+grant -> reserve metadata -> native vault write -> typed readback
+consumer projection/readback -> completed or partial
+cancel/switch bumps generation so late work cannot commit
+```

--- a/.trellis/spec/backend/managed-auth.md
+++ b/.trellis/spec/backend/managed-auth.md
@@ -2,9 +2,10 @@
 
 ## 1. Scope / Trigger
 
-Read this contract before changing Managed Auth metadata, Credential Session
-lifecycle, OS-native secret bundles, legacy JSON migration, Proxy token
-resolution, or the thin Tauri façade in `commands/managed_auth.rs`.
+Read this contract before changing Managed Auth account/credential metadata,
+OS-native secret bundles, legacy JSON migration, refresh ownership, account
+default/removal semantics, Proxy token resolution, or the core Tauri façade in
+`commands/managed_auth.rs`.
 
 Primary owners:
 
@@ -20,13 +21,10 @@ Related owners:
 - [V2 Managed Accounts](../frontend/v2-managed-auth.md) owns renderer Ports.
 - [External Agent Auth](./external-agent-auth.md) remains the Agent-owned
   Claude/desktop handoff façade; it must not grow a second OAuth store.
-- OpenAI browser loopback PKCE and Device Code are owned by
-  `services/managed_auth/providers/openai.rs` plus backend login sessions.
-  xAI Device Code is owned by `providers/xai.rs`. Codex native file
-  projection and Grok helper/`auth.json` writes stay fail-closed until
-  matching-host HIL. OpenCode Desktop observation and `auth.json`
-  projection live in `consumers/opencode.rs`; live Desktop pickup stays
-  `pending_restart` until HIL.
+- [Managed Auth Login](./managed-auth-login.md) owns backend login sessions,
+  OpenAI browser/Device Code, xAI Device Code, cancellation and reopen.
+- [Managed Auth Consumers](./managed-auth-consumers.md) owns Codex/Grok/OpenCode
+  connection observation, native projection gates, readback and restart state.
 
 This is the first production consumer of `services::secret`. Do not introduce a
 second keyring, a plaintext JSON token authority, or a `shared` refresh owner.
@@ -46,7 +44,7 @@ Startup failure is fail-closed overview (`secret_unavailable` /
 `migration_blocked`). It must not crash the app and must not fall back to a
 file or environment secret store.
 
-Current V2 commands:
+Core V2 commands:
 
 ```text
 managed_auth_get_overview() -> ManagedAuthOverview
@@ -56,15 +54,13 @@ managed_auth_preview_account_removal({ accountId, expectedRevision })
   -> ManagedAuthAccountRemovalPreview
 managed_auth_remove_account({ previewId, accountId, expectedRevision })
   -> ManagedAuthMutationResult
-
-managed_auth_start_login / get_login_session / cancel_login /
-reopen_login / switch_login_method
-  -> OpenAI (loopback + device) and xAI (device) snapshots after
-     request validation; Copilot stays provider_not_supported
-managed_auth_apply_connection_action
-  -> Codex/Grok metadata with native projection fail-closed until HIL;
-     OpenCode closed slots observe/project and may return pending_restart
 ```
+
+Login-session command signatures are owned by
+[Managed Auth Login](./managed-auth-login.md). Connection-action signatures are
+owned by [Managed Auth Consumers](./managed-auth-consumers.md). This contract
+owns their shared opaque IDs, credential metadata and mutation readback shape,
+not their provider/consumer protocol details.
 
 Leftover `commands/auth.rs` (not a second owner):
 
@@ -129,7 +125,7 @@ ManagedAuthService::resolve_access_material(provider, legacy_account_id?)
 ```
 
 OpenAI/xAI migrated sessions use `purpose=proxy_upstream`. Copilot uses
-`purpose=copilot`. Both require `refresh_owner=fyagent`. The resolver never
+`purpose=copilot`. All three use `refresh_owner=fyagent`. The resolver never
 returns a refresh token or SecretRef.
 
 ## 3. Contracts
@@ -178,6 +174,24 @@ Delete order: clear connections → delete SecretRef → delete credential /
 identity metadata. SQLite `ON DELETE CASCADE` is not a license to skip the
 native delete.
 
+### Default and account removal
+
+- Default selection accepts only a `Ready` credential under the account's
+  exact current revision. A stale revision, missing account, or account without
+  a ready credential fails before updating `managed_auth_defaults`.
+- Removal is two-step. `preview_account_removal` rereads the account revision
+  and lists every connection whose credential belongs to the account.
+  `remove_account` recomputes that preview and accepts only the matching
+  `previewId + accountId + expectedRevision`; it never trusts a renderer-owned
+  impact list.
+- Successful removal clears connection references, deletes each native
+  SecretRef, then removes credential/orphan identity metadata. Any incomplete
+  delete remains an error/recovery state; the overview must not hide a still
+  authoritative credential.
+- Mutation success returns a newly generated operation UUID and a freshly
+  computed overview. The renderer must not infer success from the command
+  returning without an error.
+
 ### Legacy JSON migration
 
 Sources, one journal row each:
@@ -202,21 +216,19 @@ legacy-copilot-auth-v3  <- copilot_auth.json
 - `legacy_store_sealed(id)` is true only for that source's
   `prepared|completed` journal. Vault unavailable or a foreign source failure
   must not seal remaining JSON stores.
-- After a source is sealed, the matching manager `seal_json_store()` and must
-  not write new tokens to plaintext JSON. Unsealed sources remain readable
-  JSON until they migrate.
+- After a source is sealed, startup must call the matching manager's
+  `seal_json_store()` and that manager must not write new tokens to plaintext
+  JSON. Unsealed sources remain readable until they migrate.
 
 ### Proxy and compatibility commands
 
 - `proxy/forwarder.rs` prefers `resolve_access_material` when a fyagent-owned
   vault session exists. Unmigrated / blocked sources may still use the old
   manager path.
-- Native-owned sessions (`codex_native` / `grok_native` / `opencode`) are
-  never refreshed by Proxy. OpenCode Path B projection writes an
-  independent `purpose=opencode_provider` session into official
-  `auth.json`, then sets `refresh_owner=opencode`. Codex/Proxy refresh
-  lineages are never copied. Live Desktop hot-reload of an external
-  write is unproven; successful FyAgent writes stay `pending_restart`.
+- Any credential whose purpose is not `proxy_upstream`, or whose refresh owner
+  is not `fyagent`, is rejected by Proxy. Consumer-specific purpose changes,
+  native projection and ownership transfer are governed by
+  [Managed Auth Consumers](./managed-auth-consumers.md).
 - V1 `commands/auth.rs` may list vault accounts only after that provider's
   JSON store is sealed. Otherwise JSON remains the live **read-only**
   compatibility path for `auth_list_accounts` / `auth_get_status`.
@@ -248,91 +260,21 @@ auth_cancel_login
   Proxy must resolve Copilot material natively, never through renderer IPC.
   Leftover Copilot list/status/models/usage may remain read-only.
 
-### Login sessions
+### Login and consumer boundary
 
-- OpenAI browser loopback PKCE is the default. Ports are only the first-party
-  registered `1455` then `1457`; unknown processes are never cancelled. Both
-  busy falls back to Device Code.
-- Device Code polling is backend-owned and uses the server interval. Cancel
-  bumps generation so a late poll cannot save a credential.
-- `reopen_login` re-opens the process-private official URL for a non-terminal
-  session. The snapshot never includes the authorization URL, callback URL,
-  code, state, or verifier.
-- Success is published only after SecretRef + metadata readback. Codex native
-  file projection stays closed without matching-host HIL (`partial` +
-  `native_projection_unavailable`).
-
-### xAI Device Code and Grok fail-closed consumer
-
-- xAI login is Device Code only. Browser loopback is rejected at request
-  validation. Discovery and token/device endpoints must be HTTPS
-  `auth.x.ai:443` with empty userinfo. Polling is backend-owned and classifies
-  `authorization_pending`, `slow_down` (interval +5s, capped),
-  `access_denied`, and `expired_token`. Cancel bumps session generation so a
-  late poll cannot save a credential.
-- Migrated / Proxy xAI sessions use `purpose=proxy_upstream` and
-  `refresh_owner=fyagent`. A Grok-purpose login creates a separate
-  `purpose=grok_native` Credential Session with its own credential ID. While
-  helper and file projection are disabled that session still uses
-  `refresh_owner=fyagent` and stays in the OS vault; it is never Proxy-resolved
-  and never copied into Grok `auth.json`.
-- Production gates in `consumers/grok.rs` stay false until matching-host HIL:
-
-```text
-GROK_AUTH_PROVIDER_COMMAND_ENABLED = false
-GROK_FILE_PROJECTION_PRODUCTION_ENABLED = false
-```
-
-- `project_grok_native` returns `Unsupported` and writes no vendor file.
-  Connect or login-to-connect finishes `partial` +
-  `native_projection_unavailable`. Overview Grok cards must not report
-  `connected`.
-- Windows `auth.json.lock` identity and `GROK_HOME` / multi-home targeting
-  remain unproven. Do not enable file writes. External Grok refresh versus
-  FyAgent generation reconcile is not a live path until a native write is
-  HIL-proven; vault CAS still discards stale generations for fyagent-owned
-  sessions.
-- Agent Auth observation for Grok Build remains `handoff_only`. Vault
-  `grok_native` metadata must not be painted as a verified Grok CLI/Desktop
-  login. CLI install success is not login evidence.
-
-### OpenCode Desktop `auth.json` consumer
-
-Path and schema follow official OpenCode `Global.Path.data/auth.json`
-(`consumers/opencode.rs` via `opencode_config::get_opencode_auth_json_path`).
-This consumer is Desktop-first:
-
-- Observation and Path B projection never require a PATH `opencode` CLI.
-- The private Desktop sidecar (ephemeral loopback port and
-  `OPENCODE_SERVER_PASSWORD`) is not a control plane. Do not probe, guess, or
-  persist sidecar ports or passwords.
-- Closed file keys are `openai`, `xai`, and `github-copilot`. Other keys stay
-  in the raw object. Read-modify-write must preserve unknown providers,
-  undecodable values, `wellknown` entries, and extra official fields on keys
-  FyAgent is not replacing.
-- Environment-variable / `OPENCODE_AUTH_CONTENT` providers are not `auth.json`
-  rows. Projection must not invent or delete them.
-- Writes use the existing atomic file owner, then `0600` on Unix, then
-  byte-equal readback. Readback mismatch restores the exact preimage or
-  deletes a newly created file. Success is never inferred from `atomic_write`
-  returning Ok.
-- Live Desktop pickup of an **external** write is unproven.
-  `OPENCODE_EXTERNAL_WRITE_HOT_RELOAD_PROVEN` stays `false`. After a successful
-  FyAgent write, connection `authStatus` is `pending_restart` with reason
-  `pending_restart`. Do not also emit `native_projection_unavailable` (that
-  reason means FyAgent could not write). Do not paint `connected` as hot.
-- `connect_consumer` / reauthenticate with `consumer=opencode` creates a
-  separate `purpose=opencode_provider` Credential Session. Proxy, Codex,
-  Grok, and Copilot purposes are rejected as lineage copies. After a
-  successful file readback, `refresh_owner` becomes `opencode`. A failed
-  owner transfer still records the connection as `pending_restart` so the
-  file write cannot look like a live Path A login.
-- Copilot login remains `provider_not_supported`. Copilot v1 JSON without a
-  stable identity stays `blocked`. Do not project that token into
-  `github-copilot`.
-- Matching-host Desktop HIL for connect, refresh, disconnect, external
-  change, and restart is still required before flipping the hot-reload gate
-  or claiming production live pickup.
+- Provider authorization, process-private session state, callback/device
+  polling, cancellation generation and provider-origin validation are owned by
+  [Managed Auth Login](./managed-auth-login.md).
+- Codex/Grok/OpenCode connection compatibility, auth-file projection,
+  consumer-specific purpose, native refresh-owner transfer and
+  `pending_restart` evidence are owned by
+  [Managed Auth Consumers](./managed-auth-consumers.md).
+- Both layers must enter this core through typed credential admission and
+  closed mutation APIs. Account/default/removal revision enforcement stays in
+  this core; consumer-specific revision coverage and its residuals stay in
+  [Managed Auth Consumers](./managed-auth-consumers.md). Neither layer may
+  write an alternate token store, bypass SecretRef readback, or return secret
+  material through IPC.
 
 ### Sync and export
 
@@ -354,18 +296,10 @@ metadata and must never include token columns.
 | Copilot v1 JSON without identity | that source `blocked`; other sources continue |
 | migration hash changes after prepare | stale/blocked; do not rename |
 | finalize rename fails after DB completed | retry rename on next startup; JSON is not writable authority |
-| login/session command for OpenAI | backend-owned snapshot; success only after SecretRef readback |
-| login for xAI Device Code | backend-owned snapshot; Grok native projection stays fail-closed |
-| login for Copilot | `provider_not_supported` |
-| Codex/Grok connect without HIL file projection | `partial` + `native_projection_unavailable`; no vendor auth.json write |
-| Grok helper or `auth.json` write while production gates are false | `Unsupported` / `partial` + `native_projection_unavailable`; no vendor file |
-| Proxy resolve of `purpose=grok_native` | conflict; no refresh |
-| OpenCode Path B write while live Desktop hot-reload is unproven | file write + readback may succeed; status stays `pending_restart`; do not emit `native_projection_unavailable` |
-| OpenCode login/connect with `consumer=opencode` | new `purpose=opencode_provider` session; never copy Proxy/Codex/Grok/Copilot refresh lineage |
-| OpenCode connect using only `purpose=proxy_upstream`/`codex_native`/`copilot` | `provider_not_supported`; no `auth.json` write |
-| OpenCode observe with Desktop data dir and no PATH CLI | sanitized provider list from `auth.json`; not `AuthObserverUnavailable` |
-| OpenCode RMW of one closed key | unknown/undecodable/other provider keys unchanged |
-| sidecar port/password supplied or scanned | reject; no network probe |
+| set-default revision is stale or no ready credential exists | reject; leave defaults unchanged |
+| removal preview ID/revision no longer matches | stale; delete neither SecretRef nor metadata |
+| removal cannot clear/delete every credential authority | report failure/recovery; do not fabricate an empty overview |
+| Proxy resolves a non-`proxy_upstream` purpose | conflict; no refresh |
 | mutation `operationId` is not UUID v4 | frontend parser rejects the result |
 | DTO/log/debug contains token/secretRef | test failure / NO-GO |
 | leftover `auth_start_login` / `auth_poll_for_account` / `auth_remove_account` / `auth_set_default_account` / `auth_logout` / `auth_cancel_login` | `legacy_auth_mutation_disabled`; no Device Code, JSON write, or vault delete |
@@ -379,15 +313,13 @@ metadata and must never include token columns.
   is renamed to a bounded `.bak`.
 - **Good:** Copilot v1 is blocked while a valid Codex store still finalizes.
 - **Base:** keychain/Credential Manager unavailable. Overview reports
-  `secret_unavailable`; plaintext JSON remains the live store.
-- **Base:** OpenAI login succeeds only after SecretRef + metadata readback.
-  Connecting Codex without HIL-proven file projection ends `partial` with
-  `native_projection_unavailable`. Migrated accounts remain visible.
-- **Good:** OpenCode `connect_consumer` login writes an independent
-  `purpose=opencode_provider` oauth/api entry, transfers `refresh_owner` to
-  `opencode`, and overview stays `pending_restart` until Desktop HIL proves
-  live pickup.
-- **Base:** missing `auth.json` is empty providers, not observer failure.
+  `secret_unavailable`; an unsealed legacy JSON manager may remain a read-only
+  compatibility/resolver source but never becomes a new writable authority.
+- **Good:** account removal preview names the current dependent connections;
+  apply recomputes the same revision/preview before deleting native secrets and
+  metadata.
+- **Base:** a stale default/removal request preserves the current overview and
+  asks the caller to reread rather than choosing another credential.
 - **Bad:** write refresh tokens back to JSON after that source is sealed.
 - **Bad:** seal every JSON store because one source failed.
 - **Bad:** pre-mark credentials `Ready` in the parser before vault readback.
@@ -401,7 +333,6 @@ mise run rust:clippy
 mise run rust:test -- managed_auth
 mise run rust:test -- leftover_legacy_auth
 mise run rust:test -- leftover_copilot_login
-mise run rust:test -- opencode
 mise run rust:test -- --test secret_service_contract
 mise run typecheck:v2
 ```
@@ -419,29 +350,11 @@ Required assertions:
   Copilot v1 does not block Codex finalize;
 - vault unavailable does not seal JSON;
 - stale generation cannot overwrite; resolver rejects native refresh owners;
+- set-default accepts only a ready credential under exact revision;
+  removal preview/apply recomputes impact and rejects stale preview IDs;
+  native secrets are deleted before credential/identity metadata;
 - overview/DTO leak scan includes `access_token`, `refresh_token`, `id_token`,
   `authorization_code`, `device_code`, `secretRef` / `secret_ref`, `verifier`;
-- OpenAI loopback callback host/path/state/PKCE, `1455`→`1457`→Device Code,
-  cancel drops a late result, and reopen opens the official page without
-  putting the authorize URL on the snapshot;
-- xAI Device Code discovery allowlist, pending/`slow_down`/expiry/deny
-  classification, cancel drops a late grant, and grok_native vs
-  proxy_upstream isolation; Proxy resolver rejects grok purpose even with
-  `refresh_owner=fyagent`;
-- Grok helper and file-projection constants remain false;
-  `project_grok_native` writes nothing;
-- Codex file projection remains closed without HIL; connect/login-to-connect
-  finishes `partial` with `native_projection_unavailable`;
-- third-party Codex writers never overwrite official `auth.json`;
-- OpenCode observation does not call PATH CLI; missing CLI is not
-  `AuthObserverUnavailable`;
-- OpenCode RMW preserves unknown/undecodable keys and `0600`; stale CAS
-  leaves the file unchanged; readback mismatch restores the preimage;
-- OpenAI/xAI `consumer=opencode` login creates `purpose=opencode_provider`
-  and does not copy Proxy/Codex/Grok/Copilot lineage; successful writes stay
-  `pending_restart` while `OPENCODE_EXTERNAL_WRITE_HOT_RELOAD_PROVEN` is
-  false;
-- Copilot v1 without identity stays blocked and is not projected;
 - leftover `auth_*` login/remove/default/logout/cancel helpers return
   `legacy_auth_mutation_disabled` without Tauri State;
 - leftover `copilot_start_device_flow` / poll / remove / set_default /
@@ -506,20 +419,4 @@ leftover copilot_start_device_flow / poll / remove / set_default / logout
   -> legacy_auth_mutation_disabled
 managed_auth_* owns login, default, and removal with preview
 auth_list_accounts / auth_get_status remain read-only
-```
-
-Wrong:
-
-```text
-missing PATH opencode -> AuthObserverUnavailable
-OpenCode connect uses proxy_upstream refresh token
-auth.json write Ok -> authStatus=connected
-```
-
-Correct:
-
-```text
-read Global.Path.data/auth.json; missing file is empty providers
-new purpose=opencode_provider session, then RMW + readback
-OPENCODE_EXTERNAL_WRITE_HOT_RELOAD_PROVEN=false -> pending_restart
 ```

--- a/.trellis/spec/backend/windows-runtime-security.md
+++ b/.trellis/spec/backend/windows-runtime-security.md
@@ -563,7 +563,10 @@ fyagent-user-helper.exe
   grok-tool --action observe|install|update [--owner native|npm]
             --job-id <uuid> --pipe <nonce>
   // After Hello: host writes 80-byte GrokNpmInstallPlan. Missing/invalid/@latest
-  // plan => helper refuses npm. Native install does not consume the npm plan.
+  // plan => helper refuses npm. The Windows product has already selected and
+  // integrity-checked the win32 x64/arm64 optional package; platform package
+  // and registry metadata resolution never move into the helper. Native
+  // install does not consume the npm plan.
 ```
 
 
@@ -578,6 +581,11 @@ fyagent-user-helper.exe
 - Helper stdout/stderr, environment, browser URL, device code, executable
   path, and command line must never return to the elevated parent or
   renderer.
+- The Windows product host is the platform-package authority. It maps only the
+  current x64/arm64 architecture to the corresponding `grok-win32-*` manifest
+  entry, validates root and platform SHA-512 at an allowed registry, and then
+  sends the compact exact-version/registry/allow-scripts control. The helper
+  must not select Darwin/Linux packages or fetch registry metadata.
 - Catalog desktop EXE install uses the separate protected package bridge and
   closed product action; this does not authorize CLI tools. There is no generic
   `ShellExecute` of a renderer/download path from Bob. Launch of an
@@ -591,6 +599,7 @@ fyagent-user-helper.exe
 | Formal elevated Windows Claude/OpenCode CLI or Auth session | `interactive_user_unavailable` / `executor_not_implemented`; no probe or child process |
 | Formal elevated Windows Grok Build lifecycle                | Closed `grok-tool` helper; no elevated fallback                                        |
 | Grok npm helper has no plan, `@latest`, or unknown registry     | Fail closed; no npm child process                                                      |
+| Windows product has no matching `grok-win32-*` package/integrity or no registry matches both hashes | Produce no helper plan; no npm child process |
 | OpenCode Windows x64 ProductName/relative EXE/signer is reviewed | Admit current-user NSIS handoff; ARM64 remains unsupported |
 | OpenCode Windows ProductName/relative EXE/signer is empty     | `windows_exe_install_admitted` rejects download and install; do not claim supported     |
 | OpenCode helper product is admitted but scan relatives omit `@opencode-aidesktop` | Inventory miss after a real current-user install; helper admission is not scan identity |
@@ -621,6 +630,11 @@ fyagent-user-helper.exe
   `interactive_user_unavailable` / `executor_not_implemented`.
 - Negative scan: no generic CLI/Auth helper verb, no path/URL argv, no raw
   stdout DTO. Closed `grok-tool` is the only Tooling helper action.
+- Windows product-host tests admit only `grok-win32-x64`/`grok-win32-arm64`,
+  reject absent platform integrity, and prove the 80-byte helper control
+  carries, besides fixed framing/version bytes, only exact package version,
+  registry index and the allow-scripts bit. The helper does not resolve
+  optional-package metadata.
 - Bob/Alice/UAC HIL remains unverified residual risk.
 
 ### 7. Wrong vs Correct

--- a/.trellis/spec/frontend/v2-agent-auth.md
+++ b/.trellis/spec/frontend/v2-agent-auth.md
@@ -3,8 +3,9 @@
 ## 1. Scope / Trigger
 
 Read this contract before changing Agent authentication status, login/logout or
-provider-connection actions, managed-account routing, active-session recovery, polling, stop-waiting,
-desktop-target selection, or authentication copy on the V2 Agents page.
+provider-connection actions, managed-account routing, active-session recovery,
+polling, stop-waiting, desktop-target selection, or authentication copy on the
+V2 Agents page.
 
 Primary owners are:
 
@@ -47,9 +48,13 @@ The observation union is closed:
 account              -> state: logged_in | logged_out | unknown
 provider_connections -> state: configured | empty | unknown, providers[]
 handoff_only          -> unverified Agent-owned handoff
-fyagent_managed       -> verified destination: auth_center
+fyagent_managed       -> verified compatibility destination: auth_center
 unavailable           -> unavailable authority
 ```
+
+`auth_center` is the closed wire-compatibility destination token used by the
+Agent Auth DTO. It is not a route literal; the renderer maps it to the current
+central `/auth` page.
 
 Every observation also carries:
 
@@ -136,7 +141,10 @@ The page never invokes native Auth commands directly.
   `configured` is not `logged_in`; `empty` is not proof of logout.
 - `handoff_only` says FyAgent can launch/guide the vendor flow but cannot verify
   the resulting account state. The UI must not convert it to success.
-- `fyagent_managed` remains a backend observation compatibility variant. Codex, Grok Build and OpenCode detail panels route to the central `/auth` page instead of duplicating account/connection mutations inside the Agent card.
+- `fyagent_managed` remains a backend observation compatibility variant.
+  Codex, Grok Build and OpenCode detail panels route to the central `/auth`
+  page instead of duplicating account/connection mutations inside the Agent
+  card.
 - `unknown`, `unverified`, and `unavailable` remain visible states with reason
   copy. Absence of evidence is never rendered as logged out or healthy.
 - Only an intent present in `allowedIntents` may be offered.

--- a/.trellis/spec/frontend/v2-managed-auth.md
+++ b/.trellis/spec/frontend/v2-managed-auth.md
@@ -18,10 +18,12 @@ Primary renderer owners:
 
 External Agent-owned authentication remains under
 [V2 External Agent Auth UI](./v2-agent-auth.md). Native credential, OAuth,
-consumer projection, refresh ownership and recovery semantics are owned by the
-backend managed-auth contract once activated; this frontend contract does not
-make browser fixtures or an unavailable native façade into authentication
-evidence.
+refresh ownership and recovery semantics are owned by
+[Managed Auth Core](../backend/managed-auth.md); provider login sessions by
+[Managed Auth Login](../backend/managed-auth-login.md); and software projection
+by [Managed Auth Consumers](../backend/managed-auth-consumers.md). This
+frontend contract does not make browser fixtures or mock IPC into native
+authentication evidence.
 
 ## 2. Signatures
 
@@ -117,8 +119,10 @@ request mode is a third-party API.
   exact contract version and exact key set, and accepts only closed enums,
   bounded labels, canonical opaque IDs/revisions and valid timestamps.
 - The overview parser validates cross-resource references, unique IDs,
-  connected-account counts, active-session uniqueness and provider/consumer
-  compatibility. A malformed reference rejects the complete snapshot.
+  connected-account counts, at most eight uniquely identified active sessions,
+  and provider/consumer compatibility. The backend admits at most one
+  non-terminal session per provider, while one OpenAI and one xAI session may
+  coexist. A malformed reference rejects the complete snapshot.
 - Login snapshots never expose authorization URLs, callback URLs, OAuth code,
   state, verifier, device authorization ID, token, native path or raw error.
   A device-code snapshot may expose only a bounded user code and a validated
@@ -136,9 +140,12 @@ request mode is a third-party API.
 - Login-session polling/recovery is owned by one hook. Remount resumes the
   backend session instead of starting a duplicate. Polling stops while the
   persistent route is hidden and on terminal/unmount.
-- Account and connection mutations are revision-bound. Positive UI state comes
-  only from the mutation result's freshly parsed overview/readback; the page
-  does not patch an optimistic success.
+- Account default/removal and OpenCode file mutations are revision-enforced by
+  their backend owners. Every connection request still carries the displayed
+  revision, but Codex/Grok metadata-only paths do not yet provide independent
+  stale-revision CAS. Positive UI state therefore comes only from the mutation
+  result's freshly parsed overview/readback; the page does not patch an
+  optimistic success or claim stronger concurrency protection.
 - `reopenLogin` asks the backend to open the official page for the current
   non-terminal session. The renderer never receives an authorization URL.
 - Account removal requires a backend impact preview. Failure to disconnect all
@@ -147,6 +154,11 @@ request mode is a third-party API.
 - `pendingRestart`, partial completion, external change, unavailable authority
   and recovery-required remain explicit states. Starting a browser, writing a
   credential or launching software is not sufficient to paint success.
+- The current backend may return a Codex connection with
+  `authStatus=connected` and `native_projection_unavailable` merely because a
+  ready `codex_native` credential exists. This is a named backend evidence
+  mismatch, not proof of native pickup. The renderer must preserve the reason
+  and must not use that combination for HIL or stronger success claims.
 
 ### Agent integration
 
@@ -184,9 +196,14 @@ request mode is a third-party API.
 | Connection references a missing account/provider | Reject the complete response. |
 | Account says two connections but only one references it | Reject the complete response. |
 | Device verification URI has query, fragment, wrong host or non-HTTPS scheme | Reject the login snapshot. |
-| A second active login session appears | Reject the overview/session chain; never poll both. |
+| More than eight active sessions or a duplicate session ID appears | Reject the overview/session chain. |
+| OpenAI and xAI each have one active session | Accept both; the UI follows the selected opaque session ID and must not merge them. |
+| A second start is attempted for a provider with a non-terminal session | Preserve `operation_conflict`; recover the existing provider session. |
 | Page is hidden by persistent routing | Pause automatic queries and polling; retain selected UI state. |
 | Mutation returns no authoritative overview/readback | Keep prior state and show uncertainty; do not claim success. |
+| Account/default/removal or OpenCode file mutation has a stale revision | Preserve stale error, reread, and require an explicit retry. |
+| Codex/Grok metadata action completes from an older displayed revision | Render only the returned overview; do not infer that the backend performed stale-write rejection. |
+| Codex is `connected` and also `native_projection_unavailable` | Preserve the unavailable reason and treat the pair as a known evidence mismatch; do not claim proven native login. |
 | Account removal preview fails | Do not expose the destructive confirmation. |
 | Connection needs restart | Show saved/pending-restart separately; do not say the consumer is already using it. |
 | Managed Agent summary is clicked | Navigate to `/auth?consumer=<closed-id>`; do not start the old Agent Auth session. |
@@ -194,15 +211,17 @@ request mode is a third-party API.
 
 ## 5. Good / Base / Bad Cases
 
-- **Good:** Codex displays an OpenAI account connection, `DeepSeek API` as the
-  current request source and `官方登录已保留` as a separate fact.
-- **Good:** an OpenAI browser login finishes credential storage but Codex still
-  needs restart; the dialog reports partial completion and offers restart or
-  later handling.
+- **Good:** Codex displays selected OpenAI account metadata, `DeepSeek API` as
+  the current request source and `官方登录已保留` as separate facts; it does not
+  use credential presence alone as proof of native Codex pickup.
+- **Good:** an OpenCode login finishes credential storage plus file readback,
+  then reports `pending_restart`; the dialog distinguishes “saved” from live
+  Desktop pickup and offers restart or later handling.
 - **Base:** OpenAI login snapshots come from backend sessions. Browser PKCE and
   Device Code can complete an account after SecretRef readback. Codex file
   projection remains `native_projection_unavailable` until HIL, so connect
-  finishes `partial` rather than claiming a live native login.
+  finishes `partial`. A simultaneous credential-derived `connected` summary is
+  the named backend residual, not a live native-login claim.
 - **Base:** OpenCode Path B file write + readback is not a live Desktop
   connection. Show `pending_restart` / “等待重启”. Do not show `已连接`
   while `OPENCODE_EXTERNAL_WRITE_HOT_RELOAD_PROVEN` is false.
@@ -230,12 +249,18 @@ mise run build:renderer
 Required assertions include:
 
 - all valid closed overview/session/mutation variants and strict rejection of
-  unknown keys, invalid references, wrong revisions and forbidden fields;
+  unknown keys, invalid references, malformed revisions and forbidden fields;
+- maximum-eight/unique session parsing plus backend per-provider single-flight
+  and cross-provider coexistence;
 - Tauri command/payload mapping and request/response identity binding;
 - `/auth` routing, navigation selection, primary-route keep-alive and browser
   native-only behavior;
 - account/connection/request-source separation, login recovery, device-code
   copy, destructive preview, readback-only success and pending-restart states;
+- stale account/OpenCode mutations reread before retry; Codex/Grok metadata
+  actions render only the returned overview and tests do not claim full CAS;
+- Codex `connected + native_projection_unavailable` remains visible as
+  contradictory residual evidence and is never counted as native pickup/HIL;
 - managed Agent cards navigate to the central page while Claude and desktop
   handoff retain their existing owner;
 - leftover Provider OAuth sections remain picker-only and leftover

--- a/scripts/ci/classify-changes.mjs
+++ b/scripts/ci/classify-changes.mjs
@@ -69,6 +69,7 @@ const RELEASE_CONTROL_FILES = new Set([
 
 const GITHUB_CONTRACT_FILES = new Set([
   ".github/labeler.yml",
+  ".github/workflows/codeql-security.yml",
   ".github/workflows/labeler.yml",
   ".github/workflows/star-history.yml",
 ]);

--- a/tests/classifyChanges.test.ts
+++ b/tests/classifyChanges.test.ts
@@ -221,6 +221,7 @@ describe("repository change classifier", () => {
       "GitHub repository automation",
       [
         ".github/labeler.yml",
+        ".github/workflows/codeql-security.yml",
         ".github/workflows/labeler.yml",
         ".github/workflows/star-history.yml",
       ],

--- a/tests/githubWorkflowTriggers.test.ts
+++ b/tests/githubWorkflowTriggers.test.ts
@@ -203,6 +203,49 @@ describe("GitHub workflow trigger policy", () => {
     ]);
   });
 
+  it("keeps CodeQL security scanning off the PR and merge-queue hot path", () => {
+    const source = readWorkflow("codeql-security.yml");
+    const triggerSection = readHeaderBefore(source, "\npermissions:");
+
+    expect(triggerSection).toBe(
+      [
+        "name: CodeQL Security / Scheduled",
+        "",
+        "on:",
+        "  schedule:",
+        '    - cron: "17 3 * * 1"',
+        "  workflow_dispatch:",
+      ].join("\n"),
+    );
+    expect(triggerSection).not.toMatch(/pull_request|merge_group|push/);
+    expect(source).not.toContain("CI / Required");
+    expect(source).toContain("runs-on: ubuntu-24.04");
+    expect(source).toContain("timeout-minutes: 30");
+    expect(source).toContain("security-events: write");
+    expect(source).not.toMatch(
+      /^\s+(?:checks|pull-requests|id-token):\s+write/m,
+    );
+    expect(source).toContain(
+      "- language: actions\n            build-mode: none",
+    );
+    expect(source).toContain(
+      "- language: javascript-typescript\n            build-mode: none",
+    );
+    expect(source).toContain("- language: rust\n            build-mode: none");
+    expect(source).not.toContain("language: swift");
+    expect(source).not.toContain("language: c-cpp");
+    expect(source).not.toContain("language: python");
+
+    const uses = [...source.matchAll(/^\s+uses:\s+(.+)$/gm)].map(
+      (match) => match[1],
+    );
+    expect(uses).toEqual([
+      "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1",
+      "github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4",
+      "github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4",
+    ]);
+  });
+
   it("keeps frontend labeling scoped to frontend-owned tests", () => {
     const source = fs
       .readFileSync(path.resolve(WORKFLOWS_DIR, "..", "labeler.yml"), "utf8")


### PR DESCRIPTION
## Summary

- move CodeQL security scanning out of pull-request and merge-queue execution into a weekly/manual advanced workflow
- disable reliance on GitHub-managed CodeQL default setup and Code Quality for merge readiness
- register the scheduled security workflow as repository automation rather than CI authority
- split and tighten managed-auth, external-agent, Codex provider, Windows runtime, and V2 auth specs for clearer retrieval and ownership

## Validation

- `mise run test:unit -- tests/classifyChanges.test.ts tests/githubWorkflowTriggers.test.ts`
- `mise run check:contracts`
- local commit convention check against latest `main`

## Merge behavior

`CI / Required` remains the only required status check for `main`; CodeQL security scanning is preserved as weekly/manual security evidence and is no longer part of the PR/merge-queue hot path.