### PR TITLE
fix: reconcile September 6-7 specs and restore integration gates

### DIFF
--- a/.trellis/spec/backend/claude-code-cli.md
+++ b/.trellis/spec/backend/claude-code-cli.md
@@ -32,8 +32,12 @@ UserHelperAction::ClaudeTool { action } -> independent wire identities 15–17
 The renderer supplies only Agent/action and existing opaque inventory fields.
 It never supplies a package, registry, version, path, command or installer URL.
 `tool_host_missing` and `tool_owner_unsupported` are closed Agent reason codes.
-The existing compact npm-plan control and authenticated helper session are
-reused; no generic command execution capability is added.
+Compact readiness is `surface=cli`, `sourceKind=cli_tooling`, no `surfaces`
+array. The renderer parser in `agent-install-readiness.ts` must admit that
+shape; requiring `managed_desktop` or treating `cli` as illegal fails the
+Agent directory scan as 「读取失败」 without reaching install. The existing
+compact npm-plan control and authenticated helper session are reused; no
+generic command execution capability is added.
 
 ## 3. Contracts
 
@@ -108,14 +112,16 @@ reused; no generic command execution capability is added.
 | Windows helper identity/admission/result is uncertain           | Fail closed; no elevated fallback                                      |
 | Any request supplies a command/package/path/registry            | Reject at the closed boundary                                          |
 | CLI install succeeds                                            | Installation only; no claim of successful login or inference           |
+| Renderer requires `managed_desktop` or treats `cli` as illegal  | Directory scan fails; host still emitted CLI not_installed + install   |
 
 ## 5. Good / Base / Bad Cases
 
 Good: a verified mirror installs the exact official optional package and the
 actual CLI reports the expected version. Base: a native installation remains
 usable/readable but must update through its original owner. Bad: `npm @latest`,
-global mirror changes, treating an npm success exit as runnable proof, or
-executing a user-writable npm from the elevated Windows parent.
+global mirror changes, treating an npm success exit as runnable proof,
+executing a user-writable npm from the elevated Windows parent, or a renderer
+parser that still expects Claude Desktop/`managed_desktop`.
 
 ## 6. Tests Required
 
@@ -123,8 +129,10 @@ Run `mise run rust:test`, `mise run rust:clippy`, `mise run typecheck`,
 `mise run test:unit`, and the existing user-helper/ACL/architecture suites.
 Assert product-specific wire identity, closed arguments, exact package and
 scope registry, narrow script allowance, platform/SRI admission, no downgrade,
-owner/prefix rejection, CLI-only policy and post-install observation. Mirror
-smoke uses an isolated temporary home/prefix/cache and no login or inference.
+owner/prefix rejection, CLI-only policy and post-install observation. Renderer
+tests must parse compact `claude-code` readiness as `cli` / `cli_tooling` and
+reject Desktop/`managed_desktop`. Mirror smoke uses an isolated temporary
+home/prefix/cache and no login or inference.
 Windows native helper execution and real vendor login require their own
 matching-host evidence; macOS and portable tests do not establish it.
 
@@ -133,6 +141,8 @@ matching-host evidence; macOS and portable tests do not establish it.
 ```text
 wrong: install latest from any mirror; npm exit 0 -> installed
 wrong: run user npm from the elevated desktop process
+wrong: renderer surfacesForAgent(claude-code)=desktop; sourceKind=managed_desktop
 correct: compiled manifest -> matching registry/root/platform -> closed plan
          -> ordinary-user execution -> actual CLI version/owner readback
+correct: renderer admits compact CLI readiness (cli_tooling, no surfaces array)
 ```

--- a/.trellis/spec/backend/claude-code-cli.md
+++ b/.trellis/spec/backend/claude-code-cli.md
@@ -90,6 +90,11 @@ generic command execution capability is added.
 - Windows always uses the existing Explorer-user helper boundary, never
   elevated PATH/npm execution. Frozen user, authenticated pipe, job nonce,
   signed helper and admission ordering remain unchanged.
+- Windows discovers `npm.cmd` then `npm.exe`. `.cmd` / `.bat` shims are
+  launched as `cmd.exe /D /S /C call "{quoted-program}" …` via `CommandExt::raw_arg`.
+  Do not `Command::new("npm.cmd")`: CreateProcess treats the application name
+  as a PE image, so the shim never runs. macOS keeps the existing Tooling
+  child-process owner and does not use cmd shims.
 - The Windows action carries independent Claude identity, while sharing npm
   plan decoding and execution. It discovers closed Claude executable names,
   inspects npm's actual prefix, checks ownership/Node/architecture, rechecks
@@ -110,6 +115,7 @@ generic command execution capability is added.
 | Already same/newer npm install on update                        | No-op; never downgrade                                                 |
 | npm exits successfully but CLI is stub/wrong version/unrunnable | Verification failure, not installed success                            |
 | Windows helper identity/admission/result is uncertain           | Fail closed; no elevated fallback                                      |
+| Windows npm is a `.cmd` / `.bat` shim launched via `Command::new(path)` | Contract regression; use quoted `cmd /C call` through `raw_arg`     |
 | Any request supplies a command/package/path/registry            | Reject at the closed boundary                                          |
 | CLI install succeeds                                            | Installation only; no claim of successful login or inference           |
 | Renderer requires `managed_desktop` or treats `cli` as illegal  | Directory scan fails; host still emitted CLI not_installed + install   |
@@ -135,14 +141,19 @@ reject Desktop/`managed_desktop`. Mirror smoke uses an isolated temporary
 home/prefix/cache and no login or inference.
 Windows native helper execution and real vendor login require their own
 matching-host evidence; macOS and portable tests do not establish it.
+Helper contract tests must require `npm.cmd` discovery plus
+`.raw_arg(&command_line)` / `call {quoted_program}` and must not accept
+`Command::new(npm.cmd)`.
 
 ## 7. Wrong vs Correct
 
 ```text
 wrong: install latest from any mirror; npm exit 0 -> installed
 wrong: run user npm from the elevated desktop process
+wrong: Command::new("npm.cmd") as the helper application name
 wrong: renderer surfacesForAgent(claude-code)=desktop; sourceKind=managed_desktop
 correct: compiled manifest -> matching registry/root/platform -> closed plan
          -> ordinary-user execution -> actual CLI version/owner readback
+correct: Windows .cmd shim -> cmd /D /S /C call "{quoted}" via raw_arg
 correct: renderer admits compact CLI readiness (cli_tooling, no surfaces array)
 ```

--- a/.trellis/spec/backend/claude-code-cli.md
+++ b/.trellis/spec/backend/claude-code-cli.md
@@ -92,9 +92,15 @@ generic command execution capability is added.
   signed helper and admission ordering remain unchanged.
 - Windows discovers `npm.cmd` then `npm.exe`. `.cmd` / `.bat` shims are
   launched as `cmd.exe /D /S /C call "{quoted-program}" …` via `CommandExt::raw_arg`.
-  Do not `Command::new("npm.cmd")`: CreateProcess treats the application name
-  as a PE image, so the shim never runs. macOS keeps the existing Tooling
-  child-process owner and does not use cmd shims.
+  Keep this explicit shared dispatch as project policy, not a claim that
+  standard-library `Command` can never start batch files. The
+  [Rust process contract](https://doc.rust-lang.org/std/process/index.html)
+  documents special batch handling and warns against depending on it.
+  `raw_arg` bypasses standard escaping: it receives only the native-owned
+  program and closed npm plan, never an arbitrary renderer command or argument.
+  Static routing assertions do not prove arbitrary batch quoting is safe.
+  macOS keeps the existing Tooling child-process owner and does not use cmd
+  shims.
 - The Windows action carries independent Claude identity, while sharing npm
   plan decoding and execution. It discovers closed Claude executable names,
   inspects npm's actual prefix, checks ownership/Node/architecture, rechecks

--- a/.trellis/spec/backend/codex-desktop-installer.md
+++ b/.trellis/spec/backend/codex-desktop-installer.md
@@ -419,6 +419,13 @@ not** call `platform.launch`. Explicit launch and restart remain on
 open uses NSWorkspace completion inside that owner, not `/usr/bin/open`.
 Managed-Agent desktop launch calls `launch_trusted_macos_application_as_user`
 with a backend-validated `.app` path.
+The source regression in `platform/process_launch.rs` distinguishes this
+application boundary from its HTTP-only browser helper: only
+`open_http_url_with_macos_open` may spawn `open` with a single validated URL
+argument. Keep the no-`open` assertion for the remaining production module and
+Codex bundle adapter; a module-wide ban would incorrectly reject the separate
+browser flow, while deleting the assertion would lose application-launch
+protection.
 
 ## 4. Validation & Error Matrix
 

--- a/.trellis/spec/backend/codex-provider-configuration.md
+++ b/.trellis/spec/backend/codex-provider-configuration.md
@@ -127,13 +127,12 @@ CODEX_WEBSOCKET_PROXY_MAY_BE_UNSUPPORTED
   They never project a saved Provider's login into `auth.json`. Managed Auth's
   separately confirmed account connection owns auth replacement. Proxy recovery
   remains a distinct exact-preimage operation under its own contract.
-- `codex_config/source_switch.rs` validates the intended source before any
-  catalog/config side effect, then patches only source-owned fields into the
-  live `toml_edit` document. Missing third-party setup is rejected, not treated
-  as an empty replacement document. A meaningful API-key configuration using
-  Codex's built-in default source remains valid. Preserve unrelated user tables,
-  MCP, profiles, features, preferences and comments, including comments attached
-  to a removed root key.
+- [Codex Request-Source Selection](./codex-source-selection.md) owns desired
+  source validation, selector comment/uncomment and the pure targeted TOML
+  patch in `codex_config/source_switch.rs`. This writer persists that result
+  through the existing guard/backup/readback path. A Provider source switch
+  may change its owned model and selected provider table; it is not the
+  selector-only config edit performed by an official account connection.
 
 ### Migration metadata and official-provider ownership
 

--- a/.trellis/spec/backend/codex-source-selection.md
+++ b/.trellis/spec/backend/codex-source-selection.md
@@ -1,0 +1,136 @@
+# Codex Request-Source Selection
+
+## 1. Scope / Trigger
+
+Read before changing the top-level `model_provider` selector or the pure
+projection of a saved Provider into live Codex TOML. Two callers share this
+configuration logic but have different write permissions:
+
+- [Managed Auth Consumers](./managed-auth-consumers.md) connects an official
+  account and may comment the selector, or disconnects and restores it.
+- [Codex Provider Configuration](./codex-provider-configuration.md) selects a
+  saved request source and patches its owned model/provider fields. Its writer
+  and Change Plan remain config-only.
+
+Owners are `src-tauri/src/codex_config/model_provider_line.rs` and
+`src-tauri/src/codex_config/source_switch.rs`. This contract does not own
+credentials, consumer status, file recovery, or Provider persistence.
+
+## 2. Signatures
+
+```rust
+comment_top_level_model_provider(config: &str) -> Option<String>
+uncomment_top_level_model_provider(config: &str) -> Option<String>
+top_level_model_provider_is_active(config: &str) -> bool
+
+validate_codex_source_config(
+    category: Option<&str>, auth: &serde_json::Value, desired_config: &str,
+) -> Result<(), AppError>
+patch_codex_source_config(
+    current_config: &str, category: Option<&str>, auth: &serde_json::Value,
+    desired_config: &str, config_dir: &Path, unify_sessions: bool,
+) -> Result<String, AppError>
+```
+
+The last two names are the `codex_config.rs` re-exports of `validate_source`
+and `patch_source`. These are native helpers, not renderer commands. Paths,
+auth bytes and full TOML never become new IPC arguments through this boundary.
+
+## 3. Contracts
+
+### Selector edit versus complete operation
+
+The line helper changes the first matching bare-key `model_provider = ...`
+assignment before the first table header. Comment inserts `#` after the
+indentation; uncomment removes one leading `#` and following whitespace.
+It retains line endings, the assignment value, trailing comments and other
+lines. `None` means this helper found no matching edit, not that the caller's
+whole operation is a no-op. The active-selector predicate is false for both
+a commented selector and no recognized selector.
+
+This is a narrow lexical helper, not a general TOML parser or revision guard.
+Do not infer support for quoted keys, multiline-string content or ambiguous
+multiple selectors from these helpers. Source projection separately parses
+complete TOML with `toml_edit`; account projection retains its own observation
+and admission. Extending the lexical grammar requires parser-aware validation
+and preservation tests, not a broader text replacement.
+
+| Operation | Permitted effect |
+| --- | --- |
+| Official account connect/switch | Compute the auth delta separately; comment an active selector to use the built-in default route. Do not edit provider tables, model, MCP or features. |
+| Codex disconnect / restore source | Uncomment the recognized saved selector when present; keep `auth.json`. Connection metadata and restart evidence belong to the consumer. |
+| Saved Provider/source selection | Comment/uncomment as preparation, then patch the selected source's owned TOML fields. Preserve `auth.json` and unrelated configuration. |
+
+An auth delta of `Noop` can therefore still produce a config write for a
+matching official account with an active third-party selector. Conversely,
+switching a saved request source does not replace an official account.
+
+### Targeted Provider projection
+
+`source_switch.rs` validates the desired source before catalog/config side
+effects, edits the existing selector, then parses and patches the live
+document. It is not limited to toggling one comment:
+
+- Root source-owned fields are `model_provider`, `model`,
+  `experimental_bearer_token`, `base_url` and `wire_api`. A missing desired
+  field removes that owned value while retaining attached user comments.
+- Optional model choices (`review_model`, reasoning effort/summary, verbosity,
+  context/compaction limits and `web_search`) change only when present in the
+  desired source. `model_catalog_json` is removed on absence only when its
+  path is recognized as FyAgent-owned.
+- Replace only the selected custom provider table. Preserve other provider
+  tables, MCP, features, profiles and the credential-store choice. Do not claim
+  byte-for-byte preservation of the selected table that this operation owns.
+- An empty official template uses the default route. An explicit compatible
+  official template may supply a selector or native-capability table; the
+  unified-session projection retains its existing ownership checks. Do not
+  apply the account operation's selector-only restriction to this writer.
+
+## 4. Validation & Error Matrix
+
+| Condition | Required result |
+| --- | --- |
+| Matching auth plus active selector | Auth bytes can remain unchanged while the selector is commented; not a whole-operation no-op. |
+| Selector already commented or absent | Comment helper returns `None`; independently evaluate any auth/source changes. |
+| Selector inside a provider/MCP/other table | The line helper does not edit it. |
+| Desired TOML invalid or present model/selector is not nonempty text | Reject source projection before file side effects. |
+| Official desired source explicitly selects an incompatible auth route | Reject; a display name alone is not official-source evidence. |
+| Custom third-party source lacks its selected table or supported authentication | Reject; do not replace the live file with an empty template. |
+| Nonempty built-in-default configuration has an API key | Validate through the existing built-in source path; do not invent a custom-table requirement. |
+| Live TOML cannot be parsed | Reject Provider projection; never reconstruct unrelated user settings from a minimal form. |
+
+Custom source admission accepts the existing API-key, native-auth, `env_key`
+or auth-table alternatives. Reserved built-in routes retain their own auth
+contract; this helper does not invent a bearer-key requirement for them.
+
+## 5. Good / Base / Bad Cases
+
+Good: an official account already matches, so its auth bytes stay intact while
+`model_provider = 'custom'` becomes `#model_provider = 'custom'`; provider and
+MCP tables remain unchanged. Base: a saved third-party source restores the
+selector and patches its selected model/table without a second selector.
+Bad: describe both operations as either “auth-only” or “comment-only”, replace
+the entire live TOML, or treat a pure patch result as proof of a successful
+file write, connected account or running-process pickup.
+
+## 6. Tests Required
+
+Run `mise run rust:test -- model_provider_line` and
+`mise run rust:test -- source_switch`. Their tests assert table isolation,
+LF/CRLF preservation, comment/uncomment round trips, no duplicate selector,
+desired-source rejection, and preservation of unrelated live configuration.
+
+`consumers/codex/project.rs` tests independently prove matching-account config
+changes without auth rotation, already-commented no-op, and stale auth/config
+revision rejection without writes. Consumer tests own backup/readback and
+restart outcomes; a lexical unit test proves none of those effects.
+
+## 7. Wrong vs Correct
+
+Wrong: `delta == Noop` means no file can change; every official source operation
+must only comment one line; `patch_source` returning text proves connection.
+
+Correct: evaluate auth and selector deltas independently, select the caller's
+bounded write set, validate the complete desired/live source where required,
+then let the existing native writer, readback and consumer observer determine
+the operation's outcome.

--- a/.trellis/spec/backend/external-agent-lifecycle.md
+++ b/.trellis/spec/backend/external-agent-lifecycle.md
@@ -204,7 +204,7 @@ identity examples include:
 
 | Product                       | macOS bundle ID                  | Windows closed identity summary                                                                                                                                                                                                               |
 | ----------------------------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| WorkBuddy                     | `com.workbuddy.workbuddy`        | Closed relative `WorkBuddy.exe`, ProductName and reviewed signer.                                                                                                                                                                             |
+| WorkBuddy                     | `com.tencent.workbuddy.mac`      | Closed relative `WorkBuddy.exe`, ProductName and reviewed signer.                                                                                                                                                                             |
 | QoderWork CN                  | `com.qoder.work.cn`              | Closed QoderWork CN relative EXE names, ProductName and signer.                                                                                                                                                                               |
 | TRAE Work CN                  | `cn.trae.solo.app`               | Closed TRAE SOLO/Work CN relative EXE names, ProductName and signer.                                                                                                                                                                          |
 | OpenCode                      | `ai.opencode.desktop`            | Closed relative `@opencode-aidesktop/OpenCode.exe` (and `OpenCode/OpenCode.exe`), ProductName `OpenCode`, reviewed signer `Anomaly Innovations, Inc https://anoma.ly/`, and Uninstall DisplayName `OpenCode` or `OpenCode <bounded-version>`. |
@@ -244,6 +244,12 @@ leaf:
   `WinVerifyTrust`, exactly one signer and reviewed signer leaf.
 - Do not infer installation from `.workbuddy`, `.qoderwork*`, `.trae*` or any
   settings directory.
+- Official WorkBuddy macOS identity is `com.tencent.workbuddy.mac` from the
+  signed Tencent `WorkBuddy.app` package. `com.workbuddy.workbuddy` is a stale
+  closed ID and must not match. `CodeBuddy CN.app` /
+  `com.tencent.codebuddycn` is a different product. Folder names are not
+  identity. Scan, system-commit policy, and privileged helper `Policy.swift`
+  stay in lockstep on this ID.
 
 ### Jobs and platform side effects
 
@@ -371,6 +377,9 @@ Assertion points:
   lifecycle policy: Grok and Claude are compact CLI/`cli_tooling`;
 - macOS exact-path deployment, cancellation boundary, running-app protection,
   rollback/recovery and disabled `/Applications` gate;
+- WorkBuddy macOS scan matches only `com.tencent.workbuddy.mac`; a same-folder
+  `com.workbuddy.workbuddy` fixture stays unmatched; helper/policy/desktop
+  bundle IDs stay equal via `helper_policy_bundle_ids_match_macos_bundle_id_for`;
 - Windows registry access masks/views/link handling, trusted PE identity,
   signer leaf, retained artifact, helper protocol/pipe binding, UAC cancel and
   vendor-wizard handoff with no wait/kill/post-install claim;

--- a/.trellis/spec/backend/external-agent-lifecycle.md
+++ b/.trellis/spec/backend/external-agent-lifecycle.md
@@ -135,6 +135,10 @@ command, argument vector, token, hash, package format, signer or bypass flags.
 - Compact single-surface products omit the `surfaces` readiness array and the
   inventory `surface` field. A multi-surface product must make each surface
   explicit instead of collapsing status.
+- Compact CLI readiness uses `sourceKind=cli_tooling`. The renderer
+  `parseAgentInstallReadiness` / `surfacesForAgent` table must stay aligned
+  with `lifecycle_policy.rs`. Treating Claude Code as `managed_desktop` is
+  not a product-absent signal; it is a contract parse failure.
 
 ### Product and source policy
 
@@ -363,6 +367,8 @@ Assertion points:
   platform, schema, redirect and version rules without stale URL fallback;
 - Claude CLI tests cover the compiled npm manifest, shared registry/argv/helper,
   actual version/owner verification, and rejection of the retired Desktop path;
+- renderer `surfacesForAgent` / readiness `sourceKind` stay aligned with
+  lifecycle policy: Grok and Claude are compact CLI/`cli_tooling`;
 - macOS exact-path deployment, cancellation boundary, running-app protection,
   rollback/recovery and disabled `/Applications` gate;
 - Windows registry access masks/views/link handling, trusted PE identity,
@@ -412,6 +418,20 @@ await ports.agentInstallReadiness.startAction({
   targetId: destination.destinationId,
   expectedTargetRevision: destination.destinationRevision,
 });
+```
+
+Wrong:
+
+```ts
+surfacesForAgent("claude-code") === ["desktop"]
+sourceKind === "managed_desktop"
+```
+
+Correct:
+
+```ts
+surfacesForAgent("claude-code") === ["cli"]
+sourceKind === "cli_tooling"
 ```
 
 Wrong:

--- a/.trellis/spec/backend/index.md
+++ b/.trellis/spec/backend/index.md
@@ -63,6 +63,7 @@ and reuse of Grok's npm mirrors and ordinary-user execution boundary.
 | [Deep-Link Import Security](./deeplink-import-security.md)                | Untrusted deep-link parsing, confirmation, import capabilities, and side-effect limits.                                          |
 | [Change Plan Typed Executor](./change-plan-executor.md)                   | Typed plans, idempotency, execution phases, compensation, and partial results.                                                   |
 | [Codex Provider Configuration](./codex-provider-configuration.md)         | Codex provider/auth projection, writer serialization, backup, rollback, and readback.                                            |
+| [Codex Request-Source Selection](./codex-source-selection.md)             | Shared selector edits, account-versus-source write boundaries, and targeted live TOML projection.                                |
 | [One-click Executable Software Installer](./codex-desktop-installer.md)   | Codex desktop discovery/install/update, PackageBridge/helper, signing, and transaction safety.                                   |
 | [Codex Session Usage Sync](./codex-session-usage.md)                      | Codex JSONL usage import, typed deferred reasons, retry/fingerprint separation, and bounded logging.                             |
 | [WorkBuddy Configuration](./workbuddy-configuration.md)                   | Revisioned WorkBuddy model/config writes, overwrite capabilities, backup, and reread.                                            |

--- a/.trellis/spec/backend/macos-system-commit.md
+++ b/.trellis/spec/backend/macos-system-commit.md
@@ -98,7 +98,7 @@ Product integers (C ABI / XPC; display names never travel):
 | 2     | OpenCodeDesktop | `ai.opencode.desktop`     | `OpenCode.app`                 | none                      |
 | 3     | QoderWork       | `com.qoder.work.cn`       | `QoderWork CN.app`             | none                      |
 | 4     | TraeWork        | `cn.trae.solo.app`        | `TRAE SOLO CN.app`             | none                      |
-| 5     | WorkBuddy       | `com.workbuddy.workbuddy` | `WorkBuddy.app`                | none                      |
+| 5     | WorkBuddy       | `com.tencent.workbuddy.mac` | `WorkBuddy.app`                | none                      |
 
 Codex slots: `1` = ChatGPT.app (fresh default), `2` = Codex.app (existing
 only). Every other product uses slot `1` as its single fresh-default basename.
@@ -154,6 +154,10 @@ this table or the admitted Agent lifecycle; Claude Code is CLI-only under
   is local/diagnostic only.
 - `.build/` and `dist/` under `src-tauri/macos-privileged-helper/` are
   gitignored build outputs.
+- WorkBuddy's expected bundle ID is `com.tencent.workbuddy.mac`. Keep
+  `agent_install/desktop.rs` `DESKTOP_PRODUCTS` / `macos_bundle_id_for`,
+  `macos_system_commit/policy.rs`, and privileged helper `Policy.swift` equal.
+  Do not admit stale `com.workbuddy.workbuddy`.
 
 ## 4. Validation & Error Matrix
 
@@ -191,6 +195,9 @@ this table or the admitted Agent lifecycle; Claude Code is CLI-only under
 - `mise run rust:test -- macos_system_commit`: product/slot table, production
   `production_enabled() == false`, `system_scope_rejection()` is
   `authorization_required`.
+- `mise run rust:test -- helper_policy_bundle_ids_match_macos_bundle_id_for`:
+  helper slot bundle IDs equal `macos_bundle_id_for` for OpenCode, QoderWork,
+  TraeWork, and WorkBuddy (`com.tencent.workbuddy.mac`).
 - `swift run PrivilegedHelperTests` in `src-tauri/macos-privileged-helper`
   (custom test executable; do not treat `swift test` XCTest discovery as the
   owner).
@@ -235,6 +242,18 @@ typedef struct {
 /* product + target_slot integers only; no path/command/URL */
 uint32_t product;
 uint32_t target_slot;
+```
+
+#### Wrong
+
+```rust
+macos_bundle_id: "com.workbuddy.workbuddy",
+```
+
+#### Correct
+
+```rust
+macos_bundle_id: "com.tencent.workbuddy.mac", // lockstep with Policy.swift
 ```
 
 #### Wrong

--- a/.trellis/spec/backend/managed-auth-consumers.md
+++ b/.trellis/spec/backend/managed-auth-consumers.md
@@ -126,11 +126,17 @@ CODEX_EXTERNAL_WRITE_HOT_RELOAD_PROVEN = false
   connection.
 - A successful file API call is not enough. Readback, owner transfer, external
   pickup evidence and recovery state jointly determine connection status and
-  mutation outcome. When file write/readback succeeds but live pickup is not
-  proven, the exact positive wire shape is `outcome=completed` with
-  `reasonCode=pending_restart`. The returned overview remains authoritative
-  about which connection is pending; a partial mutation is not a connected
-  state.
+  mutation outcome. When write/readback succeeds, `completed` +
+  `pending_restart` is only for a live consumer process that may still hold
+  previous credentials. Codex apply/disconnect inspect
+  `CodexDesktopRuntimeStatus` via `live_codex_requires_restart_for_app`:
+  `NotRunning` and `NotInstalled` clear the flag (overview is connected);
+  Running / Ambiguous / Unsupported / UntrustedTarget / inspect error keep
+  `pending_restart`. File-layer `project_under_guard` still marks the write
+  pending so tests without AppState stay fail-closed. OpenCode has no desktop
+  runtime inspect yet, so a successful write remains pending. The returned
+  overview is authoritative about which connection is pending; a partial
+  mutation is not a connected state.
 - Codex, Grok, and OpenCode summaries currently emit `target_id: None`. That is
   not lifecycle install discovery and is not evidence the software is missing.
   `requestMode` is observation of the consumer's current model source (for
@@ -171,15 +177,17 @@ CODEX_EXTERNAL_WRITE_HOT_RELOAD_PROVEN = false
   bytes. Official source comments the existing selector; unofficial source
   uncomments that same line instead of inserting a duplicate. Replacing auth
   does not imply that a configured third-party endpoint stopped being used.
-- After a successful auth write while hot reload is unproven, return
-  `completed` + `pending_restart`, and persist the Codex connection itself as
-  pending in the authoritative overview. Do not emit
+- After a successful auth or selector write, `project_under_guard` still
+  reports `pending_restart` while `CODEX_EXTERNAL_WRITE_HOT_RELOAD_PROVEN` is
+  false. `project_codex_official_account` then calls
+  `live_codex_requires_restart_for_app` and clears the flag when Desktop is
+  `NotRunning` or `NotInstalled`. Do not emit
   `native_projection_unavailable` for a successful write, and do not translate
   this positive state into a generic retry failure.
 - Codex disconnect clears FyAgent connection metadata, not the user's auth
   file. If the top-level selector is commented, the preview lists `config.toml`
-  as a write target and `auth.json` as unchanged. A successful uncomment is
-  `pending_restart` until Codex rereads the file.
+  as a write target and `auth.json` as unchanged. A successful uncomment uses
+  the same live-runtime gate: pending only when Desktop may still be running.
 
 ### Grok fail-closed consumer
 
@@ -247,7 +255,9 @@ CODEX_EXTERNAL_WRITE_HOT_RELOAD_PROVEN = false
 | OpenCode data dir exists but PATH CLI does not                            | observe `auth.json`; not `AuthObserverUnavailable`                                                                   |
 | OpenCode `auth.json` is missing                                           | empty provider set; not observer failure                                                                             |
 | OpenCode readback differs                                                 | report stale/uncertain; preserve backup and never blindly overwrite external bytes                                   |
-| OpenCode/Codex write and readback succeed while hot reload is unproven    | `completed` + `pending_restart`; returned overview marks the connection pending; not `native_projection_unavailable` |
+| OpenCode write and readback succeed while hot reload is unproven    | `completed` + `pending_restart`; returned overview marks the connection pending; not `native_projection_unavailable` |
+| Codex write succeeds while Desktop is `NotRunning` or `NotInstalled` | `completed` with no `pending_restart`; overview is connected                                                         |
+| Codex write succeeds while Desktop is Running / Ambiguous / Untrusted / Unsupported / inspect error | `completed` + `pending_restart`; fail closed                                                                         |
 | token, SecretRef, auth bytes, or raw helper output reaches DTO/log/DOM    | security regression                                                                                                  |
 | Display paths arrive outside explicit impact/recovery metadata            | security regression                                                                                                  |
 | Connection mutation lacks a matching fresh single-use preview             | reject before vendor write                                                                                           |
@@ -264,7 +274,9 @@ CODEX_EXTERNAL_WRITE_HOT_RELOAD_PROVEN = false
   `model_provider` is active, official connect comments that one line and
   leaves `[model_providers.*]` intact. Disconnect or a disconnected slot with
   that line still commented uncomments the same selector. An explicit unofficial
-  source change also uncomments it instead of duplicating it.
+  source change also uncomments it instead of duplicating it. When Codex
+  Desktop is not running or not installed, the overview is connected without
+  a Restart button.
 - **Base:** OpenCode has no `auth.json`; observation returns an empty provider
   set without requiring a CLI.
 - **Base:** Codex unset store and missing `model_provider` are effective file
@@ -306,7 +318,11 @@ Required assertions:
   `0600`, purpose isolation, and owner transfer only after file readback;
 - OpenCode owner-transfer CAS miss returns partial with pending evidence, while
   a hard repository error keeps its documented recovery residual explicit;
-- Codex and OpenCode positive writes use `completed + pending_restart`, and
+- Codex and OpenCode positive writes use `completed + pending_restart` when a
+  live process may still hold previous credentials; Codex
+  `live_restart_is_only_required_when_desktop_may_be_running` covers
+  NotRunning/NotInstalled vs fail-closed statuses; `project_under_guard` still
+  asserts pending on writes so file-layer tests stay conservative;
   strict renderer parsing rejects every other non-null reason on a completed result;
 - native sidecar/password discovery stays absent, and DTO/log/DOM leak tests
   cover tokens, SecretRef, raw auth bytes and helper output; only the explicit
@@ -320,6 +336,7 @@ Wrong:
 ```text
 select any ready account -> copy its refresh token into consumer auth.json
 atomic_write Ok -> connected
+atomic_write Ok -> always pending_restart even if Codex Desktop is not running
 credential present -> Codex connected
 official connect -> leave active model_provider = "OpenAI"
 CODEX_FILE_PROJECTION_PRODUCTION_ENABLED=false forever
@@ -331,7 +348,8 @@ Correct:
 ```text
 OpenCode selects a purpose-compatible credential under auth.json revision
 consumer-specific write -> readback -> refresh-owner transfer
-external pickup unproven -> pending_restart
+external pickup unproven AND live Codex/OpenCode process may hold old creds -> pending_restart
+Codex Desktop NotRunning/NotInstalled after write -> connected, no Restart
 Codex live identity match -> connected; otherwise saved-not-projected
 official connect -> comment first top-level model_provider; keep [model_providers.*]
 disconnect / disconnected+commented -> uncomment the same selector; keep [model_providers.*]

--- a/.trellis/spec/backend/managed-auth-consumers.md
+++ b/.trellis/spec/backend/managed-auth-consumers.md
@@ -11,6 +11,7 @@ Primary owners:
 
 - `src-tauri/src/services/managed_auth/consumers/codex/mod.rs`
 - `src-tauri/src/services/managed_auth/consumers/codex/{auth_document,delta,observation,project,swap}.rs`
+- `src-tauri/src/codex_config/model_provider_line.rs`
 - `src-tauri/src/services/managed_auth/consumers/grok.rs`
 - `src-tauri/src/services/managed_auth/consumers/opencode.rs`
 - consumer orchestration in
@@ -141,7 +142,7 @@ CODEX_EXTERNAL_WRITE_HOT_RELOAD_PROVEN = false
 - Codex file-store projection is capability-gated by machine-checkable facts:
   effective store is unset/default-file or explicit file; complete identity-
   matched ChatGPT auth material; revision CAS; mandatory backup and atomic
-  private write; auth readback with an unchanged config document. Matching-host HIL is optional smoke
+  private write; auth readback. Matching-host HIL is optional smoke
   evidence and does not control a production boolean gate.
 - Effective defaults follow the pinned OpenAI Codex contract: unset
   `cli_auth_credentials_store` → file; missing `model_provider` → openai.
@@ -150,24 +151,35 @@ CODEX_EXTERNAL_WRITE_HOT_RELOAD_PROVEN = false
 - Connected status requires live ChatGPT identity to match the connection-
   bound credential. A ready SecretRef alone is saved-not-projected /
   disconnected, never connected.
-- Minimum write delta is independent of request route: a matching account is
-  a no-op; another or missing account replaces only `auth.json`. All config
-  bytes, including model, MCP, features and provider tables, remain unchanged.
+- Auth write delta is independent of request route: a matching account is an
+  auth no-op; another or missing account replaces only `auth.json`. Official
+  `connect_account` / `switch_account` comments the first top-level
+  `model_provider = …` line (keep the user's value and comment style, e.g.
+  `#model_provider = "OpenAI"`) so Codex falls back to built-in openai. If
+  that line is already commented or absent, config is a no-op. Never delete
+  the selector, never rewrite it to `openai`, and never touch
+  `[model_providers.*]`, MCP, features, model, or other bytes. Disconnect, or
+  a disconnected slot whose selector is still commented, uncomments that same
+  line so unofficial routing returns. Auth.json is not deleted.
 - Auth projection takes the existing Codex Provider guard but does not call a
   Provider writer or backfill credentials into Provider rows. The shared file
   recovery owner preserves the exact outgoing auth preimage, including legacy
-  API-key-only documents. An account change must not silently change routing.
+  API-key-only documents. Commenting the selector is the intended official
+  ChatGPT routing change; it is not permission to rewrite provider tables.
 - Switching to an official or third-party request source is a separate,
   explicitly confirmed Provider/Change Plan operation. It preserves auth
-  bytes and patches only the source-owned config fields. Replacing auth does
-  not imply that a configured third-party endpoint stopped being used.
+  bytes. Official source comments the existing selector; unofficial source
+  uncomments that same line instead of inserting a duplicate. Replacing auth
+  does not imply that a configured third-party endpoint stopped being used.
 - After a successful auth write while hot reload is unproven, return
   `completed` + `pending_restart`, and persist the Codex connection itself as
   pending in the authoritative overview. Do not emit
   `native_projection_unavailable` for a successful write, and do not translate
   this positive state into a generic retry failure.
 - Codex disconnect clears FyAgent connection metadata, not the user's auth
-  file. The preview therefore lists the existing auth/config as unchanged.
+  file. If the top-level selector is commented, the preview lists `config.toml`
+  as a write target and `auth.json` as unchanged. A successful uncomment is
+  `pending_restart` until Codex rereads the file.
 
 ### Grok fail-closed consumer
 
@@ -239,15 +251,20 @@ CODEX_EXTERNAL_WRITE_HOT_RELOAD_PROVEN = false
 | token, SecretRef, auth bytes, or raw helper output reaches DTO/log/DOM    | security regression                                                                                                  |
 | Display paths arrive outside explicit impact/recovery metadata            | security regression                                                                                                  |
 | Connection mutation lacks a matching fresh single-use preview             | reject before vendor write                                                                                           |
-| Codex account change also rewrites config.toml                            | contract regression                                                                                                  |
+| Codex official connect/switch comments an active top-level `model_provider` and keeps provider tables | required; deleting the selector, rewriting it to `openai`, or editing model/MCP/features/provider tables is a regression |
+| Codex account change uncomments `model_provider` or inserts a second selector | contract regression                                                                                                  |
+| Codex disconnect leaves a commented top-level `model_provider` in place   | contract regression                                                                                                  |
 
 ## 5. Good / Base / Bad Cases
 
 - **Good:** OpenCode replaces only the `openai` entry, preserves unknown keys,
   writes atomically with `0600`, rereads equal bytes, transfers ownership, and
   reports `pending_restart` until Desktop pickup is HIL-proven.
-- **Good:** Codex A→B swaps only `auth.json` on either request route; an
-  explicit source change separately patches config while auth stays equal.
+- **Good:** Codex A→B swaps only `auth.json`; if the live top-level
+  `model_provider` is active, official connect comments that one line and
+  leaves `[model_providers.*]` intact. Disconnect or a disconnected slot with
+  that line still commented uncomments the same selector. An explicit unofficial
+  source change also uncomments it instead of duplicating it.
 - **Base:** OpenCode has no `auth.json`; observation returns an empty provider
   set without requiring a CLI.
 - **Base:** Codex unset store and missing `model_provider` are effective file
@@ -263,6 +280,8 @@ mise run rust:fmt:check
 mise run rust:check
 mise run rust:clippy
 mise run rust:test -- managed_auth
+mise run rust:test -- model_provider_line
+mise run rust:test -- source_switch
 mise run rust:test -- opencode
 mise run typecheck
 mise run test:unit -- tests/renderer/features/managed-auth.test.ts \
@@ -274,8 +293,9 @@ Required assertions:
 - the native command validates before `spawn_blocking`, does not run the
   synchronous service on the IPC command thread, and maps blocking-task join
   failure to `invalid_response`;
-- Codex effective file defaults, route-independent auth-only delta, private
-  backup/readback/CAS, config byte-equality, and saved-not-projected status;
+- Codex effective file defaults, auth delta plus top-level `model_provider`
+  comment/uncomment, private backup/readback/CAS, provider-table
+  preservation, and saved-not-projected status;
 - previews bind account/action/revision/path, expire, supersede and consume
   once; absent confirmation or changed overrides authorize zero vendor writes;
 - Grok production gates remain false and write zero vendor bytes;
@@ -301,6 +321,7 @@ Wrong:
 select any ready account -> copy its refresh token into consumer auth.json
 atomic_write Ok -> connected
 credential present -> Codex connected
+official connect -> leave active model_provider = "OpenAI"
 CODEX_FILE_PROJECTION_PRODUCTION_ENABLED=false forever
 sync Tauri command -> blocking credential/file coordinator
 ```
@@ -312,6 +333,9 @@ OpenCode selects a purpose-compatible credential under auth.json revision
 consumer-specific write -> readback -> refresh-owner transfer
 external pickup unproven -> pending_restart
 Codex live identity match -> connected; otherwise saved-not-projected
+official connect -> comment first top-level model_provider; keep [model_providers.*]
+disconnect / disconnected+commented -> uncomment the same selector; keep [model_providers.*]
+unofficial source -> uncomment the same selector; never a second model_provider line
 Codex capability from effective store + complete material + readback
 async Tauri command -> validate -> spawn_blocking(sync service) -> strict result
 ```

--- a/.trellis/spec/backend/managed-auth-consumers.md
+++ b/.trellis/spec/backend/managed-auth-consumers.md
@@ -11,7 +11,6 @@ Primary owners:
 
 - `src-tauri/src/services/managed_auth/consumers/codex/mod.rs`
 - `src-tauri/src/services/managed_auth/consumers/codex/{auth_document,delta,observation,project,swap}.rs`
-- `src-tauri/src/codex_config/model_provider_line.rs`
 - `src-tauri/src/services/managed_auth/consumers/grok.rs`
 - `src-tauri/src/services/managed_auth/consumers/opencode.rs`
 - consumer orchestration in
@@ -26,6 +25,9 @@ config-only third-party writer are owned by
 [Codex Provider Configuration](./codex-provider-configuration.md). Agent-card
 observation and handoff semantics remain in
 [External Agent Auth](./external-agent-auth.md).
+The shared selector and pure source-patch behavior are owned by
+[Codex Request-Source Selection](./codex-source-selection.md); do not duplicate
+their implementation or extend account operations to Provider-table writes.
 
 ## 2. Signatures
 
@@ -58,7 +60,8 @@ Consumer boundaries:
 
 ```text
 codex::observe_codex_home(path) -> CodexManagedAuthObservation
-codex::plan_codex_managed_auth_delta(live, target) -> Noop|AuthOnly
+codex::plan_codex_managed_auth_delta(live, target)
+  -> Result<Noop|AuthOnly, CodexDeltaError> // auth-file delta only
 codex::project_codex_official_account(app_state, home, subject, doc, expected_rev)
   -> CodexProjectionOutcome
 codex::file_projection_enabled() -> true when capability is generally available;
@@ -126,14 +129,15 @@ CODEX_EXTERNAL_WRITE_HOT_RELOAD_PROVEN = false
   connection.
 - A successful file API call is not enough. Readback, owner transfer, external
   pickup evidence and recovery state jointly determine connection status and
-  mutation outcome. When write/readback succeeds, `completed` +
-  `pending_restart` is only for a live consumer process that may still hold
-  previous credentials. Codex apply/disconnect inspect
+  mutation outcome. After write/readback, restart evidence is consumer-specific.
+  Codex apply/disconnect inspect
   `CodexDesktopRuntimeStatus` via `live_codex_requires_restart_for_app`:
-  `NotRunning` and `NotInstalled` clear the flag (overview is connected);
+  `NotRunning` and `NotInstalled` clear the flag;
   Running / Ambiguous / Unsupported / UntrustedTarget / inspect error keep
   `pending_restart`. File-layer `project_under_guard` still marks the write
-  pending so tests without AppState stay fail-closed. OpenCode has no desktop
+  pending so tests without AppState stay fail-closed. Clearing the flag does
+  not itself mean connected: connect/switch still needs identity readback,
+  while disconnect clears the managed binding. OpenCode has no desktop
   runtime inspect yet, so a successful write remains pending. The returned
   overview is authoritative about which connection is pending; a partial
   mutation is not a connected state.
@@ -157,33 +161,31 @@ CODEX_EXTERNAL_WRITE_HOT_RELOAD_PROVEN = false
 - Connected status requires live ChatGPT identity to match the connection-
   bound credential. A ready SecretRef alone is saved-not-projected /
   disconnected, never connected.
-- Auth write delta is independent of request route: a matching account is an
-  auth no-op; another or missing account replaces only `auth.json`. Official
-  `connect_account` / `switch_account` comments the first top-level
-  `model_provider = …` line (keep the user's value and comment style, e.g.
-  `#model_provider = "OpenAI"`) so Codex falls back to built-in openai. If
-  that line is already commented or absent, config is a no-op. Never delete
-  the selector, never rewrite it to `openai`, and never touch
-  `[model_providers.*]`, MCP, features, model, or other bytes. Disconnect, or
-  a disconnected slot whose selector is still commented, uncomments that same
-  line so unofficial routing returns. Auth.json is not deleted.
+- Auth delta and selector delta are independent: a matching account leaves
+  auth bytes unchanged but can still require a selector write. Official
+  connect/switch and disconnect use the bounded edits in
+  [Codex Request-Source Selection](./codex-source-selection.md). Neither
+  operation owns provider tables, model, MCP or features; disconnect does not
+  delete `auth.json`.
 - Auth projection takes the existing Codex Provider guard but does not call a
   Provider writer or backfill credentials into Provider rows. The shared file
   recovery owner preserves the exact outgoing auth preimage, including legacy
   API-key-only documents. Commenting the selector is the intended official
   ChatGPT routing change; it is not permission to rewrite provider tables.
-- Switching to an official or third-party request source is a separate,
-  explicitly confirmed Provider/Change Plan operation. It preserves auth
-  bytes. Official source comments the existing selector; unofficial source
-  uncomments that same line instead of inserting a duplicate. Replacing auth
-  does not imply that a configured third-party endpoint stopped being used.
-- After a successful auth or selector write, `project_under_guard` still
-  reports `pending_restart` while `CODEX_EXTERNAL_WRITE_HOT_RELOAD_PROVEN` is
-  false. `project_codex_official_account` then calls
-  `live_codex_requires_restart_for_app` and clears the flag when Desktop is
-  `NotRunning` or `NotInstalled`. Do not emit
-  `native_projection_unavailable` for a successful write, and do not translate
-  this positive state into a generic retry failure.
+- A saved request-source change is a separate, explicitly confirmed
+  Provider/Change Plan operation and preserves auth bytes. Do not confuse a
+  low-level auth swap with full official connection: the latter can also
+  change routing through the selector. The actual selected source and live
+  process pickup still require their own observations.
+- `project_under_guard` writes a changed selector before swapping auth. An
+  auth-swap error attempts to restore the config preimage; that compensation
+  currently ignores its own write error. This is not an atomic two-file
+  transaction or proof of successful rollback. Preserve the recovery receipts
+  and require reread after a failed operation; never report both files restored
+  from the auth error alone.
+- Apply the shared runtime/restart rule above after an auth or selector write.
+  Do not emit `native_projection_unavailable` for a successful write, or turn
+  positive `completed + pending_restart` into a generic retry failure.
 - Codex disconnect clears FyAgent connection metadata, not the user's auth
   file. If the top-level selector is commented, the preview lists `config.toml`
   as a write target and `auth.json` as unchanged. A successful uncomment uses
@@ -248,7 +250,7 @@ CODEX_EXTERNAL_WRITE_HOT_RELOAD_PROVEN = false
 | Codex effective store is explicit auto/keyring/ephemeral/unknown          | store unsupported; zero auth write                                                                                   |
 | Codex/Grok/OpenCode summary has `target_id: None`                         | slot is unbound to a lifecycle install; not missing-install evidence                                                 |
 | ready CodexNative credential while live identity differs                  | disconnected / saved-not-projected; not connected                                                                    |
-| live Codex identity matches bound credential                              | connected; may still be third-party route with session preserved                                                     |
+| live Codex identity matches bound credential and no restart is pending     | connected; may still be third-party route with session preserved                                                     |
 | Grok has a ready `grok_native` credential while projection is unavailable | current summary is `unavailable` + `native_projection_unavailable`; not native pickup                                |
 | Grok helper/file gate is false                                            | `Unsupported` / `partial`; no vendor file write                                                                      |
 | Proxy tries to resolve `purpose=grok_native`                              | conflict; no refresh                                                                                                 |
@@ -256,7 +258,7 @@ CODEX_EXTERNAL_WRITE_HOT_RELOAD_PROVEN = false
 | OpenCode `auth.json` is missing                                           | empty provider set; not observer failure                                                                             |
 | OpenCode readback differs                                                 | report stale/uncertain; preserve backup and never blindly overwrite external bytes                                   |
 | OpenCode write and readback succeed while hot reload is unproven    | `completed` + `pending_restart`; returned overview marks the connection pending; not `native_projection_unavailable` |
-| Codex write succeeds while Desktop is `NotRunning` or `NotInstalled` | `completed` with no `pending_restart`; overview is connected                                                         |
+| Codex write succeeds while Desktop is `NotRunning` or `NotInstalled` | `completed` with no `pending_restart`; connect/switch status follows identity readback, disconnect clears the binding |
 | Codex write succeeds while Desktop is Running / Ambiguous / Untrusted / Unsupported / inspect error | `completed` + `pending_restart`; fail closed                                                                         |
 | token, SecretRef, auth bytes, or raw helper output reaches DTO/log/DOM    | security regression                                                                                                  |
 | Display paths arrive outside explicit impact/recovery metadata            | security regression                                                                                                  |
@@ -270,13 +272,13 @@ CODEX_EXTERNAL_WRITE_HOT_RELOAD_PROVEN = false
 - **Good:** OpenCode replaces only the `openai` entry, preserves unknown keys,
   writes atomically with `0600`, rereads equal bytes, transfers ownership, and
   reports `pending_restart` until Desktop pickup is HIL-proven.
-- **Good:** Codex A→B swaps only `auth.json`; if the live top-level
+- **Good:** Codex A→B replaces the auth file; if the live top-level
   `model_provider` is active, official connect comments that one line and
   leaves `[model_providers.*]` intact. Disconnect or a disconnected slot with
   that line still commented uncomments the same selector. An explicit unofficial
   source change also uncomments it instead of duplicating it. When Codex
-  Desktop is not running or not installed, the overview is connected without
-  a Restart button.
+  Desktop is not running or not installed, no Restart action is needed.
+  Connect/switch and disconnect still produce different binding states.
 - **Base:** OpenCode has no `auth.json`; observation returns an empty provider
   set without requiring a CLI.
 - **Base:** Codex unset store and missing `model_provider` are effective file
@@ -305,9 +307,10 @@ Required assertions:
 - the native command validates before `spawn_blocking`, does not run the
   synchronous service on the IPC command thread, and maps blocking-task join
   failure to `invalid_response`;
-- Codex effective file defaults, auth delta plus top-level `model_provider`
-  comment/uncomment, private backup/readback/CAS, provider-table
-  preservation, and saved-not-projected status;
+- Codex effective file defaults, independent auth/selector deltas (including
+  matching-account selector-only writes), private backup/readback/CAS and
+  saved-not-projected status; selector/source preservation assertions belong
+  to [Codex Request-Source Selection](./codex-source-selection.md);
 - previews bind account/action/revision/path, expire, supersede and consume
   once; absent confirmation or changed overrides authorize zero vendor writes;
 - Grok production gates remain false and write zero vendor bytes;
@@ -348,8 +351,8 @@ Correct:
 ```text
 OpenCode selects a purpose-compatible credential under auth.json revision
 consumer-specific write -> readback -> refresh-owner transfer
-external pickup unproven AND live Codex/OpenCode process may hold old creds -> pending_restart
-Codex Desktop NotRunning/NotInstalled after write -> connected, no Restart
+Codex runtime may hold old credentials, or OpenCode runtime unobserved -> pending_restart
+Codex Desktop NotRunning/NotInstalled after write -> no Restart; reread binding state
 Codex live identity match -> connected; otherwise saved-not-projected
 official connect -> comment first top-level model_provider; keep [model_providers.*]
 disconnect / disconnected+commented -> uncomment the same selector; keep [model_providers.*]

--- a/.trellis/spec/backend/managed-auth-login.md
+++ b/.trellis/spec/backend/managed-auth-login.md
@@ -136,6 +136,11 @@ malformed or zero-version UUID.
   `device_code`.
 - Browser reopen uses the process-private official authorize URL. That URL
   never crosses IPC or enters Query/route state.
+- Initial open and reopen both call `open_http_url_as_user_sync` after the
+  shared HTTP(S) validator. The provider does not spawn `open` or
+  `cmd /c start`. Windows uses Explorer COM; macOS uses `open` with a single
+  argv so `&` in PKCE query strings is not a shell separator. Catalog
+  `open_external` uses the same validator and the same macOS `open` helper.
 
 ### xAI Device Code
 
@@ -184,6 +189,7 @@ malformed or zero-version UUID.
 | Consumer projection is unavailable                                                                 | Account storage may complete; consumer remains disconnected/unavailable            |
 | completed snapshot carries a non-null reason other than `pending_restart`                          | reject the wire shape; do not render success                                       |
 | snapshot/error/log contains URL secrets, codes, tokens, verifier, SecretRef, or HTTP body          | security regression                                                                |
+| OpenAI browser open uses `cmd /c start` or a provider-local `Command::new("open")`                 | contract regression; use `process_launch::open_http_url_as_user_sync`              |
 
 ## 5. Good / Base / Bad Cases
 
@@ -198,7 +204,8 @@ malformed or zero-version UUID.
 - **Base:** cancel succeeds while an HTTP poll is outstanding; the later grant
   is ignored because its generation is stale.
 - **Bad:** return the authorize URL to React, let React poll the token endpoint,
-  reuse a Proxy credential for Grok, or mark completion before vault readback.
+  reuse a Proxy credential for Grok, mark completion before vault readback, or
+  open the authorize URL with `cmd /c start`.
 
 ## 6. Tests Required
 
@@ -225,6 +232,8 @@ Required assertions:
 - `1455` → `1457` → Device Code fallback without process cancellation;
 - Device Code interval/expiry plus cancel/switch generation races;
 - reopen uses the process-private official URL and the snapshot has no URL;
+- browser open goes through `open_http_url_as_user_sync` on both macOS and
+  Windows; provider source must not contain `cmd /c start` or `Command::new("open")`;
 - xAI origin allowlist and pending/slow-down/deny/expiry classification;
 - `grok_native` versus `proxy_upstream` isolation;
 - SecretRef readback gates success; all `connect_consumer` login completions
@@ -259,4 +268,5 @@ credential readback -> completed account storage, no automatic consumer write
 separate connection preview + confirmation -> consumer write/readback
 cancel/switch bumps generation so late work cannot commit
 hold std::net::TcpListener across IPC; from_std only inside accept_one_callback
+open authorize URL via process_launch HTTP owner (Explorer / macOS open)
 ```

--- a/.trellis/spec/backend/task-runner-contract.md
+++ b/.trellis/spec/backend/task-runner-contract.md
@@ -345,6 +345,11 @@ Adding, removing, renaming, moving, changing, or changing the mode of a
 candidate fails until the source diff is reviewed and the identity inventory
 is deliberately updated. A digest-only update is not evidence that a platform
 dispatch remains safe.
+Review the final source bytes before updating individual digests, including
+changes that do not add a new platform branch. Recompute after formatting and
+rerun `supported-platform:check`; a previously green manifest does not cover
+later source edits. Do not bulk-refresh unreviewed entries or disable the seal
+to unblock the always-running CI Changes job.
 
 The checker and both inventories must remain runnable from a clean checkout
 using only Node built-ins. The always-running CI Changes job invokes this path

--- a/.trellis/spec/backend/window-presentation.md
+++ b/.trellis/spec/backend/window-presentation.md
@@ -31,7 +31,10 @@ The configured main WebView starts hidden. Native layout restore/clamp/listener
 installation finishes before `mark_window_prepared`. Ordinary Focus and parsed
 deep-link effects drain only after both preparation and renderer readiness, in
 either arrival order. Existing capacity, focus coalescing and non-waking
-rejection semantics remain unchanged.
+rejection semantics remain unchanged. Shell appearance restore is not a reveal
+gate: `prepare_main_webview` applies the persisted window theme and the main
+page-load start seeds the renderer cache. See
+[Blue Appearance](../frontend/appearance.md).
 
 Normal startup, tray open, Dock reopen and lightweight-mode exit use the same
 `request_main_window_focus` boundary. Only the effect owner shows/unminimizes/

--- a/.trellis/spec/backend/windows-runtime-security.md
+++ b/.trellis/spec/backend/windows-runtime-security.md
@@ -60,6 +60,10 @@ pub(crate) async fn open_http_url_as_user(
     raw_url: String,
 ) -> Result<(), String>;
 
+pub(crate) fn open_http_url_as_user_sync(
+    raw_url: &str,
+) -> Result<(), ProcessLaunchError>;
+
 #[cfg(target_os = "windows")]
 pub(crate) fn machine_program_files_directories() -> Vec<PathBuf>;
 
@@ -282,6 +286,10 @@ IShellFolderViewDual.Application -> IShellDispatch2`.
   executable, current-process browser launch, or `window.open` fallback. If the
   Explorer COM chain is unavailable, fail closed instead of launching as the
   elevated process account or broadening the renderer input.
+- Managed Auth OAuth authorize URLs use the same HTTP owner via
+  `open_http_url_as_user_sync` (login worker has no `AppHandle`). Never
+  `cmd /c start`: unquoted `&` in PKCE query strings is a cmd statement
+  separator and drops `client_id` / `code_challenge` / `state`.
 
 ## 4. Validation & Error Matrix
 
@@ -304,6 +312,7 @@ IShellFolderViewDual.Application -> IShellDispatch2`.
 | Desktop background object is requested directly as `IShellFolderViewDual`                        | Treat as a contract regression; request `IDispatch` first and cast explicitly.                                                                                               |
 | External link is accepted but browser would remain backgrounded                                  | Pass fixed `SW_SHOWNORMAL` for ordinary external links; helper show semantics remain unchanged.                                                                              |
 | Explorer COM acquisition or `ShellExecute` fails                                                 | Return controlled `INTERACTIVE_USER_UNAVAILABLE`; do not try a command, direct shell, renderer, or elevated-user fallback.                                                   |
+| OAuth authorize URL is opened with `cmd /c start`                                                | Contract regression; `&` splits the query. Use `open_http_url_as_user_sync`.                                                                                                 |
 | Closed desktop-agent `.exe` is relative, contains `..` or NUL, or is not `.exe`                  | `external_launch_invalid_windows_exe`; Explorer is not invoked.                                                                                                              |
 | Closed desktop-agent `.exe` is observer-proven under Alice Programs or machine Program Files     | Explorer `ShellExecute` as Alice; never `CreateProcess` / `ShellExecuteW` from Bob.                                                                                          |
 | Formal elevated Windows direct user-CLI execution or CLI-based Auth                              | Fail closed before probing/launching; OpenCode file observation/Desktop handoff is not a CLI exception.                                                                      |
@@ -328,6 +337,9 @@ IShellFolderViewDual.Application -> IShellDispatch2`.
 - Good: elevated FyAgent opens an HTTPS catalog link through Explorer's desktop
   automation object. The interactive user's default browser receives a normal-
   show request even when no File Explorer folder window is open.
+- Good: an OpenAI authorize URL with multiple `&`-separated query parameters
+  reaches Explorer `ShellExecute` as one HTTP(S) string through
+  `open_http_url_as_user_sync`.
 - Bad: read `%APPDATA%`, `dirs::home_dir`, Tauri `app_data_dir`, `HKCU`, process
   `PATH`, or a user-tool home variable on Windows and call it Alice's state.
 - Bad: restore `%ProgramData%\FyAgent\runtime`, treat PackageBridge as runtime
@@ -344,6 +356,10 @@ IShellFolderViewDual.Application -> IShellDispatch2`.
 - Portable Rust tests cover same-user, Bob/Alice, missing Shell/session/SID,
   noncanonical SID, each missing/non-absolute folder, immutable revalidation,
   redacted debug output, and stable error codes.
+- Process-launch tests prove an OpenAI authorize URL keeps every query
+  parameter through the shared HTTP validator, and that Managed Auth opens
+  the browser only via `open_http_url_as_user_sync` (no `cmd /c start`, no
+  provider-local `open`).
 - Contract tests assert initialization precedes panic/CLI/Tauri, the formal
   process/Shell equality gate and machine-runtime implementation are absent,
   the fixed PackageBridge is referenced only from the shared executable

--- a/.trellis/spec/frontend/agent-directory.md
+++ b/.trellis/spec/frontend/agent-directory.md
@@ -132,7 +132,10 @@ claude-code  surface=cli  sourceKind=cli_tooling
   action rather than inventing defaults.
 - One action mutation is active per current Agent view. Native
   `operation_conflict` remains authoritative if another page/window/job is
-  active.
+  active. After that conflict, keep the last requested action for Retry even
+  if a later readiness reread omits it from `allowedActions`. Generic and
+  Codex directory slots show Retry before a scanning-only status so a
+  recoverable conflict is not hidden behind 「正在扫描」.
 - A returned terminal action result is rendered immediately. A background job
   is polled through `get_agent_action_job` until its native terminal stage.
 - The renderer may stop polling when the route unmounts, but it must not paint
@@ -217,8 +220,8 @@ Do not send the user to the Models section to pick a filesystem destination.
 | Runtime value is `null`                                             | Render unknown/unverified, not absent/stopped.                                                         |
 | Inventory is `multiple`                                             | Require explicit target selection; no implicit first candidate.                                        |
 | Inventory is `unknown`/expired or target drifts                     | Refresh guidance; no action retry with stale capability.                                               |
-| Action is absent from `allowedActions`                              | Hide/disable with closed reason; do not call native.                                                   |
-| Native returns `operation_conflict`                                 | Preserve native job/other-operation state; do not create a local parallel action.                      |
+| Action is absent from `allowedActions`                              | Hide/disable with closed reason; do not call native except Retry of the last `operation_conflict` action. |
+| Native returns `operation_conflict`                                 | Preserve native job/other-operation state; keep last action for Retry; do not create a local parallel action. |
 | Background job remains active after UI poll budget                  | Stop/slow UI polling as designed, but do not mark failed.                                              |
 | Cancel is no longer permitted                                       | Disable cancel and preserve active/terminal state.                                                     |
 | Windows vendor wizard handoff succeeds but inventory remains absent | Explain handoff/completion scope; do not paint installed.                                              |
@@ -276,6 +279,8 @@ Required assertions:
   「正在检查来源」 (or later transfer copy) without waiting for job terminal;
 - allowed-actions projection, Codex owner routing, Auth/lifecycle separation and
   feature-navigation capability checks;
+- Retry remains after `operation_conflict` even when reread omits the action,
+  and directory slots show Retry before scanning-only status;
 - polling survives active native jobs without synthetic failure, transfer
   totals remain raw, and cancel respects `cancellable`;
 - success/error invalidation/reread clears stale installed/update state;

--- a/.trellis/spec/frontend/agent-directory.md
+++ b/.trellis/spec/frontend/agent-directory.md
@@ -98,6 +98,19 @@ or bypass flag.
 - Readiness and inventory are separate queries keyed by canonical Agent ID and
   optional legal surface. Runtime scan must not overwrite catalog capability
   review or synthesize installation state from configuration directories.
+- Renderer `surfacesForAgent` / readiness `sourceKind` must match
+  `lifecycle_policy.rs`. Compact CLI products currently are:
+
+```text
+grokbuild    surface=cli  sourceKind=cli_tooling
+claude-code  surface=cli  sourceKind=cli_tooling
+```
+
+  Desktop products use `surface=desktop` and `managed_desktop` except Codex
+  (`codex_desktop` plus `fyagent_managed`). Compact single-surface payloads
+  omit `surfaces`. A legal CLI `not_installed` + `install` payload must parse;
+  requiring `managed_desktop` or treating `cli` as illegal for Claude Code
+  fails the directory scan as 「读取失败」 instead of showing install.
 - Inventory states remain exact: `not_observed`, `single`, `multiple`,
   `unsupported`, `unknown`. Multiple candidates show a selection surface and
   never choose the first item automatically.
@@ -154,8 +167,11 @@ installation controls. Configuration navigation never starts an installation.
 - Claude Code is CLI-only: its Agent lifecycle actions reuse Tooling and the
   Agent job observer. Backend readiness/inventory determines install/update;
   the page does not offer Claude Desktop or infer CLI presence from an app
-  bundle. Missing Node/npm or an unconfirmed installation owner produces the
-  actionable closed reason; npm success alone is not installation proof.
+  bundle. The install-readiness parser and `surfacesForAgent` must admit
+  `cli` / `cli_tooling` like Grok Build. Install chrome must not title the
+  component 「Claude Desktop」. Missing Node/npm or an unconfirmed
+  installation owner produces the actionable closed reason; npm success
+  alone is not installation proof.
 - Grok CLI install/update stays on the Tooling owner. The Agent Grok panel
   must not send a registry, version, hash, or npm command. Default one-click
   install is official npm; official CLI is an explicit secondary control.
@@ -197,6 +213,8 @@ installation controls. Configuration navigation never starts an installation.
 | Cancel is no longer permitted                                       | Disable cancel and preserve active/terminal state.                                                     |
 | Windows vendor wizard handoff succeeds but inventory remains absent | Explain handoff/completion scope; do not paint installed.                                              |
 | Native DTO contains unknown/excess/forbidden field                  | Strict parser failure; never spread raw object into UI.                                                |
+| Claude/Grok compact CLI readiness uses `cli_tooling`                | Parse and project install/update; do not fail the directory scan.                                      |
+| Claude/Grok readiness uses `managed_desktop` or `desktop` surface   | Fail closed at the parser; do not render a Desktop install card.                                       |
 | Route changes/unmounts                                              | Clear transient selection/confirmation; do not cancel native work unless user explicitly requested it. |
 
 ## 5. Good / Base / Bad Cases
@@ -212,6 +230,11 @@ installation controls. Configuration navigation never starts an installation.
 - **Bad:** hard-code product order/actions, infer installation from settings,
   store a target ID in local storage, send a URL/path, select the first target,
   or treat a browser/app/installer handoff as verified completion.
+- **Bad:** treat Claude Code as `managed_desktop` / `desktop` in the
+  renderer parser, or label its install chrome 「Claude Desktop」. The native
+  compact payload is `sourceKind=cli_tooling` with no `surfaces` array; a
+  kind mismatch throws and the directory shows 「读取失败」 while the host
+  still reports `not_installed` plus `install`.
 
 ## 6. Tests Required
 
@@ -226,6 +249,9 @@ Required assertions:
 
 - exact seven-product catalog/version/order/capability parsing and no Pi;
 - official-link ID allowlist matches native v5 (Claude `product`, not Desktop);
+- Claude Code and Grok Build share CLI `surfacesForAgent` and `cli_tooling`
+  sourceKind; compact Claude `not_installed` + `install` parses; Claude
+  `managed_desktop` / `desktop` and CLI `launch` fail closed;
 - unknown/excess/duplicate/future/legacy catalog values fail closed;
 - runtime tri-state and every readiness/inventory/action/job enum render
   evidence-correct states;
@@ -274,6 +300,21 @@ await ports.agentInstallReadiness.startAction({
   targetId: selectedTarget?.targetId,
   expectedTargetRevision: selectedTarget?.expectedTargetRevision,
 });
+```
+
+Wrong:
+
+```ts
+surfacesForAgent("claude-code") === ["desktop"]
+parseAgentInstallReadiness requires sourceKind === "managed_desktop"
+```
+
+Correct:
+
+```ts
+surfacesForAgent("grokbuild") === ["cli"]
+surfacesForAgent("claude-code") === ["cli"]
+parseAgentInstallReadiness admits sourceKind === "cli_tooling"
 ```
 
 Native owns identity, legality and side effects; the page owns strict

--- a/.trellis/spec/frontend/agent-directory.md
+++ b/.trellis/spec/frontend/agent-directory.md
@@ -153,6 +153,16 @@ the selected Models/Skills/MCP/Prompts section and authentication handoff.
 Managed consumers show one compact status plus the central Auth entry, not
 stacked duplicate descriptions. Back returns to the existing directory and its
 installation controls. Configuration navigation never starts an installation.
+When inventory reports more than one eligible install destination, the directory
+card opens a shared `Dialog` from the 「选择安装目标」 control (origin animation
+returns to that control) and reuses `LifecycleTargetPicker` with opaque
+`targetId` values. A `locationLabel` that starts with `/Applications` shows a
+small 「推荐」 mark; confirmation still requires an explicit dialog confirm.
+Confirming a destination starts the native action and immediately dismisses the
+dialog back to the originating control so the card can show transfer progress.
+Do not keep the picker open until the job finishes, and do not unmount the
+return anchor when the slot switches to busy status.
+Do not send the user to the Models section to pick a filesystem destination.
 
 - “Open product” calls the closed native launch destination; it never sends a
   path/URL or shells out from the renderer.
@@ -213,6 +223,7 @@ installation controls. Configuration navigation never starts an installation.
 | Cancel is no longer permitted                                       | Disable cancel and preserve active/terminal state.                                                     |
 | Windows vendor wizard handoff succeeds but inventory remains absent | Explain handoff/completion scope; do not paint installed.                                              |
 | Native DTO contains unknown/excess/forbidden field                  | Strict parser failure; never spread raw object into UI.                                                |
+| Inventory is `multiple` and the user confirms a destination         | Start the native action and immediately dismiss the picker back to the originating control; the card shows job progress. Do not keep 「安装中…」 on the dialog until the job finishes. |
 | Claude/Grok compact CLI readiness uses `cli_tooling`                | Parse and project install/update; do not fail the directory scan.                                      |
 | Claude/Grok readiness uses `managed_desktop` or `desktop` surface   | Fail closed at the parser; do not render a Desktop install card.                                       |
 | Route changes/unmounts                                              | Clear transient selection/confirmation; do not cancel native work unless user explicitly requested it. |
@@ -220,7 +231,9 @@ installation controls. Configuration navigation never starts an installation.
 ## 5. Good / Base / Bad Cases
 
 - **Good:** catalog v5 drives the seven cards; inventory reports two apps; the
-  user selects one opaque target; native revalidates and launches it.
+  user confirms a destination in the directory picker; the dialog returns to
+  the originating control and the card shows transfer progress while the job
+  runs.
 - **Good:** a job has unknown total bytes; the UI shows stage and completed
   bytes without fabricated percentage.
 - **Base:** a Windows vendor installer was opened. The UI reports vendor handoff
@@ -257,6 +270,10 @@ Required assertions:
   evidence-correct states;
 - multiple target selection, opaque capability forwarding, expiry/drift refresh
   and no path/URL/command fields;
+- directory 「选择安装目标」 opens a Dialog picker instead of navigating to
+  configuration; `/Applications` labels render 「推荐」; confirming a
+  destination dismisses that dialog immediately and the card shows
+  「正在检查来源」 (or later transfer copy) without waiting for job terminal;
 - allowed-actions projection, Codex owner routing, Auth/lifecycle separation and
   feature-navigation capability checks;
 - polling survives active native jobs without synthetic failure, transfer
@@ -319,3 +336,19 @@ parseAgentInstallReadiness admits sourceKind === "cli_tooling"
 
 Native owns identity, legality and side effects; the page owns strict
 projection, explicit user selection and evidence-correct wording.
+
+Wrong:
+
+```tsx
+void lifecycle.run(action, selectedTarget).then(() => setPickingTarget(null));
+if (lifecycle.busy) return { kind: "status", label };
+```
+
+Correct:
+
+```tsx
+setPickingTarget(null);
+void lifecycle.run(action, selectedTarget);
+// AgentLifecycleActionSlot keeps a connected host for dialogReturnRef
+// while the inner control swaps from 「选择安装目标」 to busy status.
+```

--- a/.trellis/spec/frontend/appearance.md
+++ b/.trellis/spec/frontend/appearance.md
@@ -21,10 +21,10 @@ synchronizeWindowTheme(theme: ThemePreference): Promise<void>;
 ```rust
 // settings.json field appearanceTheme: "light" | "dark" | "system"
 parse_appearance_theme(value: &str) -> Option<&'static str>
-persist_appearance_theme(theme: &str)
+persist_appearance_theme(theme: &str) -> ()
 appearance_theme_preference() -> Option<String>
 appearance_bootstrap_script() -> Option<String>
-set_window_theme({ theme: String }) // existing command; persists then applies chrome
+async set_window_theme(window: tauri::Window, theme: String) -> Result<(), String>
 ```
 
 `shared/design-system/appearance.ts` validates and applies the preference;
@@ -38,6 +38,9 @@ Device restart authority is `~/.fyagent/settings.json` `appearanceTheme`, writte
 only by `persist_appearance_theme`. Renderer `localStorage["fyagent-theme"]` is a
 synchronous cache. `save_settings` snapshots must keep the existing appearance
 field; they are not an appearance writer.
+The native owners are `src-tauri/src/settings.rs`,
+`src-tauri/src/commands/{settings,system}.rs` and the startup wiring in
+`src-tauri/src/lib.rs`.
 
 ## 3. Contracts
 
@@ -48,6 +51,14 @@ field; they are not an appearance writer.
 - On toggle the visible commit writes the renderer cache; native persist and
   chrome IPC stay outside the View Transition snapshot, through the existing
   coalesced `set_window_theme` path. Invalid values are not persisted.
+- Native normalization trims whitespace but accepts only lowercase
+  `light`/`dark`/`system`. Persistence is best-effort: the helper logs a write
+  failure and returns `()`, then the command still attempts window chrome.
+  Command success therefore proves the chrome call, not durable persistence;
+  a failed disk write does not guarantee the new preference survives relaunch.
+  Invalid command input is not saved, but currently selects native system
+  chrome (`None`) rather than returning a validation error. Renderer callers
+  must continue to send only the closed preference set.
 - Process restart restores native window chrome in `prepare_main_webview` from
   the device field, then seeds the renderer cache/`data-theme` on main
   `PageLoadEvent::Started` from the live field. `initializeAppearance` and the
@@ -96,8 +107,10 @@ field; they are not an appearance writer.
 | Arbitrary stored value or denied store                    | Light fallback; controls stay usable.                           |
 | Existing system preference changes                        | Update effective theme, preserve system preference.             |
 | Explicit theme selected                                   | Store the closed choice; stop following system changes.         |
-| Software relaunch after an explicit choice                | Restore that closed preference; do not fall back to light.      |
+| Software relaunch after a successfully persisted choice   | Restore that closed preference; do not replace it with the default. |
 | `save_settings` payload includes a different theme        | Keep the device appearance field; do not clobber it.            |
+| Native input is padded lowercase / unknown or uppercase  | Normalize the valid choice; invalid values leave persistence unchanged and use system chrome. |
+| Disk persistence fails but native chrome succeeds        | UI stays usable; IPC may resolve successfully; durable restart preference is not proven. |
 | Capture throws/rejects or pseudo animation is unavailable | Commit latest choice; release handles/markers.                  |
 | Rapid opposite clicks                                     | Latest intent wins, no queued full-screen transitions.          |
 | Resize/background/live reduced motion                     | Settle; no stuck clip or hit-test lock.                         |
@@ -124,7 +137,9 @@ clip origins and the shared reveal easing. `motionDuration.test.ts` keeps
 cache. `useAppearance.test.tsx` covers system/storage, mount restore and
 subscriptions. Platform tests retain exact IPC and coalescing; the ACL gate
 scans every literal native command. Native tests cover the closed preference
-parser, bootstrap script and `save_settings` merge preservation.
+parser, bootstrap script and `save_settings` merge preservation. These tests
+do not perform a packaged-app relaunch or inject a settings-file write failure;
+do not cite them as evidence of durable persistence under failed I/O.
 
 `blue-themes.spec.ts` covers real pointer/keyboard, drafts, persistence,
 interruption and dark composite text on all seven pages. Existing material tests

--- a/.trellis/spec/frontend/appearance.md
+++ b/.trellis/spec/frontend/appearance.md
@@ -18,6 +18,15 @@ useAppearance(): { theme: Theme; toggle(source: HTMLElement, origin?: {x: number
 synchronizeWindowTheme(theme: ThemePreference): Promise<void>;
 ```
 
+```rust
+// settings.json field appearanceTheme: "light" | "dark" | "system"
+parse_appearance_theme(value: &str) -> Option<&'static str>
+persist_appearance_theme(theme: &str)
+appearance_theme_preference() -> Option<String>
+appearance_bootstrap_script() -> Option<String>
+set_window_theme({ theme: String }) // existing command; persists then applies chrome
+```
+
 `shared/design-system/appearance.ts` validates and applies the preference;
 `shared/features/useAppearance.ts` is its single mounted shell owner.
 `widgets/app-shell/ThemeToggle.tsx` composes Button and existing icons outside
@@ -25,14 +34,27 @@ native drag regions. `shared/ui/ThemeReveal.ts` owns only the ephemeral browser
 transition. `shared/platform/tauri/theme.ts` invokes the existing native
 `set_window_theme` command with `{ theme }`; no new native API/permission is added.
 
+Device restart authority is `~/.fyagent/settings.json` `appearanceTheme`, written
+only by `persist_appearance_theme`. Renderer `localStorage["fyagent-theme"]` is a
+synchronous cache. `save_settings` snapshots must keep the existing appearance
+field; they are not an appearance writer.
+
 ## 3. Contracts
 
 - Existing `light`/`dark` are respected; `system` remains live system-following
   until explicit user selection. Missing/invalid/denied storage uses light.
   Preference failures never block startup or a visible switch. Do not add a
   second settings file or store resource/credential data in appearance state.
+- On toggle the visible commit writes the renderer cache; native persist and
+  chrome IPC stay outside the View Transition snapshot, through the existing
+  coalesced `set_window_theme` path. Invalid values are not persisted.
+- Process restart restores native window chrome in `prepare_main_webview` from
+  the device field, then seeds the renderer cache/`data-theme` on main
+  `PageLoadEvent::Started` from the live field. `initializeAppearance` and the
+  shell owner re-read the cache; they do not wait on theme IPC. Native window
+  reveal still belongs to content readiness.
 - Initial root `data-theme` is applied before route loading, including startup
-  errors. Native window reveal still belongs to content readiness, not theme IPC.
+  errors.
 - Both palettes are blue: clear light blue and medium-depth mist/steel blue,
   not black. Roles cover text, status, input, hover, focus, selected, material,
   rim and scrim. Primary button ink and filled background are paired.
@@ -64,25 +86,33 @@ transition. `shared/platform/tauri/theme.ts` invokes the existing native
 | Arbitrary stored value or denied store                    | Light fallback; controls stay usable.                           |
 | Existing system preference changes                        | Update effective theme, preserve system preference.             |
 | Explicit theme selected                                   | Store the closed choice; stop following system changes.         |
+| Software relaunch after an explicit choice                | Restore that closed preference; do not fall back to light.      |
+| `save_settings` payload includes a different theme        | Keep the device appearance field; do not clobber it.            |
 | Capture throws/rejects or pseudo animation is unavailable | Commit latest choice; release handles/markers.                  |
 | Rapid opposite clicks                                     | Latest intent wins, no queued full-screen transitions.          |
 | Resize/background/live reduced motion                     | Settle; no stuck clip or hit-test lock.                         |
 | External storage during capture                           | Cancel stale local commit without overwriting external storage. |
 | Modal exists                                              | No root reveal prolonging sensitive content presentation.       |
-| Native theme command fails                                | Keep CSS/UI usable; no query/startup failure.                   |
+| Native theme command or persist fails                     | Keep CSS/UI usable; no query/startup failure.                   |
 
 ## 5. Good / Base / Bad Cases
 
 Good: update semantic tokens and validate real selected/hovered composites in
-both engines. Base: a WebView lacks View Transitions; the same button switches
-directly. Bad: invert the application, copy account DOM to canvas, import another
-theme framework, or wait for IPC inside capture.
+both engines; relaunch restores the last closed preference from the device
+field. Base: a WebView lacks View Transitions; the same button switches
+directly; browser fixtures keep using the renderer cache. Bad: invert the
+application, copy account DOM to canvas, import another theme framework, wait
+for IPC inside capture, or treat WebView `localStorage` as the only restart
+authority.
 
 ## 6. Tests Required
 
 `ThemeReveal.test.ts` covers request identity, failures, timing and origins.
-`useAppearance.test.tsx` covers system/storage and subscriptions. Platform tests
-retain exact IPC and coalescing; the ACL gate scans every literal native command.
+`tests/renderer/app/appearance.test.ts` covers startup restore from the renderer
+cache. `useAppearance.test.tsx` covers system/storage, mount restore and
+subscriptions. Platform tests retain exact IPC and coalescing; the ACL gate
+scans every literal native command. Native tests cover the closed preference
+parser, bootstrap script and `save_settings` merge preservation.
 
 `blue-themes.spec.ts` covers real pointer/keyboard, drafts, persistence,
 interruption and dark composite text on all seven pages. Existing material tests
@@ -100,7 +130,9 @@ Report each run, middle-third measurements and native/GPU limitations.
 
 ## 7. Wrong vs Correct
 
-Wrong: commit theme context for every page, start competing color transitions
-and native queries, then check only the final theme. Correct: apply closed root
-tokens, keep the browser views stable, reject superseded callbacks and separately
-verify preparation, each reveal third and final cleanup.
+Wrong: keep the preference only in WebView `localStorage`, then treat a missing
+cache on relaunch as a new light default. Correct: persist the closed choice
+through the existing `set_window_theme` owner into `appearanceTheme`, restore
+chrome before reveal, seed the renderer cache from the live field, and apply
+closed root tokens without competing color transitions or theme IPC inside
+capture.

--- a/.trellis/spec/frontend/appearance.md
+++ b/.trellis/spec/frontend/appearance.md
@@ -62,11 +62,21 @@ field; they are not an appearance writer.
   update together via root CSS variables. No route reconstruction/query
   invalidation, page-wide React theme context or global color interpolation.
 - A user reveal uses one native View Transition and one WAAPI circle on
-  `::view-transition-new(root)`. Pointer uses exact viewport coordinates;
-  keyboard uses the current trigger center. Radius covers the farthest corner.
-  CSS owns `--fy-motion-theme` (560ms); reuse the unit-aware parser and spatial
-  curve. Suppress competing CSS transitions throughout capture and reveal,
-  not only until the update callback resolves.
+  `::view-transition-new(root)`. `shared/ui/ThemeReveal.ts` is the only owner;
+  Mac and Windows share that path. Pointer uses exact viewport coordinates;
+  keyboard uses the current trigger center. Radius covers the farthest corner
+  of the reference box, with padding for subpixel snapshot height. Clip
+  geometry is a percentage `circle()` of that box. CSS owns `--fy-motion-theme`
+  (560ms) and `--fy-motion-theme-ease`; JS reads the duration through the
+  unit-aware parser and uses the matching `fyThemeRevealEasing` curve. Do not
+  reuse `fySpatialEasing` here: that front-loaded curve spends most of the
+  duration on the last slice of radius and reads as a stuck far corner.
+  Active reveal layers keep `transform: none` and `transform-origin: 0 0` so a
+  centered view-transition origin cannot shift the circle off the trigger. A
+  finished reveal skips the view transition before cancelling its clip
+  animation so the next toggle cannot inherit a full-circle mask. Suppress
+  competing CSS transitions throughout capture and reveal, not only until the
+  update callback resolves.
 - New requests cancel old presentation. Old update/ready/finished callbacks
   cannot commit or clear the new one. Resize, hidden document and live reduced
   motion/forced colors settle the latest intent. External storage supersedes
@@ -107,7 +117,9 @@ authority.
 
 ## 6. Tests Required
 
-`ThemeReveal.test.ts` covers request identity, failures, timing and origins.
+`ThemeReveal.test.ts` covers request identity, failures, timing, percentage
+clip origins and the shared reveal easing. `motionDuration.test.ts` keeps
+`--fy-motion-theme-ease` aligned with `fyThemeRevealEasing`.
 `tests/renderer/app/appearance.test.ts` covers startup restore from the renderer
 cache. `useAppearance.test.tsx` covers system/storage, mount restore and
 subscriptions. Platform tests retain exact IPC and coalescing; the ACL gate
@@ -136,3 +148,9 @@ through the existing `set_window_theme` owner into `appearanceTheme`, restore
 chrome before reveal, seed the renderer cache from the live field, and apply
 closed root tokens without competing color transitions or theme IPC inside
 capture.
+
+Wrong: scale clip coordinates by `devicePixelRatio`, leave a `fill: both`
+circle after the transition, or branch Mac/Windows playback. Correct: keep
+one `ThemeReveal` path, percentage clip on the CSS-pixel reference box, skip
+then cancel leftover `::view-transition-new(root)` animations, and use
+`fyThemeRevealEasing` on every platform.

--- a/.trellis/spec/frontend/dialog-lifecycle.md
+++ b/.trellis/spec/frontend/dialog-lifecycle.md
@@ -69,6 +69,12 @@ duration parser; WAAPI accepts milliseconds only at this presentation boundary.
   Revalidate captured finite geometry against the current viewport at consumption:
   an async picker/preview can outlive a resize, so old snapshot admission is not
   permanent permission to fly outside the visible window.
+- Directory install-target pickers stay mounted with `open={pickingTarget !== null}`.
+  Confirm starts the native job and sets open false in the same click; do not
+  wait for `run()` to settle. `dialogReturnRef` must point at a host that remains
+  connected while the slot swaps from the trigger button to busy status. Putting
+  the return ref on the button that unmounts on busy yields a disconnected
+  source and a neutral fade, which hides the card progress the user needs.
 - Switch uses the existing PressableButton asChild capture before Radix's
   checked-change handler. A modal-producing switch opts into bounded click
   geometry with its own element as the return anchor: async status feedback can
@@ -207,6 +213,7 @@ duration parser; WAAPI accepts milliseconds only at this presentation boundary.
 | ----------------------------------------------------- | --------------------------------------------------------------------------------- |
 | Source control opens a dialog after async work        | Use that explicit original source, not whichever element is now focused.          |
 | Source moved, vanished or scrolled out before close   | Re-measure; return to the current valid box or use neutral exit.                  |
+| Confirm starts work that replaces the trigger with status | Keep a connected `dialogReturnRef` host; fly back to that host, not a fade.   |
 | Close occurs while entering                           | Freeze current geometry, revoke interaction/secrets and finish one exit.          |
 | Explicit non-credential fade exit                     | Inert/aria-hidden body retires within 80ms; action DOM disappears immediately.    |
 | CSS optimizer emits seconds instead of milliseconds   | Preserve physical duration; production timing test must still see 420ms.          |

--- a/.trellis/spec/frontend/dialog-lifecycle.md
+++ b/.trellis/spec/frontend/dialog-lifecycle.md
@@ -66,6 +66,9 @@ duration parser; WAAPI accepts milliseconds only at this presentation boundary.
   are retained. No DOM clone, text, identity label, credential value or image is
   copied. The first matching opening consumes the capture once. Exits remeasure
   the real source or explicit return target; invalid targets remain neutral.
+  Resolve that target before both animation and immediate-settlement branches;
+  `data-motion-origin` describes the same admitted target in each branch, not
+  a detached menu item. A sourced marker alone does not prove motion occurred.
   Revalidate captured finite geometry against the current viewport at consumption:
   an async picker/preview can outlive a resize, so old snapshot admission is not
   permanent permission to fly outside the visible window.
@@ -222,6 +225,7 @@ duration parser; WAAPI accepts milliseconds only at this presentation boundary.
 | System reduced-motion changes during travel           | Settle current visuals and release any completed exit.                            |
 | Portal commits after parent mount                     | Committed node starts the animation; no silent skipped entrance.                  |
 | Zero-duration exit                                    | Complete after presence bookkeeping; do not leave a focus/scroll lock.            |
+| Transient source disappeared but explicit return target remains visible | Resolve that target before immediate settlement as well as animation; hidden/removed targets remain neutral. |
 | Right click, secondary touch, disabled/hidden control | No duplicate action or new press admission.                                       |
 | Another modal opens during old focus return           | Never focus outside the newer modal.                                              |
 | Navigation occurs during a transition                 | Preserve URL/selection authority and hidden-route query isolation.                |
@@ -249,6 +253,9 @@ the actual business action.
   isolation, both WorkBuddy assignment paths and transient-menu return/focus in
   Chromium/WebKit. Cover chained confirmation handoff as well as persistent
   buttons. The production wrapper inventory must remain nonempty and complete.
+  Record short-lived exit origin evidence in-page before dismissal; remote
+  polling after Escape can miss the entire exit. Keep exact source, actual
+  cleanup and focus assertions; never extend production duration for a test.
 - `dialogPresentation.test.ts` verifies viewport-coordinate rebasing, remaining
   duration, same-track ownership and cancellation. Dialog tests verify a
   never-opened sibling cannot hold the outer presence barrier, and an old close
@@ -261,6 +268,9 @@ the actual business action.
   programmatic neutral fallback and unchanged blocked navigation.
 - Dialog tests retain third-round keyboard/focus safeguards and zero-duration
   unmount. Tests must verify actual modal/scroll cleanup, not only callbacks.
+  `Dialog.test.tsx` also records immediate exit origins after a transient source
+  disappears: visible return target remains sourced; hidden/removed targets
+  remain neutral, and all three cases release the modal lock.
 - `motionDuration.test.ts` covers ms/s/exponents and invalid input;
   `dialogPresentation.test.ts` checks track endpoints, no content/resource
   copying, cancellation, partial-start failures and the 80ms exit cap.

--- a/.trellis/spec/frontend/managed-auth.md
+++ b/.trellis/spec/frontend/managed-auth.md
@@ -161,9 +161,10 @@ cache, and terminal-delivery rules are owned by
 - The selected source's native `writeTargets` are frozen with the preview and
   displayed before applying. A generated model catalog is a separate disclosed
   file. Official account connect/switch comments only the top-level
-  `model_provider` selector; unofficial source selection uncomments that
-  same line or patches source-owned fields. Source selection does not
-  replace the official account's auth file.
+  `model_provider` selector in config, independently of its auth-file delta.
+  Saved source selection can also patch source-owned model/provider fields,
+  but never replaces the official account's auth file. The exact ownership
+  split is in [Codex Request-Source Selection](../backend/codex-source-selection.md).
 
 Required regressions: `tests/renderer/pages/auth/CodexRequestSource.test.tsx` covers
 one apply, both readbacks, failure/retry without rewriting, unknown admission,
@@ -310,6 +311,7 @@ listed in
 | Completed login/mutation has another non-null reason                                                                  | Reject the response as invalid managed-auth data.                                                                                                       |
 | Account removal preview fails                                                                                         | Do not expose the destructive confirmation.                                                                                                             |
 | Connection needs restart                                                                                              | Show saved/pending-restart separately; do not say the consumer is already using it.                                                                     |
+| Codex mutation completes with no pending restart                                                                      | Render the returned binding state; no Restart action does not itself mean connected, especially after disconnect.                                      |
 | Managed Agent summary is clicked                                                                                      | Navigate to `/auth?consumer=<closed-id>`; do not start the old Agent Auth session.                                                                      |
 | Access/refresh token, OAuth authorization code, PKCE verifier, raw state/command or unapproved path escapes its owner | Security regression; allowlisted device `userCode`/verification URI and parsed file-impact display metadata are intentional, not credentials to replay. |
 
@@ -372,6 +374,10 @@ Required assertions include:
   `connect_consumer` login with no `accountId`;
 - a connection `targetId` of `null` does not render “未检测到可管理的安装实例”;
 - ConnectionActionDialog stays mounted with `open={connection && action}`;
+  its account selection resets only when connection/action/preferred-account
+  scope changes, without a state-setting layout effect or remounting Dialog.
+  `MutationDialogs.test.tsx` covers reopen selection, same-tick double confirm,
+  consumed-preview rejection across reopen and a fresh-preview retry;
   the auth page does not wrap it in `{connectionAction && …}`; pending footer
   copy does not overlap 「取消」;
 - a disconnected Codex slot that advertises `disconnect` is labeled

--- a/.trellis/spec/frontend/managed-auth.md
+++ b/.trellis/spec/frontend/managed-auth.md
@@ -114,13 +114,18 @@ request mode is a third-party API.
   connection count. Quota/profile availability does not redefine login health
   or reorder accounts by short-lived usage.
 - Account detail lists already-linked software and matching unlinked software
-  for the same provider. Linked cards expose the closed connection actions
-  that change the bound account (`switch_account`). `switch_to_official` is a
-  retained wire value, not a currently advertised account mutation. Unlinked
-  matching slots expose `connect_account` when the backend advertises it. A
-  ready account may also start a `connect_consumer` login for a matching
-  consumer that is not yet connectable from the saved credential purpose. The
-  page does not auto-connect on login and does not install software.
+  for the same provider. Linked means live-connected (`accountId` matches and
+  `authStatus` is not `disconnected`). A saved-not-projected Codex slot that
+  already names this account still belongs in the connectable list and still
+  exposes `connect_account` / `switch_account` when the backend advertises
+  them. If that slot also advertises `disconnect` while still disconnected, the
+  account page labels it 「恢复第三方模型来源」: it restores the unofficial
+  top-level selector without connecting official login. Linked cards expose the
+  closed connection actions that change the bound account (`switch_account`).
+  `switch_to_official` is a retained wire value, not a currently advertised
+  account mutation. A ready account may also start a `connect_consumer` login
+  for a matching consumer that is not yet connectable from the saved credential
+  purpose. The page does not auto-connect on login and does not install software.
 - Connection rows show the connected official account/provider slot, current
   request source, whether an official session is preserved, credential-renewal
   owner as user-facing copy, pending restart and closed available actions.
@@ -155,8 +160,10 @@ cache, and terminal-delivery rules are owned by
   does not accept an arbitrary return URL, secret or path.
 - The selected source's native `writeTargets` are frozen with the preview and
   displayed before applying. A generated model catalog is a separate disclosed
-  file. Account selection does not rewrite this config, and source selection
-  does not replace the official account's auth file.
+  file. Official account connect/switch comments only the top-level
+  `model_provider` selector; unofficial source selection uncomments that
+  same line or patches source-owned fields. Source selection does not
+  replace the official account's auth file.
 
 Required regressions: `tests/renderer/pages/auth/CodexRequestSource.test.tsx` covers
 one apply, both readbacks, failure/retry without rewriting, unknown admission,
@@ -274,7 +281,10 @@ listed in
   focus after the backing exits. Do not abruptly `return null` from an
   unprotected login wrapper or add another focus
   owner. Pass the actual action's origin ref before asynchronous work; see
-  [Dialog Lifecycle](./dialog-lifecycle.md).
+  [Dialog Lifecycle](./dialog-lifecycle.md). Connection-action confirmations stay
+  mounted with `open={connection !== null && action !== null}`; the page must
+  not wrap them in `{action && <ConnectionActionDialog>}`. Pending footer copy
+  uses isolated nowrap buttons; see [Motion](./motion-system.md).
 - Copy says what is complete, pending or unknown and gives one safe next step.
   It must not claim login, connection or request routing beyond backend
   readback evidence.
@@ -357,9 +367,15 @@ Required assertions include:
   `pending_restart`, reject every other completed/non-null reason, and keep
   pending restart distinct from generic retry;
 - account detail lists matching unlinked slots and exposes connect/switch from
-  that page; purpose-mismatch Codex slots start `connect_consumer` login with
-  no `accountId`;
+  that page, including a saved-only Codex card that already names this
+  account (“用此账号连接”); purpose-mismatch Codex slots start
+  `connect_consumer` login with no `accountId`;
 - a connection `targetId` of `null` does not render “未检测到可管理的安装实例”;
+- ConnectionActionDialog stays mounted with `open={connection && action}`;
+  the auth page does not wrap it in `{connectionAction && …}`; pending footer
+  copy does not overlap 「取消」;
+- a disconnected Codex slot that advertises `disconnect` is labeled
+  「恢复第三方模型来源」;
 - managed Agent cards navigate to the central page while Claude and desktop
   handoff retain their existing owner;
 - current renderer code has no retired Provider OAuth or Settings account

--- a/.trellis/spec/frontend/motion-system.md
+++ b/.trellis/spec/frontend/motion-system.md
@@ -43,6 +43,14 @@ delay. Do not mix stiffness/damping/mass with duration/bounce in one spring.
 - One `usePressFeedback` registration per host uses live disabled/hidden/reduced
   admission refs and cancels its effects on cleanup. A fast click must visibly
   dip/recover, not only a long hold. Scale must not change layout or neighbours.
+  When the same control becomes `disabled` mid-press, snap `scale` to `1`
+  immediately and stop the recovery spring. Do not let `fyPressRecovery` keep
+  animating a disabled dialog action.
+- Dialog footers (`.fy-control-dialog-actions`) keep buttons on one nowrap row
+  with isolated compositing. Pending label changes must not run opacity or
+  transform CSS transitions on those buttons; disabled footer controls force
+  `transform: none`. Visual overlap of 「取消」 and 「正在处理…」 is a
+  regression even when the DOM boxes do not intersect.
 - Positioned or measured hosts use `pressVisualRef` for the existing inner
   visual. Secret/search controls preserve centering; selection hosts preserve
   lens geometry. Feature buttons reuse PressableButton, not copied gestures.
@@ -74,6 +82,7 @@ delay. Do not mix stiffness/damping/mass with duration/bounce in one spring.
 | ------------------------------------------- | --------------------------------------------------------------- |
 | Optimizer changes `420ms` to `.42s`         | Same physical duration, tested in production assets.            |
 | Disabled/hidden/right-click/secondary touch | No new press admission or duplicate action.                     |
+| A pressed control becomes disabled          | Scale snaps to 1; no lingering recovery spring or transform.    |
 | Positioned control is pressed               | Only its visual scales; centering and neighbours remain stable. |
 | One control unmounts                        | Other style subscriptions still update.                         |
 | Live preference changes mid-motion          | Settle promptly, preserve action semantics and cleanup.         |
@@ -95,7 +104,9 @@ curves; production timing checks preserve optimized 420ms entry/360ms exit.
 `pressIsolation.test.tsx` uses two real style subscriptions. Browser press tests
 sample fractional bounding boxes for quick pointer/Enter/Space/touch, clipping,
 disabled/hidden state, adjacent geometry and live preferences. Integer
-offsetWidth cannot measure a sub-percent rebound budget.
+offsetWidth cannot measure a sub-percent rebound budget. Dialog footer pending
+copy (`正在处理…`) must keep cancel and confirm as separate non-overlapping
+controls without opacity/transform transitions.
 
 `state-motion.spec.ts` proves declarative disclosure and lens revisit versus
 actual selection travel. Dialog tests and 320ms same-session resize belong to

--- a/.trellis/spec/frontend/motion-system.md
+++ b/.trellis/spec/frontend/motion-system.md
@@ -27,7 +27,9 @@ ToastViewport({ messages: readonly ToastMessage[] })
 ```
 
 `fySpatialEasing` derives a native CSS curve from the shared `.32,.72,0,1`
-tuple; the CSS easing token must match. CSS owns duration tokens. The parser
+tuple; the CSS easing token must match. Root theme reveal uses
+`fyThemeRevealEasing` / `--fy-motion-theme-ease` instead: a full-window radius
+must not reuse the spatial curve. CSS owns duration tokens. The parser
 accepts one finite, nonnegative `ms` or `s` value and returns seconds; native
 WAAPI converts to milliseconds at its adapter, exactly once. Unitless,
 compound, negative, nonfinite or missing values mean no travel, not a guessed
@@ -87,8 +89,9 @@ route CPU work, duplicate click handling or scale the whole credential form.
 
 ## 6. Tests Required
 
-`motionDuration.test.ts` covers both units, exponents and invalid values;
-production timing checks preserve optimized 420ms entry/360ms exit.
+`motionDuration.test.ts` covers both units, exponents and invalid values,
+and keeps `--fy-motion-ease` / `--fy-motion-theme-ease` aligned with the JS
+curves; production timing checks preserve optimized 420ms entry/360ms exit.
 `pressIsolation.test.tsx` uses two real style subscriptions. Browser press tests
 sample fractional bounding boxes for quick pointer/Enter/Space/touch, clipping,
 disabled/hidden state, adjacent geometry and live preferences. Integer

--- a/.trellis/spec/frontend/surfaces-responsive.md
+++ b/.trellis/spec/frontend/surfaces-responsive.md
@@ -124,9 +124,13 @@ CSS consumes the blur/rim/sheen tokens directly, including preference changes.
   third column. `align-items:start` preserves natural short-card height.
   Metadata uses `fit-content(var(--fy-definition-label-cap)) minmax(0,1fr)`;
   the shared label cap is `min(30%,8em)`, with `--fy-definition-gap` between
-  name and value. The `fy-info-card` content container stacks definitions at
-  210px or less. Existing Auth 500px and form-specific floors retain their roles.
-  Copy-only paths remain copy-only; do not reveal hidden data to fill space.
+  name and value. Caption-level definition rows span the card: values sit on
+  the trailing edge, and a faint `--fy-divider` hairline separates text rows.
+  Copy-only path rows keep horizontal label/action alignment, pin the copy
+  control to the trailing edge, and omit the hairline. Copy-only paths remain
+  copy-only; do not reveal hidden data to fill space. The `fy-info-card`
+  content container stacks definitions at 210px or less. Existing Auth 500px
+  and form-specific floors retain their roles.
 - Flexible text/actions need `min-width:0`, bounded width, wrapping and
   `overflow-wrap:anywhere` where URLs/identities can be long. Editable code and
   path/list previews may have explicit local scrolling/ellipsis; do not add

--- a/.trellis/spec/frontend/type-safety.md
+++ b/.trellis/spec/frontend/type-safety.md
@@ -51,6 +51,14 @@ Use `import type` for types, meaningful discriminated unions for variants and
 runtime narrowing for dynamic objects. A type assertion is not validation.
 No broad `any`, `ts-ignore` or weakened compiler settings to make migration pass.
 
+Use the concrete DOM type for a mounted host ref, such as
+`useRef<HTMLDivElement>(null)` in `AgentLifecycleActionSlot`. The installed
+React type definitions already make `RefObject<T>.current` nullable; shared
+return-anchor props use `RefObject<HTMLElement>`, not an extra nullable generic
+or a cast from a generic element onto a div. Browser test attributes also need
+an explicit null guard before crossing `page.evaluate`; an assertion that does
+not narrow the type is not a substitute.
+
 ## 4. Validation & Error Matrix
 
 | Condition                                          | Required result                                                                 |

--- a/.trellis/spec/guides/cross-layer-thinking-guide.md
+++ b/.trellis/spec/guides/cross-layer-thinking-guide.md
@@ -81,6 +81,13 @@ semantics. Do not put those details into this guide.
   writes stay `authorization_required` while
   `macos_system_commit::production_enabled()` is false. Helper code may exist
   without claiming a delivered system one-click.
+- When changing Agent legal surfaces or `sourceKind`, update
+  `lifecycle_policy.rs` and renderer `surfacesForAgent` /
+  `parseAgentInstallReadiness` together. Claude Code is CLI/`cli_tooling`
+  like Grok Build; a kind mismatch fails the directory scan as 「读取失败」
+  instead of `not_installed`. See
+  [Agent Directory](../frontend/agent-directory.md) and
+  [Claude Code CLI](../backend/claude-code-cli.md).
 - Before claiming a Windows desktop product is installed or missing: freeze
   the installed current-user relative and Uninstall DisplayName matching, not
   only the downloaded installer stub. KnownPath Missing is dropped. See

--- a/.trellis/spec/guides/cross-layer-thinking-guide.md
+++ b/.trellis/spec/guides/cross-layer-thinking-guide.md
@@ -64,9 +64,8 @@ semantics. Do not put those details into this guide.
 - Verify failed/partial writes do not leave optimistic renderer state.
 - Verify event listeners, queries, probes, jobs, and secrets have bounded
   lifecycle cleanup.
-- For shell appearance, persist the closed preference through the existing
-  `set_window_theme` owner; do not add a second settings file or treat WebView
-  `localStorage` as the restart authority. See
+- For shell appearance, distinguish the renderer cache, durable preference and
+  native chrome result, including failure/relaunch evidence; see
   [Blue Appearance](../frontend/appearance.md).
 - Verify browser fixtures remain non-authoritative and native evidence is not
   inferred from portable tests.
@@ -79,19 +78,17 @@ semantics. Do not put those details into this guide.
   [External Agent Catalog and Runtime](../backend/external-agent-catalog-runtime.md).
 - Verify version/path/history facts come from their owning configuration,
   provenance ledger, or Git history rather than a parallel guide matrix.
-- For Agent install/update/launch: consult the lifecycle policy owner rather
-  than a page-local product list; job snapshots are contract v4 with optional
-  `transfer`; do not invent percent in the page. System `/Applications`
-  writes stay `authorization_required` while
-  `macos_system_commit::production_enabled()` is false. Helper code may exist
-  without claiming a delivered system one-click.
-- When changing Agent legal surfaces or `sourceKind`, update
-  `lifecycle_policy.rs` and renderer `surfacesForAgent` /
-  `parseAgentInstallReadiness` together. Claude Code is CLI/`cli_tooling`
-  like Grok Build; a kind mismatch fails the directory scan as 「读取失败」
-  instead of `not_installed`. See
+- For Agent install/update/launch, check native capability, progress and
+  authorization evidence rather than deriving them in the page; see
+  [External Agent Lifecycle](../backend/external-agent-lifecycle.md).
+- When changing legal surfaces or source kinds, verify the native policy and
+  strict renderer parser admit the same payloads; see
   [Agent Directory](../frontend/agent-directory.md) and
   [Claude Code CLI](../backend/claude-code-cli.md).
+- For account or request-source switching, separate credential changes,
+  configuration changes and live-process pickup; see
+  [Codex Request-Source Selection](../backend/codex-source-selection.md) and
+  [Managed Auth Consumers](../backend/managed-auth-consumers.md).
 - Before claiming a Windows desktop product is installed or missing: freeze
   the installed current-user relative and Uninstall DisplayName matching, not
   only the downloaded installer stub. KnownPath Missing is dropped. See

--- a/.trellis/spec/guides/cross-layer-thinking-guide.md
+++ b/.trellis/spec/guides/cross-layer-thinking-guide.md
@@ -64,6 +64,10 @@ semantics. Do not put those details into this guide.
 - Verify failed/partial writes do not leave optimistic renderer state.
 - Verify event listeners, queries, probes, jobs, and secrets have bounded
   lifecycle cleanup.
+- For shell appearance, persist the closed preference through the existing
+  `set_window_theme` owner; do not add a second settings file or treat WebView
+  `localStorage` as the restart authority. See
+  [Blue Appearance](../frontend/appearance.md).
 - Verify browser fixtures remain non-authoritative and native evidence is not
   inferred from portable tests.
 - If a renderer query gates native window reveal, confirm it can settle while

--- a/.trellis/workspace/pythonrust/index.md
+++ b/.trellis/workspace/pythonrust/index.md
@@ -8,7 +8,7 @@
 
 <!-- @@@auto:current-status -->
 - **Active File**: `journal-2.md`
-- **Total Sessions**: 82
+- **Total Sessions**: 83
 - **Last Active**: 2026-09-07
 <!-- @@@/auto:current-status -->
 
@@ -19,7 +19,7 @@
 <!-- @@@auto:active-documents -->
 | File | Lines | Status |
 |------|-------|--------|
-| `journal-2.md` | ~658 | Active |
+| `journal-2.md` | ~681 | Active |
 | `journal-1.md` | ~1987 | Archived |
 <!-- @@@/auto:active-documents -->
 
@@ -30,6 +30,7 @@
 <!-- @@@auto:session-history -->
 | # | Date | Title | Commits | Branch |
 |---|------|-------|---------|--------|
+| 83 | 2026-09-07 | Review September 6-7 specs and restore integration checks | `ee5745ca`, `77e50e83` | `dev/laiyongjie` |
 | 82 | 2026-09-07 | Keep the scrollbar repair at the original overflow boundary | `f8ee21fb33650f9692b7f46786ff385ee749e944` | `dev/laiyongjie` |
 | 81 | 2026-09-07 | Repair PR 181 CI discovery and cross-host browser contracts | `ddcf264a07437df787a3b08f3ea23db74d4f1737` | `dev/laiyongjie` |
 | 80 | 2026-09-07 | Validate integration subjects using real Git merge parents | `3a350fa299138b44c63468fc449f8acc930fd72f` | `dev/laiyongjie` |

--- a/.trellis/workspace/pythonrust/index.md
+++ b/.trellis/workspace/pythonrust/index.md
@@ -8,7 +8,7 @@
 
 <!-- @@@auto:current-status -->
 - **Active File**: `journal-2.md`
-- **Total Sessions**: 83
+- **Total Sessions**: 84
 - **Last Active**: 2026-09-07
 <!-- @@@/auto:current-status -->
 
@@ -19,7 +19,7 @@
 <!-- @@@auto:active-documents -->
 | File | Lines | Status |
 |------|-------|--------|
-| `journal-2.md` | ~681 | Active |
+| `journal-2.md` | ~703 | Active |
 | `journal-1.md` | ~1987 | Archived |
 <!-- @@@/auto:active-documents -->
 
@@ -30,6 +30,7 @@
 <!-- @@@auto:session-history -->
 | # | Date | Title | Commits | Branch |
 |---|------|-------|---------|--------|
+| 84 | 2026-09-07 | Finish dialog return regression before main integration | `61986e6921c18eaa9f952857ce10344dd007afa5` | `dev/laiyongjie` |
 | 83 | 2026-09-07 | Review September 6-7 specs and restore integration checks | `ee5745ca`, `77e50e83` | `dev/laiyongjie` |
 | 82 | 2026-09-07 | Keep the scrollbar repair at the original overflow boundary | `f8ee21fb33650f9692b7f46786ff385ee749e944` | `dev/laiyongjie` |
 | 81 | 2026-09-07 | Repair PR 181 CI discovery and cross-host browser contracts | `ddcf264a07437df787a3b08f3ea23db74d4f1737` | `dev/laiyongjie` |

--- a/.trellis/workspace/pythonrust/index.md
+++ b/.trellis/workspace/pythonrust/index.md
@@ -8,7 +8,7 @@
 
 <!-- @@@auto:current-status -->
 - **Active File**: `journal-2.md`
-- **Total Sessions**: 84
+- **Total Sessions**: 85
 - **Last Active**: 2026-09-07
 <!-- @@@/auto:current-status -->
 
@@ -19,7 +19,7 @@
 <!-- @@@auto:active-documents -->
 | File | Lines | Status |
 |------|-------|--------|
-| `journal-2.md` | ~703 | Active |
+| `journal-2.md` | ~725 | Active |
 | `journal-1.md` | ~1987 | Archived |
 <!-- @@@/auto:active-documents -->
 
@@ -30,6 +30,7 @@
 <!-- @@@auto:session-history -->
 | # | Date | Title | Commits | Branch |
 |---|------|-------|---------|--------|
+| 85 | 2026-09-07 | Verify final contracts and clarify Windows batch evidence | `6efaff0b4aab8659f52e570654fa5c1882657cbb` | `dev/laiyongjie` |
 | 84 | 2026-09-07 | Finish dialog return regression before main integration | `61986e6921c18eaa9f952857ce10344dd007afa5` | `dev/laiyongjie` |
 | 83 | 2026-09-07 | Review September 6-7 specs and restore integration checks | `ee5745ca`, `77e50e83` | `dev/laiyongjie` |
 | 82 | 2026-09-07 | Keep the scrollbar repair at the original overflow boundary | `f8ee21fb33650f9692b7f46786ff385ee749e944` | `dev/laiyongjie` |

--- a/.trellis/workspace/pythonrust/journal-2.md
+++ b/.trellis/workspace/pythonrust/journal-2.md
@@ -701,3 +701,25 @@ Continued PR 182 after reading back actual repository state. Reproduced the deta
 ### Status
 
 [OK] **Completed**
+
+
+## Session 85: Verify final contracts and clarify Windows batch evidence
+<!-- trellis-session: v=2 fp=7ec193484419cea7 -->
+
+**Date**: 2026-09-07
+**Task**: Verify final contracts and clarify Windows batch evidence
+**Branch**: `dev/laiyongjie`
+
+### Summary
+
+Completed full local validation for PR 182: mise run check passed (1582 frontend units, 3511 Rust tests); production build/boot and all 526 browser regressions passed; six serial navigation/presentation profiling checks passed at 1x/4x CPU cost. Retained 4x long-task observations in the PR evidence. Official Rust documentation showed the batch-launch rationale was overstated, so clarified explicit cmd dispatch as project policy and raw_arg as non-escaping rather than claiming std::process::Command cannot start batch files. Runtime, tests and build inputs are unchanged from 79790c39; reran check:contracts successfully. No separate Trellis task.
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `6efaff0b4aab8659f52e570654fa5c1882657cbb` | docs(spec): clarify explicit Windows batch launch policy |
+
+### Status
+
+[OK] **Completed**

--- a/.trellis/workspace/pythonrust/journal-2.md
+++ b/.trellis/workspace/pythonrust/journal-2.md
@@ -679,3 +679,25 @@ Reviewed 64 non-merge commits using UTC+8 committer dates and validated all 82 c
 ### Status
 
 [OK] **Completed**
+
+
+## Session 84: Finish dialog return regression before main integration
+<!-- trellis-session: v=2 fp=f79abeff791da1b0 -->
+
+**Date**: 2026-09-07
+**Task**: Finish dialog return regression before main integration
+**Branch**: `dev/laiyongjie`
+
+### Summary
+
+Continued PR 182 after reading back actual repository state. Reproduced the detached-menu/visible-return-target immediate-exit mismatch with a failing test; resolved the return anchor before all presentation branches. Retained hidden/removed rejection and recorded transient browser exit evidence in-page without changing animation timing, retries or CI gates. Updated dialog lifecycle SPEC. Passed 30 focused units, typecheck, lint, formatting, and 10 Chromium/WebKit repeated return tests. Whole-project and exact-head hosted merge checks remain to be completed.
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `61986e6921c18eaa9f952857ce10344dd007afa5` | fix(ui): resolve dialog return anchors before immediate settlement |
+
+### Status
+
+[OK] **Completed**

--- a/.trellis/workspace/pythonrust/journal-2.md
+++ b/.trellis/workspace/pythonrust/journal-2.md
@@ -656,3 +656,26 @@ PR181首轮CI因既有双父merge提交的自定义标题失败；复用现有�
 ### Next Steps
 
 - Complete final whole-project checks and hosted exact-head PR plus merge-group CI before enabling normal auto-merge.
+
+
+## Session 83: Review September 6-7 specs and restore integration checks
+<!-- trellis-session: v=2 fp=eb8bf687d6915f1a -->
+
+**Date**: 2026-09-07
+**Task**: Review September 6-7 specs and restore integration checks
+**Branch**: `dev/laiyongjie`
+
+### Summary
+
+Reviewed 64 non-merge commits using UTC+8 committer dates and validated all 82 current SPEC navigation entries. Centralized Codex source-selection ownership, corrected auth/config/no-op/restart and best-effort persistence/rollback claims, and reduced guide duplication. Restored 8 reviewed platform digests, concrete DOM ref and nullable browser types, stable auth-dialog selection with single-use preview regression, shared radius token, and formatting. Local frontend: 179 files, 1579 passing and 1 existing skip; desktop mock: 7 passing. Contracts, lint, typecheck, Rust check and Clippy passed. Full native tests are still running; exact-head PR and merge-group checks must pass before merge. No Trellis task was created, as requested.
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `ee5745ca` | docs(spec): reconcile Codex source and runtime evidence contracts |
+| `77e50e83` | fix(ci): restore renderer checks and reviewed platform identities |
+
+### Status
+
+[OK] **Completed**

--- a/scripts/tasks/supported-platform-structure-assets.json
+++ b/scripts/tasks/supported-platform-structure-assets.json
@@ -55,7 +55,7 @@
     ],
     [
       "src-tauri/src/agent_install/desktop.rs",
-      "f28d2783233b27ecb1858db0db83e298fa8f2d580a86937eb5cfba6211370033"
+      "b916b40cdc5449461a25f9d018ac7dc6818f00bb9ad4017c944e3143511ce2a7"
     ],
     [
       "src-tauri/src/agent_install/inventory.rs",
@@ -75,7 +75,7 @@
     ],
     [
       "src-tauri/src/agent_install/windows.rs",
-      "02e7baad16d617ba26a80a450d76aca750a7e87fc0a2e5aef53b0b9fd534e065"
+      "6dd173d8bb7e91de223be4eb2c41b2e9616248fb2567ab52c7ab937cedf865fa"
     ],
     [
       "src-tauri/src/app_store.rs",
@@ -95,7 +95,7 @@
     ],
     [
       "src-tauri/src/codex_config.rs",
-      "d8e23a77d82431b65dc380e86a58b32fdd0a40245a4ce6abf4ea4db4a6313a11"
+      "8ddf64ebe7a24f85322e24408dd85532c031765ed87b0480527a42c441fe6df8"
     ],
     [
       "src-tauri/src/codex_config/catalog.rs",
@@ -163,7 +163,7 @@
     ],
     [
       "src-tauri/src/lib.rs",
-      "9693dc73fc821f407ceb60373f81ea7cd10ff8122b77d98a6ee844d22d1b02d9"
+      "113591d1e2496b0df2307662ad53870f6a810ff65a4554962512813712bce2a8"
     ],
     [
       "src-tauri/src/lightweight.rs",
@@ -199,7 +199,7 @@
     ],
     [
       "src-tauri/src/platform/process_launch.rs",
-      "1ca580892134df4fdaf1dec6e06a67c4c319783361d1b75070f419ef677c7661"
+      "48328884f5a82adbb4d8a0d594f0357e722f44c2cf3ae0ec169b3ceddc5a27ff"
     ],
     [
       "src-tauri/src/proxy/providers/codex_oauth_auth.rs",
@@ -227,7 +227,7 @@
     ],
     [
       "src-tauri/src/services/managed_auth/providers/openai.rs",
-      "8327871323df55e2ed6e4898473a8e46a1f6db2131e2cf146dc757edf045d7b6"
+      "541aefd34dbf8b9e4276d98607b5bc02c0be66006d5b821fa4c353d526406cb5"
     ],
     [
       "src-tauri/src/services/model_probe.rs",
@@ -315,7 +315,7 @@
     ],
     [
       "src-tauri/src/settings.rs",
-      "7512dc82f3807b0a05f103d9fc8d55f3cf6ad9bc3b53985ceb399a7267a467fe"
+      "5ee6e10af746639c69332cb0b4b9a47473e669e04b037d137742669777c765b8"
     ],
     [
       "src-tauri/src/tray.rs",
@@ -383,7 +383,7 @@
     ],
     [
       "tests/codexUserHelperContract.test.ts",
-      "53db0643361efdff6c9ec1f60911c5d8a03b09dae4319b71cb95bd1faa7a5eee"
+      "966e056c6655918bb7909c98753ffa1433d0c63ec353711c3062bc94360f8130"
     ],
     [
       "tests/codexWindowsUserScopeContract.test.ts",

--- a/scripts/tasks/supported-platform-structure-assets.json
+++ b/scripts/tasks/supported-platform-structure-assets.json
@@ -199,7 +199,7 @@
     ],
     [
       "src-tauri/src/platform/process_launch.rs",
-      "48328884f5a82adbb4d8a0d594f0357e722f44c2cf3ae0ec169b3ceddc5a27ff"
+      "b2caea203ee4eb1fcd73d69659d7f7aa9e0a3fd94a7cf145bc1ffd9a7c67a93a"
     ],
     [
       "src-tauri/src/proxy/providers/codex_oauth_auth.rs",

--- a/src-tauri/macos-privileged-helper/Sources/FyAgentPrivilegedProtocol/Policy.swift
+++ b/src-tauri/macos-privileged-helper/Sources/FyAgentPrivilegedProtocol/Policy.swift
@@ -68,7 +68,7 @@ public enum KnownApplicationPolicyTable {
         ),
         KnownApplicationPolicy(
             product: .workBuddy,
-            bundleIdentifier: "com.workbuddy.workbuddy",
+            bundleIdentifier: "com.tencent.workbuddy.mac",
             versionSource: .infoPlist,
             slots: [
                 TargetSlotPolicy(slot: 1, basename: "WorkBuddy.app", allowsFreshInstall: true),

--- a/src-tauri/macos-privileged-helper/Tests/FyAgentPrivilegedTransactionTests/TransactionTests.swift
+++ b/src-tauri/macos-privileged-helper/Tests/FyAgentPrivilegedTransactionTests/TransactionTests.swift
@@ -83,7 +83,7 @@ struct TransactionTests {
         let existing = try FakeApp.make(
             in: env.apps,
             basename: "WorkBuddy.app",
-            bundleId: "com.workbuddy.workbuddy",
+            bundleId: "com.tencent.workbuddy.mac",
             version: "5.0.0",
             executable: "WorkBuddy"
         )
@@ -91,7 +91,7 @@ struct TransactionTests {
         let source = try FakeApp.make(
             in: env.root.appendingPathComponent("source"),
             basename: "WorkBuddy.app",
-            bundleId: "com.workbuddy.workbuddy",
+            bundleId: "com.tencent.workbuddy.mac",
             version: "5.1.0",
             executable: "WorkBuddy"
         )

--- a/src-tauri/src/agent_install/desktop.rs
+++ b/src-tauri/src/agent_install/desktop.rs
@@ -38,6 +38,8 @@ use crate::services::external_agents::AgentCatalogId;
 const MAX_TRAE_PRODUCT_JSON_BYTES: usize = 256 * 1024;
 const MAX_WINDOWS_IDENTITY_WINDOW: usize = 512 * 1024;
 const MAX_WINDOWS_IDENTITY_FILE: u64 = 512 * 1024 * 1024;
+/// Official WorkBuddy macOS identity from the signed 5.5.3 package.
+const WORKBUDDY_MACOS_BUNDLE_ID: &str = "com.tencent.workbuddy.mac";
 
 pub(super) struct DesktopProduct {
     pub(super) agent_id: AgentCatalogId,
@@ -49,7 +51,7 @@ pub(super) struct DesktopProduct {
 const DESKTOP_PRODUCTS: &[DesktopProduct] = &[
     DesktopProduct {
         agent_id: AgentCatalogId::WorkBuddy,
-        macos_bundle_id: "com.workbuddy.workbuddy",
+        macos_bundle_id: WORKBUDDY_MACOS_BUNDLE_ID,
         windows_product_names: &["WorkBuddy"],
         windows_relative_exes: &["WorkBuddy/WorkBuddy.exe"],
     },
@@ -1102,10 +1104,16 @@ mod tests {
         write_fake_macos_app(
             &apps,
             "NotTheProductName",
-            "com.workbuddy.workbuddy",
-            "5.3.14",
+            WORKBUDDY_MACOS_BUNDLE_ID,
+            "5.5.3",
         );
         write_fake_macos_app(&apps, "WorkBuddy", "com.evil.workbuddy", "9.9.9");
+        write_fake_macos_app(
+            &apps,
+            "WorkBuddy Legacy",
+            "com.workbuddy.workbuddy",
+            "1.0.0",
+        );
         write_fake_macos_app(&apps, "QoderWork CN", "com.qoder.work.cn", "0.9.12");
         write_fake_macos_app(&apps, "TRAE SOLO CN", "cn.trae.solo.app", "0.1.51");
 
@@ -1114,7 +1122,7 @@ mod tests {
             std::slice::from_ref(&apps),
         );
         assert_eq!(workbuddy.len(), 1);
-        assert_eq!(workbuddy[0].local_version.as_deref(), Some("5.3.14"));
+        assert_eq!(workbuddy[0].local_version.as_deref(), Some("5.5.3"));
 
         let qoder = discover_macos_installations(
             product(AgentCatalogId::QoderWork),

--- a/src-tauri/src/agent_install/windows.rs
+++ b/src-tauri/src/agent_install/windows.rs
@@ -1144,7 +1144,7 @@ mod tests {
     fn product() -> DesktopProduct {
         DesktopProduct {
             agent_id: AgentCatalogId::WorkBuddy,
-            macos_bundle_id: "com.workbuddy.workbuddy",
+            macos_bundle_id: "com.tencent.workbuddy.mac",
             windows_product_names: &["WorkBuddy"],
             windows_relative_exes: &["WorkBuddy/WorkBuddy.exe"],
         }

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -17,8 +17,13 @@ mod auth;
 mod catalog;
 mod credential_store;
 mod features;
+mod model_provider_line;
 mod source_switch;
 mod storage;
+pub(crate) use model_provider_line::{
+    comment_top_level_model_provider, top_level_model_provider_is_active,
+    uncomment_top_level_model_provider,
+};
 pub(crate) use source_switch::{
     patch_source as patch_codex_source_config, validate_source as validate_codex_source_config,
 };

--- a/src-tauri/src/codex_config/model_provider_line.rs
+++ b/src-tauri/src/codex_config/model_provider_line.rs
@@ -1,0 +1,188 @@
+//! Top-level `model_provider` comment/uncomment.
+//!
+//! Official ChatGPT login uses Codex's built-in openai route, which is the
+//! default when the top-level key is absent. Unofficial routing keeps the
+//! user's `[model_providers.*]` tables and only toggles the selector line so
+//! the previous provider id can be restored.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LineAction {
+    Comment,
+    Uncomment,
+}
+
+/// Comment the first top-level `model_provider = …` assignment.
+/// Returns `None` when the live document already has no active selector.
+pub(crate) fn comment_top_level_model_provider(config: &str) -> Option<String> {
+    rewrite_top_level_model_provider_line(config, LineAction::Comment)
+}
+
+/// Uncomment the first top-level `#model_provider = …` assignment.
+/// Returns `None` when no commented selector exists before the first table.
+pub(crate) fn uncomment_top_level_model_provider(config: &str) -> Option<String> {
+    rewrite_top_level_model_provider_line(config, LineAction::Uncomment)
+}
+
+pub(crate) fn top_level_model_provider_is_active(config: &str) -> bool {
+    scan_top_level_model_provider_line(config).is_some_and(|active| active)
+}
+
+fn rewrite_top_level_model_provider_line(config: &str, action: LineAction) -> Option<String> {
+    let mut in_table = false;
+    let mut changed = false;
+    let mut out = String::with_capacity(config.len().saturating_add(1));
+    for (content, ending) in lines_with_endings(config) {
+        let trimmed = content.trim_start();
+        if !in_table && is_table_header(trimmed) {
+            in_table = true;
+        }
+        if !changed && !in_table {
+            if let Some(rewritten) = rewrite_line(content, action) {
+                out.push_str(&rewritten);
+                out.push_str(ending);
+                changed = true;
+                continue;
+            }
+        }
+        out.push_str(content);
+        out.push_str(ending);
+    }
+    changed.then_some(out)
+}
+
+fn scan_top_level_model_provider_line(config: &str) -> Option<bool> {
+    let mut in_table = false;
+    for (content, _) in lines_with_endings(config) {
+        let trimmed = content.trim_start();
+        if !in_table && is_table_header(trimmed) {
+            in_table = true;
+        }
+        if in_table {
+            continue;
+        }
+        if is_active_assignment(trimmed) {
+            return Some(true);
+        }
+        if uncommented_assignment(trimmed).is_some() {
+            return Some(false);
+        }
+    }
+    None
+}
+
+fn is_table_header(trimmed: &str) -> bool {
+    !trimmed.starts_with('#') && trimmed.starts_with('[')
+}
+
+fn rewrite_line(content: &str, action: LineAction) -> Option<String> {
+    let indent_len = content.len() - content.trim_start().len();
+    let indent = &content[..indent_len];
+    let trimmed = content.trim_start();
+    match action {
+        LineAction::Comment => {
+            if is_active_assignment(trimmed) {
+                Some(format!("{indent}#{trimmed}"))
+            } else {
+                None
+            }
+        }
+        LineAction::Uncomment => {
+            uncommented_assignment(trimmed).map(|assignment| format!("{indent}{assignment}"))
+        }
+    }
+}
+
+fn is_active_assignment(trimmed: &str) -> bool {
+    let Some(after) = trimmed.strip_prefix("model_provider") else {
+        return false;
+    };
+    after.trim_start().starts_with('=')
+}
+
+fn uncommented_assignment(trimmed: &str) -> Option<&str> {
+    let rest = trimmed.strip_prefix('#')?;
+    let assignment = rest.trim_start();
+    is_active_assignment(assignment).then_some(assignment)
+}
+
+fn lines_with_endings(config: &str) -> impl Iterator<Item = (&str, &str)> {
+    let mut remaining = config;
+    std::iter::from_fn(move || {
+        if remaining.is_empty() {
+            return None;
+        }
+        let split = remaining
+            .find('\n')
+            .map_or(remaining.len(), |index| index + 1);
+        let chunk = &remaining[..split];
+        remaining = &remaining[split..];
+        let ending = if chunk.ends_with("\r\n") {
+            "\r\n"
+        } else if chunk.ends_with('\n') {
+            "\n"
+        } else {
+            ""
+        };
+        Some((&chunk[..chunk.len() - ending.len()], ending))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn comments_only_the_top_level_selector_and_preserves_provider_tables() {
+        let input = "model = \"gpt\"\nmodel_provider = \"OpenAI\"\n\n[model_providers.OpenAI]\nbase_url = \"https://example.test/v1\"\n";
+        let output = comment_top_level_model_provider(input).unwrap();
+        assert_eq!(
+            output,
+            "model = \"gpt\"\n#model_provider = \"OpenAI\"\n\n[model_providers.OpenAI]\nbase_url = \"https://example.test/v1\"\n"
+        );
+        assert!(uncomment_top_level_model_provider(&output).is_some());
+        assert!(comment_top_level_model_provider(&output).is_none());
+        assert!(!top_level_model_provider_is_active(&output));
+    }
+
+    #[test]
+    fn uncomments_hash_without_space_and_keeps_crlf() {
+        let input = "#model_provider = \"OpenAI\"\r\nmodel = \"gpt\"\r\n";
+        let output = uncomment_top_level_model_provider(input).unwrap();
+        assert_eq!(output, "model_provider = \"OpenAI\"\r\nmodel = \"gpt\"\r\n");
+        assert!(top_level_model_provider_is_active(&output));
+        assert_eq!(
+            comment_top_level_model_provider(&output).as_deref(),
+            Some(input)
+        );
+    }
+
+    #[test]
+    fn ignores_selector_lines_inside_tables() {
+        let input = "[model_providers.OpenAI]\nmodel_provider = \"ignored\"\n";
+        assert!(comment_top_level_model_provider(input).is_none());
+        assert!(uncomment_top_level_model_provider(
+            "[model_providers.OpenAI]\n#model_provider = \"ignored\"\n"
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn comments_user_codex_openai_selector_without_touching_the_table() {
+        let input = concat!(
+            "model_provider = \"OpenAI\"\n",
+            "model = \"gpt-5.6-luna\"\n",
+            "\n",
+            "[model_providers.OpenAI]\n",
+            "name = \"OpenAI\"\n",
+            "base_url = \"https://example.test/v1\"\n",
+        );
+        let output = comment_top_level_model_provider(input).unwrap();
+        assert!(output.starts_with("#model_provider = \"OpenAI\"\n"));
+        assert!(output.contains("[model_providers.OpenAI]"));
+        assert!(output.contains("base_url = \"https://example.test/v1\""));
+        assert_eq!(
+            uncomment_top_level_model_provider(&output).as_deref(),
+            Some(input)
+        );
+    }
+}

--- a/src-tauri/src/codex_config/source_switch.rs
+++ b/src-tauri/src/codex_config/source_switch.rs
@@ -78,6 +78,12 @@ pub(crate) fn patch_source(
     unify_sessions: bool,
 ) -> Result<String, AppError> {
     validate_source(category, auth, desired_config)?;
+    let owned_current = if category == Some("official") {
+        super::comment_top_level_model_provider(current_config)
+    } else {
+        super::uncomment_top_level_model_provider(current_config)
+    };
+    let current_config = owned_current.as_deref().unwrap_or(current_config);
     let mut current = current_config
         .parse::<DocumentMut>()
         .map_err(|_| invalid("现有 Codex 配置格式无效，请先检查原文件"))?;
@@ -211,6 +217,7 @@ mod tests {
         }
         assert!(after.get("model_provider").is_none());
         assert!(after.get("model").is_none());
+        assert!(result.contains("#model_provider"));
     }
 
     #[test]
@@ -245,6 +252,32 @@ mod tests {
             after["model_providers"]["new-api"]["experimental_bearer_token"].as_str(),
             Some("new-fixture")
         );
+    }
+
+    #[test]
+    fn third_party_source_uncomments_existing_selector_instead_of_duplicating() {
+        let dir = tempfile::tempdir().unwrap();
+        let current = "#model_provider = \"OpenAI\"\nmodel = \"gpt\"\n[model_providers.OpenAI]\nname = \"OpenAI\"\nbase_url = \"https://example.test/v1\"\nwire_api = \"responses\"\nrequires_openai_auth = false\n";
+        let desired = "model_provider = \"OpenAI\"\nmodel = \"gpt\"\n[model_providers.OpenAI]\nname = \"OpenAI\"\nbase_url = \"https://example.test/v1\"\nwire_api = \"responses\"\nrequires_openai_auth = false\n";
+        let result = patch_source(
+            current,
+            None,
+            &json!({"OPENAI_API_KEY": "fixture"}),
+            desired,
+            dir.path(),
+            false,
+        )
+        .unwrap();
+        let selector_lines = result
+            .lines()
+            .filter(|line| {
+                let trimmed = line.trim_start();
+                trimmed.starts_with("model_provider") || trimmed.starts_with("#model_provider")
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(selector_lines.len(), 1);
+        assert!(selector_lines[0].trim_start().starts_with("model_provider"));
+        assert!(!result.contains("#model_provider"));
     }
 
     #[test]

--- a/src-tauri/src/codex_desktop/platform/macos/dmg.rs
+++ b/src-tauri/src/codex_desktop/platform/macos/dmg.rs
@@ -2573,7 +2573,7 @@ mod tests {
 
     #[test]
     fn managed_update_preserves_the_selected_bundle_path_without_scope_fallback() {
-        const BUNDLE_ID: &str = "com.workbuddy.workbuddy";
+        const BUNDLE_ID: &str = "com.tencent.workbuddy.mac";
         let (filesystem, _) = fixture_filesystem();
         let target = Path::new(USER_APPLICATIONS).join("Existing WorkBuddy.app");
         add_bundle(filesystem.as_ref(), &target);
@@ -2737,7 +2737,7 @@ mod tests {
 
     #[test]
     fn managed_running_application_blocks_before_any_staging_write() {
-        const BUNDLE_ID: &str = "com.workbuddy.workbuddy";
+        const BUNDLE_ID: &str = "com.tencent.workbuddy.mac";
         let (filesystem, _) = fixture_filesystem();
         let target = Path::new(USER_APPLICATIONS).join("WorkBuddy.app");
         add_bundle(filesystem.as_ref(), &target);

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -53,6 +53,7 @@ fn merge_settings_for_save(
     incoming.current_provider_opencode = existing.current_provider_opencode.clone();
     incoming.current_provider_openclaw = existing.current_provider_openclaw.clone();
     incoming.current_provider_hermes = existing.current_provider_hermes.clone();
+    incoming.appearance_theme = existing.appearance_theme.clone();
     incoming
 }
 
@@ -641,6 +642,22 @@ mod tests {
             merged.current_provider_hermes.as_deref(),
             Some("latest-hermes")
         );
+    }
+
+    #[test]
+    fn save_settings_should_preserve_existing_appearance_theme() {
+        let existing = AppSettings {
+            appearance_theme: Some("dark".to_string()),
+            ..AppSettings::default()
+        };
+        let incoming = AppSettings {
+            appearance_theme: Some("light".to_string()),
+            ..AppSettings::default()
+        };
+
+        let merged = merge_settings_for_save(incoming, &existing);
+
+        assert_eq!(merged.appearance_theme.as_deref(), Some("dark"));
     }
 
     #[test]

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -48,9 +48,11 @@ pub async fn get_skills_migration_result() -> Result<Option<SkillsMigrationPaylo
 pub async fn set_window_theme(window: tauri::Window, theme: String) -> Result<(), String> {
     use tauri::Theme;
 
-    let tauri_theme = match theme.as_str() {
-        "dark" => Some(Theme::Dark),
-        "light" => Some(Theme::Light),
+    crate::settings::persist_appearance_theme(&theme);
+
+    let tauri_theme = match crate::settings::parse_appearance_theme(&theme) {
+        Some("dark") => Some(Theme::Dark),
+        Some("light") => Some(Theme::Light),
         _ => None,
     };
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -449,7 +449,32 @@ fn install_main_window_layout_listener(window: &tauri::WebviewWindow) {
     });
 }
 
+fn apply_persisted_window_theme(window: &tauri::WebviewWindow) {
+    let preference = crate::settings::appearance_theme_preference();
+    if preference.is_none() {
+        return;
+    }
+    let theme = match preference.as_deref() {
+        Some("dark") => Some(tauri::Theme::Dark),
+        Some("light") => Some(tauri::Theme::Light),
+        _ => None,
+    };
+    if let Err(error) = window.set_theme(theme) {
+        log::debug!("Unable to restore window appearance: {error}");
+    }
+}
+
+fn seed_renderer_appearance<R: tauri::Runtime>(webview: &tauri::Webview<R>) {
+    let Some(script) = crate::settings::appearance_bootstrap_script() else {
+        return;
+    };
+    if let Err(error) = webview.eval(&script) {
+        log::debug!("Unable to restore renderer appearance: {error}");
+    }
+}
+
 pub(crate) fn prepare_main_webview(window: &tauri::WebviewWindow) {
+    apply_persisted_window_theme(window);
     if let Err(error) = restore_hidden_main_window_layout(window) {
         log::warn!("Unable to apply main-window layout policy: {error}");
     }
@@ -952,6 +977,7 @@ pub fn run() {
             if webview.label() == "main"
                 && matches!(payload.event(), tauri::webview::PageLoadEvent::Started)
             {
+                seed_renderer_appearance(webview);
                 mark_activation_renderer_unready();
                 schedule_frontend_recovery(webview.app_handle());
             }

--- a/src-tauri/src/macos_system_commit/policy.rs
+++ b/src-tauri/src/macos_system_commit/policy.rs
@@ -41,7 +41,7 @@ const CODEX_BUNDLE_ID: &str = "com.openai.codex";
 const OPENCODE_BUNDLE_ID: &str = "ai.opencode.desktop";
 const QODERWORK_BUNDLE_ID: &str = "com.qoder.work.cn";
 const TRAEWORK_BUNDLE_ID: &str = "cn.trae.solo.app";
-const WORKBUDDY_BUNDLE_ID: &str = "com.workbuddy.workbuddy";
+const WORKBUDDY_BUNDLE_ID: &str = "com.tencent.workbuddy.mac";
 
 impl KnownSystemProduct {
     pub const fn as_u32(self) -> u32 {
@@ -210,7 +210,7 @@ mod tests {
         assert_eq!(OPENCODE_BUNDLE_ID, "ai.opencode.desktop");
         assert_eq!(QODERWORK_BUNDLE_ID, "com.qoder.work.cn");
         assert_eq!(TRAEWORK_BUNDLE_ID, "cn.trae.solo.app");
-        assert_eq!(WORKBUDDY_BUNDLE_ID, "com.workbuddy.workbuddy");
+        assert_eq!(WORKBUDDY_BUNDLE_ID, "com.tencent.workbuddy.mac");
     }
 
     #[test]

--- a/src-tauri/src/platform/process_launch.rs
+++ b/src-tauri/src/platform/process_launch.rs
@@ -1158,9 +1158,26 @@ mod tests {
 
     #[test]
     fn macos_application_open_adapter_uses_nsworkspace_completion_not_the_open_tool() {
-        let source = include_str!("process_launch.rs");
-        assert!(source.contains("openApplicationAtURL_configuration_completionHandler"));
-        assert!(!source.contains("Command::new(\"open\")"));
+        let source = include_str!("process_launch.rs").replace("\r\n", "\n");
+        let production = source
+            .split_once("\n#[cfg(test)]\nmod tests {")
+            .expect("top-level test module boundary")
+            .0;
+        let (before_http, http_and_after) = production
+            .split_once("fn open_http_url_with_macos_open(")
+            .expect("HTTP-only browser launch helper");
+        let (http, after_http) = http_and_after
+            .split_once("#[cfg(target_os = \"macos\")]\nstruct TauriOpenerInteractiveUserLauncher")
+            .expect("browser helper ends before the platform adapter");
+        assert!(http.contains("Command::new(\"open\")"));
+        assert!(http.contains(".arg(url)"));
+        for other_source in [before_http, after_http] {
+            assert!(
+                !other_source.contains("Command::new(\"open\")"),
+                "only the HTTP browser helper may spawn open; application launch uses NSWorkspace"
+            );
+        }
+        assert!(after_http.contains("openApplicationAtURL_configuration_completionHandler"));
         assert!(
             !source.contains(&format!("{}{}", "request", "Authorization")),
             "application-open must not use privileged file-operations authorization"

--- a/src-tauri/src/platform/process_launch.rs
+++ b/src-tauri/src/platform/process_launch.rs
@@ -331,14 +331,26 @@ pub(crate) fn launch_fyagent_user_helper_as_user(
 /// Opens an HTTP(S) URL through the interactive user's shell.
 ///
 /// On Windows this takes the Explorer COM route and deliberately fails when
-/// Explorer cannot supply the interactive shell. macOS retains the
-/// existing Tauri opener behavior.
+/// Explorer cannot supply the interactive shell. On macOS, validated HTTP(S)
+/// URLs use `open` with a single argv so OAuth query strings stay intact;
+/// directories still use the Tauri opener.
 pub(crate) async fn open_http_url_as_user(app: AppHandle, raw_url: String) -> Result<(), String> {
     let request = InteractiveUserLaunch::http_url(&raw_url)
         .map_err(|error| error.public_code().to_owned())?;
     dispatch_with_platform_launcher(app, request)
         .await
         .map_err(|error| error.public_code().to_owned())
+}
+
+/// Same HTTP open as [`open_http_url_as_user`], for callers that already run
+/// off the UI thread and have no `AppHandle`. macOS and Windows share the
+/// HTTP(S) validator, then the interactive-user launcher: Explorer COM on
+/// Windows, `open` on macOS. There is no `cmd /c start` fallback, because
+/// unquoted `&` in OAuth query strings is a cmd statement separator.
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+pub(crate) fn open_http_url_as_user_sync(raw_url: &str) -> Result<(), ProcessLaunchError> {
+    let request = InteractiveUserLaunch::http_url(raw_url)?;
+    dispatch_sync_with_platform_launcher(request)
 }
 
 /// Opens a backend-derived directory through the interactive user's shell.
@@ -468,6 +480,15 @@ fn dispatch_blocking_with_platform_launcher(
 }
 
 #[cfg(target_os = "macos")]
+fn open_http_url_with_macos_open(url: &str) -> Result<(), ProcessLaunchError> {
+    std::process::Command::new("open")
+        .arg(url)
+        .spawn()
+        .map(|_| ())
+        .map_err(|_| ProcessLaunchError::PlatformLaunchFailed)
+}
+
+#[cfg(target_os = "macos")]
 struct TauriOpenerInteractiveUserLauncher {
     app: AppHandle,
 }
@@ -475,10 +496,7 @@ struct TauriOpenerInteractiveUserLauncher {
 #[cfg(target_os = "macos")]
 impl InteractiveUserLauncher for TauriOpenerInteractiveUserLauncher {
     fn open_http_url(&self, url: &str) -> Result<(), ProcessLaunchError> {
-        self.app
-            .opener()
-            .open_url(url, None::<String>)
-            .map_err(|_| ProcessLaunchError::PlatformLaunchFailed)
+        open_http_url_with_macos_open(url)
     }
 
     fn open_directory(&self, directory: &Path) -> Result<(), ProcessLaunchError> {
@@ -510,8 +528,8 @@ struct MacosWorkspaceApplicationLauncher;
 
 #[cfg(target_os = "macos")]
 impl InteractiveUserLauncher for MacosWorkspaceApplicationLauncher {
-    fn open_http_url(&self, _url: &str) -> Result<(), ProcessLaunchError> {
-        Err(ProcessLaunchError::InteractiveUserUnavailable)
+    fn open_http_url(&self, url: &str) -> Result<(), ProcessLaunchError> {
+        open_http_url_with_macos_open(url)
     }
 
     fn open_directory(&self, _directory: &Path) -> Result<(), ProcessLaunchError> {
@@ -827,6 +845,43 @@ mod tests {
                 });
             self.failure.map_or(Ok(()), Err)
         }
+    }
+
+    #[test]
+    fn https_oauth_query_ampersands_reach_the_launcher() {
+        let launcher = FakeInteractiveUserLauncher::default();
+        let service = ProcessLaunchService::new(launcher.clone());
+        let url = "https://auth.openai.com/oauth/authorize?response_type=code&client_id=app_x&redirect_uri=http://localhost:1455/auth/callback&state=s";
+
+        service
+            .open_http_url_as_user(url)
+            .expect("valid HTTPS authorize URL");
+
+        let recorded = launcher.recorded_calls();
+        let RecordedLaunch::HttpUrl(opened) = &recorded[0] else {
+            panic!("expected HTTP URL");
+        };
+        let parsed = url::Url::parse(opened).expect("opened URL");
+        let query: std::collections::HashMap<_, _> = parsed.query_pairs().into_owned().collect();
+        assert_eq!(parsed.path(), "/oauth/authorize");
+        assert_eq!(query.get("response_type").map(String::as_str), Some("code"));
+        assert_eq!(query.get("client_id").map(String::as_str), Some("app_x"));
+        assert_eq!(
+            query.get("redirect_uri").map(String::as_str),
+            Some("http://localhost:1455/auth/callback")
+        );
+        assert_eq!(query.get("state").map(String::as_str), Some("s"));
+    }
+
+    #[test]
+    fn managed_auth_browser_open_uses_shared_http_launch() {
+        let provider = include_str!("../services/managed_auth/providers/openai.rs");
+        let launch = include_str!("process_launch.rs");
+        assert!(provider.contains("open_http_url_as_user_sync"));
+        assert!(launch.contains("open_http_url_with_macos_open"));
+        assert!(!provider.contains(r#"Command::new("cmd")"#));
+        assert!(!provider.contains(r#"Command::new("open")"#));
+        assert!(!provider.contains(r#"args(["/C", "start""#));
     }
 
     #[test]

--- a/src-tauri/src/services/managed_auth/connection_actions.rs
+++ b/src-tauri/src/services/managed_auth/connection_actions.rs
@@ -229,14 +229,25 @@ impl<B: SecretBackend + 'static> ManagedAuthService<B> {
                 | ManagedAuthConnectionAction::SwitchAccount,
             ) => {
                 let home = self.codex_home();
-                Ok((vec![home.join("auth.json")], vec![home.join("config.toml")]))
+                let auth = home.join("auth.json");
+                let config = home.join("config.toml");
+                let config_text = std::fs::read_to_string(&config).unwrap_or_default();
+                if crate::codex_config::top_level_model_provider_is_active(&config_text) {
+                    Ok((vec![auth, config], Vec::new()))
+                } else {
+                    Ok((vec![auth], vec![config]))
+                }
             }
             (ManagedAuthConsumer::Codex, ManagedAuthConnectionAction::Disconnect) => {
                 let home = self.codex_home();
-                Ok((
-                    Vec::new(),
-                    vec![home.join("auth.json"), home.join("config.toml")],
-                ))
+                let auth = home.join("auth.json");
+                let config = home.join("config.toml");
+                let config_text = std::fs::read_to_string(&config).unwrap_or_default();
+                if crate::codex_config::uncomment_top_level_model_provider(&config_text).is_some() {
+                    Ok((vec![config], vec![auth]))
+                } else {
+                    Ok((Vec::new(), vec![auth, config]))
+                }
             }
             (
                 ManagedAuthConsumer::Opencode,

--- a/src-tauri/src/services/managed_auth/consumers/codex/delta.rs
+++ b/src-tauri/src/services/managed_auth/consumers/codex/delta.rs
@@ -69,9 +69,8 @@ pub(crate) fn plan_codex_managed_auth_delta(
     }
 
     let account_matches = auth_matches_account(&live.auth_state, target_provider_subject);
-    // Credentials do not own model routing. A custom route remains custom
-    // even after an official account is selected; only an explicit source
-    // operation may change config.toml.
+    // Credentials do not own model routing tables. Official account projection
+    // comments the top-level model_provider selector; provider tables stay put.
     Ok(if account_matches {
         CodexManagedAuthDelta::Noop
     } else {
@@ -112,6 +111,7 @@ mod tests {
                     revision: "mr1:auth".into(),
                 },
             },
+            selector_commented: false,
             may_need_restart: false,
         }
     }

--- a/src-tauri/src/services/managed_auth/consumers/codex/mod.rs
+++ b/src-tauri/src/services/managed_auth/consumers/codex/mod.rs
@@ -12,7 +12,8 @@ pub(crate) use observation::{
     CodexManagedAuthObservation,
 };
 pub(crate) use project::{
-    materialize_from_bundle, project_codex_official_account, restore_unofficial_codex_selector,
+    live_codex_requires_restart_for_app, materialize_from_bundle, project_codex_official_account,
+    restore_unofficial_codex_selector,
 };
 pub(crate) use swap::{auth_path_in, capture_auth_preimage, restore_auth_recovery};
 

--- a/src-tauri/src/services/managed_auth/consumers/codex/mod.rs
+++ b/src-tauri/src/services/managed_auth/consumers/codex/mod.rs
@@ -11,7 +11,9 @@ pub(crate) use observation::{
     auth_matches_account, live_chatgpt_account_id, observe_managed_auth,
     CodexManagedAuthObservation,
 };
-pub(crate) use project::{materialize_from_bundle, project_codex_official_account};
+pub(crate) use project::{
+    materialize_from_bundle, project_codex_official_account, restore_unofficial_codex_selector,
+};
 pub(crate) use swap::{auth_path_in, capture_auth_preimage, restore_auth_recovery};
 
 use crate::services::managed_auth::{
@@ -122,6 +124,9 @@ pub(crate) fn connection_summary(
     } else if account_connectable(ready_saved) && store_ready {
         allowed_actions.push(ManagedAuthConnectionAction::ConnectAccount);
     }
+    if !live_matches_bound && observation.selector_commented && store_ready {
+        allowed_actions.push(ManagedAuthConnectionAction::Disconnect);
+    }
     if pending_restart {
         allowed_actions.push(ManagedAuthConnectionAction::Restart);
     }
@@ -205,6 +210,32 @@ mod tests {
         assert!(!summary
             .allowed_actions
             .contains(&ManagedAuthConnectionAction::SwitchToOfficial));
+        assert!(!summary
+            .allowed_actions
+            .contains(&ManagedAuthConnectionAction::Disconnect));
+    }
+
+    #[test]
+    fn commented_selector_while_disconnected_offers_disconnect() {
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("config.toml"),
+            "#model_provider = \"OpenAI\"\n[model_providers.OpenAI]\nbase_url = \"https://example.test/v1\"\n",
+        )
+        .unwrap();
+        let observed = observe_codex_home(dir.path());
+        assert!(observed.selector_commented);
+        let summary = connection_summary(&observed, None, None, &[], now_timestamp());
+        assert_eq!(
+            summary.auth_status,
+            ManagedAuthConnectionState::Disconnected
+        );
+        assert!(summary
+            .allowed_actions
+            .contains(&ManagedAuthConnectionAction::Disconnect));
+        assert!(!summary
+            .allowed_actions
+            .contains(&ManagedAuthConnectionAction::ConnectAccount));
     }
 
     #[test]

--- a/src-tauri/src/services/managed_auth/consumers/codex/observation.rs
+++ b/src-tauri/src/services/managed_auth/consumers/codex/observation.rs
@@ -6,10 +6,13 @@ use std::path::Path;
 use sha2::{Digest, Sha256};
 
 use crate::codex_config::is_custom_codex_model_provider_id;
-use crate::codex_config::{parse_cli_auth_credentials_store, CodexCredentialStore};
+use crate::codex_config::{
+    parse_cli_auth_credentials_store, uncomment_top_level_model_provider, CodexCredentialStore,
+};
 use crate::services::managed_auth::{
     providers::openai, ManagedAuthRequestMode, ManagedAuthSecretBundle,
 };
+use toml_edit::Item;
 
 use super::auth_document::{
     classify_auth_bytes, CodexChatGptAuthDocument, CodexNativeAuthState, MAX_AUTH_JSON_BYTES,
@@ -39,6 +42,7 @@ pub(crate) struct CodexManagedAuthObservation {
     pub request_mode: ManagedAuthRequestMode,
     pub request_provider_label: Option<String>,
     pub auth_state: CodexNativeAuthState,
+    pub selector_commented: bool,
     /// Conservative: true when Desktop hot-reload is unproven after a write.
     #[allow(dead_code)]
     pub may_need_restart: bool,
@@ -65,6 +69,7 @@ impl Default for CodexManagedAuthObservation {
             request_mode: ManagedAuthRequestMode::OfficialSubscription,
             request_provider_label: Some("openai".to_string()),
             auth_state: CodexNativeAuthState::Missing,
+            selector_commented: false,
             may_need_restart: false,
         }
     }
@@ -88,6 +93,7 @@ pub(crate) fn observe_managed_auth(codex_home: &Path) -> CodexManagedAuthObserva
                 request_mode: ManagedAuthRequestMode::Unknown,
                 request_provider_label: None,
                 auth_state: observe_auth_file(&auth_path).1,
+                selector_commented: false,
                 may_need_restart: false,
             };
         }
@@ -112,6 +118,7 @@ pub(crate) fn observe_managed_auth(codex_home: &Path) -> CodexManagedAuthObserva
         request_mode,
         request_provider_label,
         auth_state,
+        selector_commented: uncomment_top_level_model_provider(&config_text).is_some(),
         may_need_restart: false,
     }
 }
@@ -148,16 +155,25 @@ fn classify_provider_route(
             None,
         );
     };
-    if !is_custom_codex_model_provider_id(id) {
+    // A matching [model_providers.<id>] table overrides the built-in route,
+    // including reserved names such as OpenAI that users reuse for a custom
+    // endpoint. Commenting the top-level selector restores official openai.
+    let has_override_table = document
+        .get("model_providers")
+        .and_then(Item::as_table_like)
+        .and_then(|providers| providers.get(id))
+        .and_then(|entry| entry.as_table_like())
+        .is_some();
+    if has_override_table || is_custom_codex_model_provider_id(id) {
         (
-            CodexProviderRoute::Official,
-            ManagedAuthRequestMode::OfficialSubscription,
+            CodexProviderRoute::ThirdParty,
+            ManagedAuthRequestMode::ThirdPartyApi,
             Some(id.to_string()),
         )
     } else {
         (
-            CodexProviderRoute::ThirdParty,
-            ManagedAuthRequestMode::ThirdPartyApi,
+            CodexProviderRoute::Official,
+            ManagedAuthRequestMode::OfficialSubscription,
             Some(id.to_string()),
         )
     }
@@ -286,5 +302,35 @@ mod tests {
         let observed = observe_managed_auth(dir.path());
         assert_eq!(observed.provider_route, CodexProviderRoute::ThirdParty);
         assert_eq!(observed.request_mode, ManagedAuthRequestMode::ThirdPartyApi);
+    }
+
+    #[test]
+    fn commented_openai_selector_is_official_even_with_override_table() {
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("config.toml"),
+            "#model_provider = \"OpenAI\"\n[model_providers.OpenAI]\nbase_url = \"https://example.test/v1\"\n",
+        )
+        .unwrap();
+        let observed = observe_managed_auth(dir.path());
+        assert_eq!(observed.provider_route, CodexProviderRoute::Official);
+        assert_eq!(
+            observed.request_mode,
+            ManagedAuthRequestMode::OfficialSubscription
+        );
+    }
+
+    #[test]
+    fn reserved_name_with_override_table_is_third_party() {
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("config.toml"),
+            "model_provider = \"OpenAI\"\n[model_providers.OpenAI]\nbase_url = \"https://example.test/v1\"\n",
+        )
+        .unwrap();
+        let observed = observe_managed_auth(dir.path());
+        assert_eq!(observed.provider_route, CodexProviderRoute::ThirdParty);
+        assert_eq!(observed.request_mode, ManagedAuthRequestMode::ThirdPartyApi);
+        assert_eq!(observed.request_provider_label.as_deref(), Some("OpenAI"));
     }
 }

--- a/src-tauri/src/services/managed_auth/consumers/codex/project.rs
+++ b/src-tauri/src/services/managed_auth/consumers/codex/project.rs
@@ -1,8 +1,10 @@
-//! Codex account projection. This owner never writes model configuration.
+//! Codex account projection. Auth swap plus a top-level `model_provider`
+//! comment so official ChatGPT login uses the built-in openai route.
 
 use std::path::Path;
 
 use crate::app_config::AppType;
+use crate::codex_config::{comment_top_level_model_provider, uncomment_top_level_model_provider};
 use crate::services::managed_auth::{
     ManagedAuthMutationOutcome, ManagedAuthReasonCode, ManagedAuthSecretBundle,
 };
@@ -11,7 +13,9 @@ use crate::store::AppState;
 use super::auth_document::CodexChatGptAuthDocument;
 use super::delta::{plan_codex_managed_auth_delta, CodexDeltaError, CodexManagedAuthDelta};
 use super::observation::{document_from_bundle, observe_managed_auth};
-use super::swap::{auth_path_in, swap_codex_chatgpt_auth, CodexAuthSwapError};
+use super::swap::{
+    auth_path_in, swap_codex_chatgpt_auth, CodexAuthSwapError, CodexAuthSwapReceipt,
+};
 
 #[derive(Debug, Clone)]
 pub(crate) struct CodexProjectionOutcome {
@@ -59,7 +63,10 @@ fn project_under_guard(
     }
     let delta = plan_codex_managed_auth_delta(&live, target_provider_subject)
         .map_err(CodexDeltaError::reason_code)?;
-    if delta == CodexManagedAuthDelta::Noop {
+    let config_path = codex_home.join("config.toml");
+    let config_text = std::fs::read_to_string(&config_path).unwrap_or_default();
+    let commented_config = comment_top_level_model_provider(&config_text);
+    if delta == CodexManagedAuthDelta::Noop && commented_config.is_none() {
         return Ok(CodexProjectionOutcome {
             outcome: ManagedAuthMutationOutcome::Completed,
             reason: None,
@@ -67,31 +74,63 @@ fn project_under_guard(
             wrote_auth: false,
         });
     }
-    // The shared writer retains the exact old auth file even when it contains
-    // only a legacy API key. No hidden Provider backfill or config write is
-    // needed to make that credential recoverable.
-    let receipt = swap_codex_chatgpt_auth(
-        &auth_path_in(codex_home),
-        live.auth_revision.as_deref(),
-        target_document,
-    )
-    .map_err(|error| match error {
-        CodexAuthSwapError::Stale | CodexAuthSwapError::ExternalChange => {
-            ManagedAuthReasonCode::ExternalChangeDetected
+    let _scope = crate::config::file_mutation_scope();
+    let original_config = commented_config.as_ref().map(|_| config_text.into_bytes());
+    if let Some(next) = commented_config.as_ref() {
+        crate::config::atomic_write(&config_path, next.as_bytes())
+            .map_err(|_| ManagedAuthReasonCode::PartialCompletion)?;
+    }
+    let receipt = if delta == CodexManagedAuthDelta::Noop {
+        CodexAuthSwapReceipt {
+            revision: live.auth_revision.clone().unwrap_or_default(),
+            account_id: target_provider_subject.to_string(),
+            changed: false,
+            pending_restart: commented_config.is_some(),
         }
-        CodexAuthSwapError::IdentityMismatch => ManagedAuthReasonCode::IdentityMismatch,
-        CodexAuthSwapError::Invalid | CodexAuthSwapError::Io => {
-            ManagedAuthReasonCode::PartialCompletion
+    } else {
+        match swap_codex_chatgpt_auth(
+            &auth_path_in(codex_home),
+            live.auth_revision.as_deref(),
+            target_document,
+        ) {
+            Ok(receipt) => receipt,
+            Err(error) => {
+                if let Some(original) = original_config.as_deref() {
+                    let _ = crate::config::atomic_write(&config_path, original);
+                }
+                return Err(match error {
+                    CodexAuthSwapError::Stale | CodexAuthSwapError::ExternalChange => {
+                        ManagedAuthReasonCode::ExternalChangeDetected
+                    }
+                    CodexAuthSwapError::IdentityMismatch => ManagedAuthReasonCode::IdentityMismatch,
+                    CodexAuthSwapError::Invalid | CodexAuthSwapError::Io => {
+                        ManagedAuthReasonCode::PartialCompletion
+                    }
+                });
+            }
         }
-    })?;
+    };
+    let pending_restart = receipt.pending_restart || commented_config.is_some();
     Ok(CodexProjectionOutcome {
         outcome: ManagedAuthMutationOutcome::Completed,
-        reason: receipt
-            .pending_restart
-            .then_some(ManagedAuthReasonCode::PendingRestart),
-        pending_restart: receipt.pending_restart,
+        reason: pending_restart.then_some(ManagedAuthReasonCode::PendingRestart),
+        pending_restart,
         wrote_auth: receipt.changed,
     })
+}
+
+pub(crate) fn restore_unofficial_codex_selector(
+    codex_home: &Path,
+) -> Result<bool, ManagedAuthReasonCode> {
+    let config_path = codex_home.join("config.toml");
+    let config_text = std::fs::read_to_string(&config_path).unwrap_or_default();
+    let Some(next) = uncomment_top_level_model_provider(&config_text) else {
+        return Ok(false);
+    };
+    let _scope = crate::config::file_mutation_scope();
+    crate::config::atomic_write(&config_path, next.as_bytes())
+        .map_err(|_| ManagedAuthReasonCode::PartialCompletion)?;
+    Ok(true)
 }
 
 pub(crate) fn materialize_from_bundle(
@@ -122,7 +161,7 @@ mod tests {
     }
 
     #[test]
-    fn account_switch_preserves_commented_custom_config_without_provider_rows() {
+    fn account_switch_comments_top_level_selector_and_keeps_provider_tables() {
         let dir = tempfile::tempdir().unwrap();
         let config = dir.path().join("config.toml");
         let original = b"# user configuration\r\nmodel_provider = 'custom'\r\nmodel = 'user-model'\r\n[model_providers.custom]\r\nname = 'User provider'\r\nbase_url = 'https://example.test/v1'\r\nwire_api = 'responses'\r\n[mcp_servers.example]\r\ncommand = 'keep-me'\r\n[features]\r\nmulti_agent = true\r\n";
@@ -134,13 +173,16 @@ mod tests {
         let result =
             project_under_guard(dir.path(), "acct-a", &account("acct-a"), &revision).unwrap();
         assert!(result.wrote_auth && result.pending_restart);
-        assert_eq!(std::fs::read(&config).unwrap(), original);
-        assert!(!crate::config::rolling_backup_path(&config).exists());
+        let after = String::from_utf8(std::fs::read(&config).unwrap()).unwrap();
+        assert!(after.contains("#model_provider = 'custom'"));
+        assert!(after.contains("[model_providers.custom]"));
+        assert!(after.contains("[mcp_servers.example]"));
+        assert!(crate::config::rolling_backup_path(&config).exists());
         assert_eq!(
             std::fs::read(crate::config::rolling_backup_path(&auth)).unwrap(),
             before_auth
         );
-        assert!(!observe_managed_auth(dir.path())
+        assert!(observe_managed_auth(dir.path())
             .provider_route
             .is_official());
     }
@@ -175,11 +217,10 @@ mod tests {
     }
 
     #[test]
-    fn existing_matching_account_never_changes_route_or_rotates_auth_backup() {
+    fn existing_matching_account_comments_selector_without_rotating_auth() {
         let dir = tempfile::tempdir().unwrap();
         let config = dir.path().join("config.toml");
-        let config_bytes = b"# keep\nmodel_provider = 'custom'\n";
-        std::fs::write(&config, config_bytes).unwrap();
+        std::fs::write(&config, b"# keep\nmodel_provider = 'custom'\n").unwrap();
         let auth = auth_path_in(dir.path());
         let document = account("acct-a");
         std::fs::write(&auth, document.serialize_bytes().unwrap()).unwrap();
@@ -187,8 +228,50 @@ mod tests {
         let revision = observe_managed_auth(dir.path()).connection_revision();
         let result = project_under_guard(dir.path(), "acct-a", &document, &revision).unwrap();
         assert!(!result.wrote_auth);
+        assert!(result.pending_restart);
         assert_eq!(std::fs::read(&auth).unwrap(), before);
-        assert_eq!(std::fs::read(&config).unwrap(), config_bytes);
+        assert_eq!(
+            std::fs::read_to_string(&config).unwrap(),
+            "# keep\n#model_provider = 'custom'\n"
+        );
         assert!(!crate::config::rolling_backup_path(&auth).exists());
+        assert!(observe_managed_auth(dir.path())
+            .provider_route
+            .is_official());
+    }
+
+    #[test]
+    fn already_commented_selector_is_a_config_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = dir.path().join("config.toml");
+        let config_bytes = b"#model_provider = \"OpenAI\"\n[model_providers.OpenAI]\nbase_url = \"https://example.test/v1\"\n";
+        std::fs::write(&config, config_bytes).unwrap();
+        let auth = auth_path_in(dir.path());
+        let document = account("acct-a");
+        std::fs::write(&auth, document.serialize_bytes().unwrap()).unwrap();
+        let revision = observe_managed_auth(dir.path()).connection_revision();
+        let result = project_under_guard(dir.path(), "acct-a", &document, &revision).unwrap();
+        assert!(!result.wrote_auth);
+        assert!(!result.pending_restart);
+        assert_eq!(std::fs::read(&config).unwrap(), config_bytes);
+        assert!(observe_managed_auth(dir.path())
+            .provider_route
+            .is_official());
+    }
+
+    #[test]
+    fn restore_uncomments_openai_selector_and_keeps_provider_table() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = dir.path().join("config.toml");
+        std::fs::write(
+            &config,
+            b"#model_provider = \"OpenAI\"\nmodel = \"gpt\"\n[model_providers.OpenAI]\nbase_url = \"https://example.test/v1\"\n",
+        )
+        .unwrap();
+        assert!(restore_unofficial_codex_selector(dir.path()).unwrap());
+        let after = std::fs::read_to_string(&config).unwrap();
+        assert!(after.starts_with("model_provider = \"OpenAI\"\n"));
+        assert!(after.contains("[model_providers.OpenAI]"));
+        assert!(!restore_unofficial_codex_selector(dir.path()).unwrap());
     }
 }

--- a/src-tauri/src/services/managed_auth/consumers/codex/project.rs
+++ b/src-tauri/src/services/managed_auth/consumers/codex/project.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 
 use crate::app_config::AppType;
 use crate::codex_config::{comment_top_level_model_provider, uncomment_top_level_model_provider};
+use crate::codex_desktop::types::CodexDesktopRuntimeStatus;
 use crate::services::managed_auth::{
     ManagedAuthMutationOutcome, ManagedAuthReasonCode, ManagedAuthSecretBundle,
 };
@@ -25,6 +26,24 @@ pub(crate) struct CodexProjectionOutcome {
     pub wrote_auth: bool,
 }
 
+/// A file write only needs `pending_restart` when a live Codex Desktop process
+/// might still be holding the previous credentials. Not installed / not
+/// running means the next launch reads the files we just wrote.
+pub(crate) fn live_codex_requires_restart_after_write(
+    status: Option<&CodexDesktopRuntimeStatus>,
+) -> bool {
+    !matches!(
+        status,
+        Some(CodexDesktopRuntimeStatus::NotRunning) | Some(CodexDesktopRuntimeStatus::NotInstalled)
+    )
+}
+
+pub(crate) fn live_codex_requires_restart_for_app(app_state: &AppState) -> bool {
+    let runtime =
+        tauri::async_runtime::block_on(app_state.codex_desktop_service.get_runtime_status());
+    live_codex_requires_restart_after_write(runtime.as_ref().ok())
+}
+
 /// Serialize with Provider writes, but never invoke a Provider writer from an
 /// account operation. The displayed revision covers both auth and the store/
 /// routing configuration used to decide whether file projection is supported.
@@ -35,17 +54,24 @@ pub(crate) fn project_codex_official_account(
     target_document: &CodexChatGptAuthDocument,
     expected_connection_revision: &str,
 ) -> Result<CodexProjectionOutcome, ManagedAuthReasonCode> {
-    let _guard = futures::executor::block_on(
-        app_state
-            .proxy_service
-            .lock_switch_for_app(AppType::Codex.as_str()),
-    );
-    project_under_guard(
-        codex_home,
-        target_provider_subject,
-        target_document,
-        expected_connection_revision,
-    )
+    let mut outcome = {
+        let _guard = futures::executor::block_on(
+            app_state
+                .proxy_service
+                .lock_switch_for_app(AppType::Codex.as_str()),
+        );
+        project_under_guard(
+            codex_home,
+            target_provider_subject,
+            target_document,
+            expected_connection_revision,
+        )?
+    };
+    if outcome.pending_restart && !live_codex_requires_restart_for_app(app_state) {
+        outcome.pending_restart = false;
+        outcome.reason = None;
+    }
+    Ok(outcome)
 }
 
 fn project_under_guard(
@@ -273,5 +299,22 @@ mod tests {
         assert!(after.starts_with("model_provider = \"OpenAI\"\n"));
         assert!(after.contains("[model_providers.OpenAI]"));
         assert!(!restore_unofficial_codex_selector(dir.path()).unwrap());
+    }
+
+    #[test]
+    fn live_restart_is_only_required_when_desktop_may_be_running() {
+        assert!(!live_codex_requires_restart_after_write(Some(
+            &CodexDesktopRuntimeStatus::NotRunning
+        )));
+        assert!(!live_codex_requires_restart_after_write(Some(
+            &CodexDesktopRuntimeStatus::NotInstalled
+        )));
+        assert!(live_codex_requires_restart_after_write(Some(
+            &CodexDesktopRuntimeStatus::Running
+        )));
+        assert!(live_codex_requires_restart_after_write(Some(
+            &CodexDesktopRuntimeStatus::UntrustedTarget
+        )));
+        assert!(live_codex_requires_restart_after_write(None));
     }
 }

--- a/src-tauri/src/services/managed_auth/login.rs
+++ b/src-tauri/src/services/managed_auth/login.rs
@@ -9,8 +9,8 @@ use chrono::{SecondsFormat, Utc};
 use zeroize::Zeroizing;
 
 use super::consumers::codex::{
-    file_projection_enabled, project_codex_official_account, restore_unofficial_codex_selector,
-    CodexChatGptAuthDocument,
+    file_projection_enabled, live_codex_requires_restart_for_app, project_codex_official_account,
+    restore_unofficial_codex_selector, CodexChatGptAuthDocument,
 };
 use super::core::{stable_connection_id, stable_revision, ConnectionRecord, ConnectionStatus};
 use super::login_sessions::{map_openai_reason, LoginSessionHandle};
@@ -91,7 +91,9 @@ where
             ));
         }
         let mut method = request.method;
-        if method == ManagedAuthLoginMethod::BrowserLoopback && self.loopback_both_busy() {
+        let loopback_busy =
+            method == ManagedAuthLoginMethod::BrowserLoopback && self.loopback_both_busy();
+        if loopback_busy {
             method = ManagedAuthLoginMethod::DeviceCode;
         }
         let (snapshot, handle) = self.login_sessions.create(
@@ -216,6 +218,10 @@ where
                 } else {
                     false
                 };
+                let pending_restart = restored
+                    && self
+                        .with_app_state(live_codex_requires_restart_for_app)
+                        .unwrap_or(true);
                 if let Some(connection) = rows
                     .into_iter()
                     .find(|row| row.connection_id == request.connection_id)
@@ -223,7 +229,7 @@ where
                     let mut cleared = connection;
                     cleared.credential_id = None;
                     cleared.status = ConnectionStatus::Disconnected;
-                    cleared.pending_restart = restored;
+                    cleared.pending_restart = pending_restart;
                     cleared.updated_at = chrono::Utc::now().timestamp();
                     self.repository
                         .upsert_connection(&cleared)
@@ -231,7 +237,7 @@ where
                 }
                 Ok(self.mutation_result(
                     ManagedAuthMutationOutcome::Completed,
-                    restored.then_some(ManagedAuthReasonCode::PendingRestart),
+                    pending_restart.then_some(ManagedAuthReasonCode::PendingRestart),
                 ))
             }
             super::ManagedAuthConnectionAction::ConnectAccount

--- a/src-tauri/src/services/managed_auth/login.rs
+++ b/src-tauri/src/services/managed_auth/login.rs
@@ -9,7 +9,8 @@ use chrono::{SecondsFormat, Utc};
 use zeroize::Zeroizing;
 
 use super::consumers::codex::{
-    file_projection_enabled, project_codex_official_account, CodexChatGptAuthDocument,
+    file_projection_enabled, project_codex_official_account, restore_unofficial_codex_selector,
+    CodexChatGptAuthDocument,
 };
 use super::core::{stable_connection_id, stable_revision, ConnectionRecord, ConnectionStatus};
 use super::login_sessions::{map_openai_reason, LoginSessionHandle};
@@ -200,23 +201,38 @@ where
                 Ok(self.mutation_result(ManagedAuthMutationOutcome::Completed, None))
             }
             super::ManagedAuthConnectionAction::Disconnect => {
-                if let Some(connection) = self
+                let rows = self
                     .repository
                     .list_connections()
-                    .map_err(ManagedAuthErrorDto::from_core)?
+                    .map_err(ManagedAuthErrorDto::from_core)?;
+                let is_codex = rows.iter().any(|row| {
+                    row.connection_id == request.connection_id
+                        && row.consumer == ManagedAuthConsumer::Codex
+                }) || request.connection_id
+                    == stable_connection_id(ManagedAuthConsumer::Codex, "", "openai");
+                let restored = if is_codex {
+                    restore_unofficial_codex_selector(&self.codex_home())
+                        .map_err(ManagedAuthErrorDto::from_reason)?
+                } else {
+                    false
+                };
+                if let Some(connection) = rows
                     .into_iter()
                     .find(|row| row.connection_id == request.connection_id)
                 {
                     let mut cleared = connection;
                     cleared.credential_id = None;
                     cleared.status = ConnectionStatus::Disconnected;
-                    cleared.pending_restart = false;
+                    cleared.pending_restart = restored;
                     cleared.updated_at = chrono::Utc::now().timestamp();
                     self.repository
                         .upsert_connection(&cleared)
                         .map_err(ManagedAuthErrorDto::from_core)?;
                 }
-                Ok(self.mutation_result(ManagedAuthMutationOutcome::Completed, None))
+                Ok(self.mutation_result(
+                    ManagedAuthMutationOutcome::Completed,
+                    restored.then_some(ManagedAuthReasonCode::PendingRestart),
+                ))
             }
             super::ManagedAuthConnectionAction::ConnectAccount
             | super::ManagedAuthConnectionAction::SwitchAccount => {

--- a/src-tauri/src/services/managed_auth/providers/openai.rs
+++ b/src-tauri/src/services/managed_auth/providers/openai.rs
@@ -379,21 +379,16 @@ async fn write_callback_response(
 }
 
 pub(crate) fn open_system_browser(url: &str) -> Result<(), ErrorKind> {
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     {
-        std::process::Command::new("open")
-            .arg(url)
-            .spawn()
-            .map(|_| ())
-            .map_err(|error| error.kind())
-    }
-    #[cfg(target_os = "windows")]
-    {
-        std::process::Command::new("cmd")
-            .args(["/C", "start", "", url])
-            .spawn()
-            .map(|_| ())
-            .map_err(|error| error.kind())
+        crate::platform::process_launch::open_http_url_as_user_sync(url).map_err(
+            |error| match error {
+                crate::platform::process_launch::ProcessLaunchError::InvalidHttpUrl => {
+                    ErrorKind::InvalidInput
+                }
+                _ => ErrorKind::Other,
+            },
+        )
     }
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     {
@@ -729,6 +724,10 @@ mod tests {
         assert_eq!(query.get("originator").unwrap(), OPENAI_ORIGINATOR);
         assert_eq!(query.get("scope").unwrap(), OPENAI_SCOPE);
         assert!(!url.contains("code_verifier"));
+        assert!(
+            url.matches('&').count() >= 8,
+            "authorize URL must carry the full first-party query"
+        );
     }
 
     #[test]

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -404,6 +404,11 @@ pub struct AppSettings {
     pub common_config_confirmed: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub language: Option<String>,
+    /// Closed shell appearance preference. Renderer localStorage is a cache;
+    /// this device file is the restart authority. `save_settings` snapshots
+    /// cannot clobber it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub appearance_theme: Option<String>,
 
     // ===== 主页面显示的应用 =====
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -529,6 +534,7 @@ impl Default for AppSettings {
             first_run_notice_confirmed: None,
             common_config_confirmed: None,
             language: None,
+            appearance_theme: None,
             visible_apps: None,
             claude_config_dir: None,
             codex_config_dir: None,
@@ -690,6 +696,12 @@ impl AppSettings {
             .filter(|s| matches!(*s, "en" | "zh" | "zh-TW" | "ja"))
             .map(|s| s.to_string());
 
+        self.appearance_theme = self
+            .appearance_theme
+            .as_deref()
+            .and_then(parse_appearance_theme)
+            .map(str::to_string);
+
         if let Some(sync) = &mut self.webdav_sync {
             sync.normalize();
             if sync.is_empty() {
@@ -813,6 +825,49 @@ pub fn get_settings_for_frontend() -> AppSettings {
     }
     settings.webdav_backup = None;
     settings
+}
+
+pub(crate) fn parse_appearance_theme(value: &str) -> Option<&'static str> {
+    match value.trim() {
+        "light" => Some("light"),
+        "dark" => Some("dark"),
+        "system" => Some("system"),
+        _ => None,
+    }
+}
+
+pub(crate) fn appearance_theme_preference() -> Option<String> {
+    get_settings()
+        .appearance_theme
+        .as_deref()
+        .and_then(parse_appearance_theme)
+        .map(str::to_string)
+}
+
+pub(crate) fn persist_appearance_theme(theme: &str) {
+    let Some(theme) = parse_appearance_theme(theme) else {
+        return;
+    };
+    if appearance_theme_preference().as_deref() == Some(theme) {
+        return;
+    }
+    if let Err(error) = mutate_settings(|settings| {
+        settings.appearance_theme = Some(theme.to_string());
+    }) {
+        log::warn!("Unable to persist appearance preference: {error}");
+    }
+}
+
+pub(crate) fn appearance_bootstrap_script() -> Option<String> {
+    appearance_bootstrap_script_for(appearance_theme_preference().as_deref())
+}
+
+pub(crate) fn appearance_bootstrap_script_for(preference: Option<&str>) -> Option<String> {
+    let preference = parse_appearance_theme(preference?)?;
+    let encoded = serde_json::to_string(preference).ok()?;
+    Some(format!(
+        r#"try{{var key="fyagent-theme";var preference={encoded};try{{localStorage.setItem(key,preference);}}catch(e){{}}var theme=preference==="system"?((window.matchMedia&&window.matchMedia("(prefers-color-scheme: dark)").matches)?"dark":"light"):preference;document.documentElement.setAttribute("data-theme",theme);}}catch(e){{}}"#,
+    ))
 }
 
 pub fn update_settings(mut new_settings: AppSettings) -> Result<(), AppError> {
@@ -1374,5 +1429,44 @@ mod tests {
         .expect("visible apps");
 
         assert!(!visible.is_visible(&AppType::ClaudeDesktop));
+    }
+
+    #[test]
+    fn appearance_theme_accepts_only_the_closed_preference_set() {
+        assert_eq!(parse_appearance_theme(" dark "), Some("dark"));
+        assert_eq!(parse_appearance_theme("light"), Some("light"));
+        assert_eq!(parse_appearance_theme("system"), Some("system"));
+        assert_eq!(parse_appearance_theme("not-a-theme"), None);
+        assert_eq!(parse_appearance_theme(""), None);
+
+        let mut settings = AppSettings {
+            appearance_theme: Some("  DARK  ".to_string()),
+            ..AppSettings::default()
+        };
+        settings.normalize_paths();
+        assert_eq!(settings.appearance_theme.as_deref(), None);
+
+        settings.appearance_theme = Some("dark".to_string());
+        settings.normalize_paths();
+        assert_eq!(settings.appearance_theme.as_deref(), Some("dark"));
+
+        let serialized = serde_json::to_value(AppSettings::default()).expect("default settings");
+        assert!(!serialized
+            .as_object()
+            .expect("settings object")
+            .contains_key("appearanceTheme"));
+    }
+
+    #[test]
+    fn appearance_bootstrap_script_seeds_only_a_closed_preference() {
+        assert!(appearance_bootstrap_script_for(None).is_none());
+        assert!(appearance_bootstrap_script_for(Some("nope")).is_none());
+
+        let script = appearance_bootstrap_script_for(Some("dark")).expect("dark bootstrap");
+        assert!(script.contains("fyagent-theme"));
+        assert!(script.contains("\"dark\""));
+        assert!(script.contains("data-theme"));
+        assert!(!script.contains("password"));
+        assert!(!script.contains("secret"));
     }
 }

--- a/src-tauri/user-helper/src/windows.rs
+++ b/src-tauri/user-helper/src/windows.rs
@@ -616,21 +616,47 @@ fn npm_major_from(npm: &Path) -> Result<u32, HelperErrorCode> {
     parse_npm_major(&output).ok_or(HelperErrorCode::ToolHostMissing)
 }
 
+fn is_windows_command_script(path: &Path) -> bool {
+    path.extension()
+        .and_then(|value| value.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("cmd") || ext.eq_ignore_ascii_case("bat"))
+}
+
+fn command_script_line(program: &Path, args: &[&str]) -> String {
+    let quoted_program = quote_windows_path(program);
+    if args.is_empty() {
+        format!("call {quoted_program}")
+    } else {
+        let quoted_args = args
+            .iter()
+            .map(|arg| quote_windows_cmd_arg(arg))
+            .collect::<Vec<_>>()
+            .join(" ");
+        format!("call {quoted_program} {quoted_args}")
+    }
+}
+
+fn quote_windows_cmd_arg(value: &str) -> String {
+    if value.chars().any(|c| {
+        matches!(
+            c,
+            ' ' | '"' | '&' | '(' | ')' | '^' | ';' | '<' | '>' | '|' | ','
+        )
+    }) {
+        format!("\"{}\"", value.replace('"', "\\\""))
+    } else {
+        value.to_string()
+    }
+}
+
 fn run_grok_binary_with_env(
     program: &Path,
     args: &[&str],
     timeout: Duration,
     extra_env: &[(&str, &str)],
 ) -> Result<(String, i32), HelperErrorCode> {
-    let extension = program
-        .extension()
-        .and_then(|value| value.to_str())
-        .unwrap_or("")
-        .eq_ignore_ascii_case("cmd");
-    if extension {
-        let cmd = system_command_processor()?;
-        let command_line = format!("{} {}", quote_windows_path(program), args.join(" "));
-        run_program_with_env(&cmd, &["/D", "/S", "/C", &command_line], timeout, extra_env)
+    if is_windows_command_script(program) {
+        run_command_script(program, args, timeout, extra_env)
     } else {
         run_program_with_env(program, args, timeout, extra_env)
     }
@@ -641,18 +667,20 @@ fn run_grok_binary(
     args: &[&str],
     timeout: Duration,
 ) -> Result<(String, i32), HelperErrorCode> {
-    let extension = program
-        .extension()
-        .and_then(|value| value.to_str())
-        .unwrap_or("")
-        .eq_ignore_ascii_case("cmd");
-    if extension {
-        let cmd = system_command_processor()?;
-        let command_line = format!("{} {}", quote_windows_path(program), args.join(" "));
-        run_program(&cmd, &["/D", "/S", "/C", &command_line], timeout)
-    } else {
-        run_program(program, args, timeout)
-    }
+    run_grok_binary_with_env(program, args, timeout, &[])
+}
+
+fn run_command_script(
+    program: &Path,
+    args: &[&str],
+    timeout: Duration,
+    extra_env: &[(&str, &str)],
+) -> Result<(String, i32), HelperErrorCode> {
+    let cmd = system_command_processor()?;
+    let command_line = command_script_line(program, args);
+    let mut command = Command::new(&cmd);
+    command.args(["/D", "/S", "/C"]).raw_arg(&command_line);
+    run_spawned_command(command, timeout, extra_env)
 }
 
 fn run_program(
@@ -670,8 +698,16 @@ fn run_program_with_env(
     extra_env: &[(&str, &str)],
 ) -> Result<(String, i32), HelperErrorCode> {
     let mut command = Command::new(program);
+    command.args(args);
+    run_spawned_command(command, timeout, extra_env)
+}
+
+fn run_spawned_command(
+    mut command: Command,
+    timeout: Duration,
+    extra_env: &[(&str, &str)],
+) -> Result<(String, i32), HelperErrorCode> {
     command
-        .args(args)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -2641,6 +2677,22 @@ mod tests {
             ANCESTOR_DANGEROUS_ACCESS,
             false
         ));
+    }
+
+    #[test]
+    fn command_script_line_keeps_spaced_npm_shim_callable() {
+        assert_eq!(
+            command_script_line(
+                Path::new(r"C:\Program Files\nodejs\npm.cmd"),
+                &["prefix", "-g"],
+            ),
+            r#"call "C:\Program Files\nodejs\npm.cmd" prefix -g"#
+        );
+        assert!(!command_script_line(
+            Path::new(r"C:\Program Files\nodejs\npm.cmd"),
+            &["i", "-g", "@anthropic-ai/claude-code@2.1.261"],
+        )
+        .contains(r#"\""#));
     }
 
     fn wide(value: &str) -> Vec<u16> {

--- a/src-tauri/user-helper/src/windows/claude.rs
+++ b/src-tauri/user-helper/src/windows/claude.rs
@@ -82,6 +82,13 @@ pub(super) fn execute(
     action: GrokToolAction,
     plan: Option<GrokNpmInstallPlan>,
 ) -> Result<ToolOperationResult, HelperErrorCode> {
+    execute_inner(action, plan)
+}
+
+fn execute_inner(
+    action: GrokToolAction,
+    plan: Option<GrokNpmInstallPlan>,
+) -> Result<ToolOperationResult, HelperErrorCode> {
     let before = observe_candidate()?;
     if action == GrokToolAction::Observe {
         return Ok(ToolOperationResult::observed(
@@ -105,7 +112,9 @@ pub(super) fn execute(
             }
         }
         (GrokToolAction::Update, None) => return Err(HelperErrorCode::ToolNotDetected),
-        _ => return Err(HelperErrorCode::ToolOwnerMismatch),
+        _ => {
+            return Err(HelperErrorCode::ToolOwnerMismatch);
+        }
     }
     let npm = find_path_program(&["npm.cmd", "npm.exe"]).ok_or(HelperErrorCode::ToolHostMissing)?;
     let node = npm
@@ -145,7 +154,9 @@ pub(super) fn execute(
     if observe_candidate()? != before {
         return Err(HelperErrorCode::ToolOwnerMismatch);
     }
-    execute_npm_plan(&npm, OfficialNpmTool::Claude, &plan)?;
+    if let Err(code) = execute_npm_plan(&npm, OfficialNpmTool::Claude, &plan) {
+        return Err(code);
+    }
     // Inspect the admitted npm prefix even when a newly installed launcher has
     // not yet appeared on a reopened terminal's PATH.
     let binary = prefix

--- a/src/app/styles/appearance.css
+++ b/src/app/styles/appearance.css
@@ -15,11 +15,15 @@ html[data-theme-reveal="active"]::view-transition-image-pair(root) {
   isolation: auto;
 }
 
+/* Keep the snapshot in the viewport's own space. A centered view-transition
+ * origin would shift a circular clip off the theme control. */
 html[data-theme-reveal="active"]::view-transition-group(root),
 html[data-theme-reveal="active"]::view-transition-old(root),
 html[data-theme-reveal="active"]::view-transition-new(root) {
   animation: none;
   mix-blend-mode: normal;
+  transform: none;
+  transform-origin: 0 0;
 }
 
 html[data-theme-reveal="active"]::view-transition-old(root) {

--- a/src/app/styles/controls.css
+++ b/src/app/styles/controls.css
@@ -422,7 +422,8 @@
   min-height: 0;
   overflow: auto;
   overscroll-behavior: contain;
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
+  word-break: normal;
   scrollbar-gutter: stable;
 }
 .fy-control-dialog-content {
@@ -458,7 +459,8 @@
   color: var(--fy-text-secondary);
   font-size: var(--fy-font-control);
   line-height: var(--fy-line-body);
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
+  word-break: normal;
 }
 .fy-control-dialog-body {
   padding: 16px 24px 0;
@@ -472,13 +474,29 @@
 .fy-control-dialog-actions {
   display: flex;
   flex: 0 0 auto;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   justify-content: flex-end;
+  align-items: center;
   gap: 8px;
   padding: 20px 24px;
+  overflow: visible;
+  isolation: isolate;
 }
-.fy-control-dialog-actions > .fy-control-button {
-  min-width: 72px;
+.fy-control-dialog-actions .fy-control-button {
+  flex: 0 0 auto;
+  flex-shrink: 0;
+  min-width: 92px;
+  max-width: none;
+  width: auto;
+  white-space: nowrap;
+  overflow-wrap: normal;
+  word-break: keep-all;
+  line-height: 1.2;
+  isolation: isolate;
+  transition: none;
+}
+.fy-control-dialog-actions .fy-control-button:disabled {
+  transform: none !important;
 }
 .fy-toast-host {
   position: fixed;

--- a/src/app/styles/features.css
+++ b/src/app/styles/features.css
@@ -220,9 +220,15 @@
       0,
       1fr
     );
-  gap: var(--fy-space-sm) var(--fy-definition-gap);
+  column-gap: var(--fy-definition-gap);
+  row-gap: 0;
   margin: 0;
   font-size: 12px;
+}
+.fy-feature-definition dt,
+.fy-feature-definition dd {
+  padding-block: var(--fy-space-sm);
+  border-bottom: var(--fy-radius-separator) solid var(--fy-divider);
 }
 .fy-feature-definition dt {
   min-width: 0;
@@ -233,10 +239,18 @@
   min-width: 0;
   margin: 0;
   overflow-wrap: anywhere;
+  text-align: end;
 }
-.fy-feature-definition
-  dd:has(> .fy-feature-path:not(:has(.fy-feature-path-value))) {
-  min-width: min-content;
+.fy-feature-definition dt:nth-last-child(2),
+.fy-feature-definition dd:last-child {
+  border-bottom: none;
+}
+.fy-feature-definition dt:has(+ dd .fy-feature-path),
+.fy-feature-definition dd:has(.fy-feature-path) {
+  border-bottom: none;
+}
+.fy-feature-definition dd:has(> .fy-feature-path) {
+  justify-self: stretch;
 }
 .fy-feature-code {
   font-family: ui-monospace, Consolas, monospace;
@@ -244,8 +258,13 @@
 .fy-feature-path {
   display: flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 8px;
   min-width: 0;
+  width: 100%;
+}
+.fy-feature-path:has(.fy-feature-path-value) {
+  justify-content: space-between;
 }
 .fy-feature-path-value {
   flex: 1 1 auto;
@@ -458,12 +477,19 @@
   color: var(--fy-text);
   font-size: 13px;
 }
+.fy-feature-info-card .fy-feature-actions {
+  justify-content: flex-end;
+}
 @container fy-info-card (max-width: 210px) {
   .fy-feature-definition {
     grid-template-columns: minmax(0, 1fr);
   }
   .fy-feature-definition dd {
-    margin-bottom: var(--fy-space-sm);
+    margin-bottom: 0;
+    text-align: start;
+  }
+  .fy-feature-definition dd:has(> .fy-feature-path) {
+    text-align: end;
   }
 }
 .fy-feature-app-chips {

--- a/src/app/styles/tokens.css
+++ b/src/app/styles/tokens.css
@@ -99,6 +99,7 @@
   --fy-motion-dialog-resize: 320ms;
   --fy-motion-toast: 240ms;
   --fy-motion-theme: 560ms;
+  --fy-motion-theme-ease: cubic-bezier(0.25, 0.08, 0.25, 1);
   --fy-motion-spinner: 900ms;
   --fy-motion-spinner-reduced: 1800ms;
   --fy-motion-ease: cubic-bezier(0.32, 0.72, 0, 1);

--- a/src/pages/agents/AgentDirectory.tsx
+++ b/src/pages/agents/AgentDirectory.tsx
@@ -1,4 +1,4 @@
-import { useCallback, type ReactNode } from "react";
+import { useCallback, useRef, useState, type ReactNode } from "react";
 
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -22,7 +22,11 @@ import {
 } from "../../shared/features/types";
 import { BrandIconFrame } from "../../shared/ui/catalog";
 import { Button } from "../../shared/ui/Button";
+import { Dialog } from "../../shared/ui/Dialog";
+import type { DialogOriginRef } from "../../shared/ui/dialogOrigin";
+import { useDialogState } from "../../shared/ui/useDialogState";
 import { InlineNotice } from "../../shared/ui/primitives";
+import { LifecycleTargetPicker } from "../../shared/ui/LifecycleTargetPicker";
 
 import {
   AgentLifecycleActionSlot,
@@ -200,6 +204,16 @@ function DirectoryActionFeedback({
   );
 }
 
+function preferredInstallTarget(
+  targets: readonly AgentInstallationTarget[],
+): AgentInstallationTarget | null {
+  return (
+    targets.find((target) => target.label.startsWith("/Applications")) ??
+    targets[0] ??
+    null
+  );
+}
+
 function GenericDirectoryCard({
   entry,
   observation,
@@ -213,6 +227,10 @@ function GenericDirectoryCard({
 }) {
   const { ports } = useFeatures();
   const queryClient = useQueryClient();
+  const pickerOriginRef = useRef<HTMLElement | null>(null);
+  const [pickingTarget, setPickingTarget] = useDialogState<true>(null);
+  const [selectedTarget, setSelectedTarget] =
+    useState<AgentInstallationTarget | null>(null);
   const primaryAction = deriveAgentLifecyclePrimaryAction(
     entry.id,
     observation.readiness ?? null,
@@ -253,31 +271,93 @@ function GenericDirectoryCard({
           : eligibleTargets.length === 1
             ? "single"
             : "selection_required";
+  const openTargetPicker = () => {
+    const preferred = preferredInstallTarget(eligibleTargets);
+    setSelectedTarget(preferred);
+    setPickingTarget(true);
+  };
   return (
-    <DirectoryCardShell
-      entry={entry}
-      observation={observation}
-      lifecycleBusy={lifecycle.busy}
-      error={lifecycle.error}
-      success={lifecycle.success}
-      authSlot={
-        <AgentAuthStatusPanel
-          agentId={entry.id}
-          mode="compact"
-          enabled={observation.configurable}
-        />
-      }
-      onConfigure={onConfigure}
-      lifecycleSlot={
-        <GenericLifecycleSlot
-          observation={observation}
-          scanningCopy={scanningCopy}
-          lifecycle={lifecycle}
-          targetStatus={targetStatus}
-          onConfigure={() => onConfigure(entry.id)}
-        />
-      }
-    />
+    <>
+      <DirectoryCardShell
+        entry={entry}
+        observation={observation}
+        lifecycleBusy={lifecycle.busy}
+        error={lifecycle.error}
+        success={lifecycle.success}
+        authSlot={
+          <AgentAuthStatusPanel
+            agentId={entry.id}
+            mode="compact"
+            enabled={observation.configurable}
+          />
+        }
+        onConfigure={onConfigure}
+        lifecycleSlot={
+          <GenericLifecycleSlot
+            observation={observation}
+            scanningCopy={scanningCopy}
+            lifecycle={lifecycle}
+            targetStatus={targetStatus}
+            originRef={pickerOriginRef}
+            onConfigure={openTargetPicker}
+          />
+        }
+      />
+      <Dialog
+        open={pickingTarget !== null}
+        size="comfortable"
+        originRef={pickerOriginRef}
+        title={`选择 ${entry.displayName} 的安装位置`}
+        description="选择要安装到的目录。根目录 Applications 是推荐位置。"
+        onOpenChange={(open) => {
+          if (!open) setPickingTarget(null);
+        }}
+        actions={
+          pickingTarget ? (
+            <>
+              <Button onClick={() => setPickingTarget(null)}>取消</Button>
+              <Button
+                className="fy-control-button-primary"
+                disabled={
+                  selectedTarget === null ||
+                  !lifecycle.primaryAction ||
+                  !selectedTarget.eligibleActions.includes(
+                    lifecycle.primaryAction,
+                  )
+                }
+                onClick={() => {
+                  if (!lifecycle.primaryAction || !selectedTarget) return;
+                  setPickingTarget(null);
+                  void lifecycle.run(lifecycle.primaryAction, selectedTarget);
+                }}
+              >
+                {lifecycle.primaryAction === "update"
+                  ? "确认更新"
+                  : "确认安装"}
+              </Button>
+            </>
+          ) : undefined
+        }
+      >
+        {pickingTarget ? (
+          <LifecycleTargetPicker
+            id={`agent-directory-target-${entry.id}`}
+            action={lifecycle.primaryAction ?? "install"}
+            targets={eligibleTargets}
+            value={selectedTarget?.targetId ?? null}
+            onChange={setSelectedTarget}
+            loading={inventory.isPending}
+            error={
+              inventory.isError
+                ? "暂时无法读取安装位置。请刷新后重试。"
+                : null
+            }
+            disabled={lifecycle.busy}
+            onRefresh={() => void inventory.refetch()}
+          />
+        ) : null}
+      </Dialog>
+    </>
   );
 }
 
@@ -291,6 +371,7 @@ function genericLifecycleSlotView(
     | "unavailable"
     | "single"
     | "selection_required",
+  originRef: DialogOriginRef,
   onConfigure: () => void,
 ): AgentLifecycleActionSlotView {
   if (lifecycle.busy) {
@@ -304,7 +385,7 @@ function genericLifecycleSlotView(
       return { kind: "status", label: "正在读取安装目标" };
     }
     if (targetStatus !== "single") {
-      return { kind: "select_target", onClick: onConfigure };
+      return { kind: "select_target", onClick: onConfigure, originRef };
     }
     return {
       kind: "primary",
@@ -329,6 +410,7 @@ function GenericLifecycleSlot({
   scanningCopy,
   lifecycle,
   targetStatus,
+  originRef,
   onConfigure,
 }: {
   observation: AgentDirectoryRowObservation;
@@ -340,6 +422,7 @@ function GenericLifecycleSlot({
     | "unavailable"
     | "single"
     | "selection_required";
+  originRef: DialogOriginRef;
   onConfigure: () => void;
 }) {
   return (
@@ -349,6 +432,7 @@ function GenericLifecycleSlot({
         scanningCopy,
         lifecycle,
         targetStatus,
+        originRef,
         onConfigure,
       )}
     />

--- a/src/pages/agents/AgentDirectory.tsx
+++ b/src/pages/agents/AgentDirectory.tsx
@@ -377,6 +377,9 @@ function genericLifecycleSlotView(
   if (lifecycle.busy) {
     return { kind: "status", label: genericBusyCopy(lifecycle) };
   }
+  if (lifecycle.canRetry) {
+    return { kind: "retry", onClick: () => void lifecycle.retry() };
+  }
   if (scanningCopy && !lifecycle.primaryAction) {
     return { kind: "status", label: scanningCopy };
   }
@@ -392,9 +395,6 @@ function genericLifecycleSlotView(
       action: lifecycle.primaryAction,
       onClick: () => void lifecycle.runPrimary(),
     };
-  }
-  if (lifecycle.canRetry) {
-    return { kind: "retry", onClick: () => void lifecycle.retry() };
   }
   if (scanningCopy) {
     return { kind: "status", label: scanningCopy };
@@ -489,6 +489,9 @@ function codexLifecycleSlotView(
   if (projection.busy) {
     return { kind: "status", label: codexBusyCopy(projection) };
   }
+  if (projection.canRetry) {
+    return { kind: "retry", onClick: () => void onRun() };
+  }
   if (observation.kind === "pending" && !observation.refreshing) {
     return { kind: "status", label: "正在扫描" };
   }
@@ -498,9 +501,6 @@ function codexLifecycleSlotView(
       action: projection.primaryAction,
       onClick: () => void onRun(),
     };
-  }
-  if (projection.canRetry) {
-    return { kind: "retry", onClick: () => void onRun() };
   }
   if (scanningCopy) {
     return { kind: "status", label: scanningCopy };

--- a/src/pages/agents/AgentDirectory.tsx
+++ b/src/pages/agents/AgentDirectory.tsx
@@ -331,9 +331,7 @@ function GenericDirectoryCard({
                   void lifecycle.run(lifecycle.primaryAction, selectedTarget);
                 }}
               >
-                {lifecycle.primaryAction === "update"
-                  ? "确认更新"
-                  : "确认安装"}
+                {lifecycle.primaryAction === "update" ? "确认更新" : "确认安装"}
               </Button>
             </>
           ) : undefined
@@ -348,9 +346,7 @@ function GenericDirectoryCard({
             onChange={setSelectedTarget}
             loading={inventory.isPending}
             error={
-              inventory.isError
-                ? "暂时无法读取安装位置。请刷新后重试。"
-                : null
+              inventory.isError ? "暂时无法读取安装位置。请刷新后重试。" : null
             }
             disabled={lifecycle.busy}
             onRefresh={() => void inventory.refetch()}

--- a/src/pages/agents/AgentInstallReadinessSection.tsx
+++ b/src/pages/agents/AgentInstallReadinessSection.tsx
@@ -163,13 +163,10 @@ function orderedLifecycleActions(
   });
 }
 
-function componentTitle(
-  agentId: AgentCatalogId,
-  surface: SurfaceKind,
-): { title: string; showTitle: boolean } {
-  if (agentId === "claude-code") {
-    return { title: "Claude Desktop", showTitle: true };
-  }
+function componentTitle(surface: SurfaceKind): {
+  title: string;
+  showTitle: boolean;
+} {
   return {
     title: surface === "cli" ? "命令行" : "桌面应用",
     showTitle: false,
@@ -180,7 +177,7 @@ function projectionFromSurface(
   agentId: AgentCatalogId,
   item: AgentSurfaceReadiness,
 ): SurfaceProjection {
-  const { title, showTitle } = componentTitle(agentId, item.surface);
+  const { title, showTitle } = componentTitle(item.surface);
   return {
     surface: item.surface,
     title,
@@ -228,7 +225,7 @@ function surfacesForProduct(
     ];
   }
   const surface: SurfaceKind = hideLaunch ? "cli" : "desktop";
-  const { title, showTitle } = componentTitle(agentId, surface);
+  const { title, showTitle } = componentTitle(surface);
   return [
     {
       surface,

--- a/src/pages/agents/AgentLifecycleActionSlot.tsx
+++ b/src/pages/agents/AgentLifecycleActionSlot.tsx
@@ -23,7 +23,7 @@ function SelectTargetButton({
   onClick,
 }: {
   originRef?: DialogOriginRef;
-  returnRef: RefObject<HTMLElement | null>;
+  returnRef: RefObject<HTMLElement>;
   onClick: () => void;
 }) {
   return (
@@ -49,7 +49,7 @@ export function AgentLifecycleActionSlot({
 }: {
   view: AgentLifecycleActionSlotView;
 }): ReactNode {
-  const hostRef = useRef<HTMLElement | null>(null);
+  const hostRef = useRef<HTMLDivElement>(null);
   if (view.kind === "empty") return null;
   return (
     <div ref={hostRef} className="fy-agent-directory-lifecycle-host">

--- a/src/pages/agents/AgentLifecycleActionSlot.tsx
+++ b/src/pages/agents/AgentLifecycleActionSlot.tsx
@@ -1,6 +1,7 @@
-import type { ReactNode } from "react";
+import { useRef, type ReactNode, type RefObject } from "react";
 
 import { Button } from "../../shared/ui/Button";
+import type { DialogOriginRef } from "../../shared/ui/dialogOrigin";
 import { Spinner } from "../../shared/ui/primitives";
 
 function directoryPrimaryActionLabel(action: "install" | "update"): string {
@@ -16,11 +17,31 @@ function StatusSlot({ label }: { label: string }) {
   );
 }
 
+function SelectTargetButton({
+  originRef,
+  returnRef,
+  onClick,
+}: {
+  originRef?: DialogOriginRef;
+  returnRef: RefObject<HTMLElement | null>;
+  onClick: () => void;
+}) {
+  return (
+    <Button
+      dialogOriginRef={originRef}
+      dialogReturnRef={returnRef}
+      onClick={onClick}
+    >
+      选择安装目标
+    </Button>
+  );
+}
+
 export type AgentLifecycleActionSlotView =
   | { kind: "status"; label: string }
   | { kind: "primary"; action: "install" | "update"; onClick: () => void }
   | { kind: "retry"; onClick: () => void }
-  | { kind: "select_target"; onClick: () => void }
+  | { kind: "select_target"; onClick: () => void; originRef?: DialogOriginRef }
   | { kind: "empty" };
 
 export function AgentLifecycleActionSlot({
@@ -28,20 +49,25 @@ export function AgentLifecycleActionSlot({
 }: {
   view: AgentLifecycleActionSlotView;
 }): ReactNode {
-  switch (view.kind) {
-    case "status":
-      return <StatusSlot label={view.label} />;
-    case "primary":
-      return (
+  const hostRef = useRef<HTMLElement | null>(null);
+  if (view.kind === "empty") return null;
+  return (
+    <div ref={hostRef} className="fy-agent-directory-lifecycle-host">
+      {view.kind === "status" ? (
+        <StatusSlot label={view.label} />
+      ) : view.kind === "primary" ? (
         <Button onClick={view.onClick}>
           {directoryPrimaryActionLabel(view.action)}
         </Button>
-      );
-    case "retry":
-      return <Button onClick={view.onClick}>重试</Button>;
-    case "select_target":
-      return <Button onClick={view.onClick}>选择安装目标</Button>;
-    case "empty":
-      return null;
-  }
+      ) : view.kind === "retry" ? (
+        <Button onClick={view.onClick}>重试</Button>
+      ) : (
+        <SelectTargetButton
+          originRef={view.originRef}
+          returnRef={hostRef}
+          onClick={view.onClick}
+        />
+      )}
+    </div>
+  );
 }

--- a/src/pages/agents/Page.css
+++ b/src/pages/agents/Page.css
@@ -755,7 +755,7 @@
   display: inline-flex;
   align-items: center;
   padding: 1px 6px;
-  border-radius: 999px;
+  border-radius: var(--fy-radius-pill);
   color: var(--fy-accent-ink);
   font-size: 10px;
   font-weight: 650;
@@ -1104,7 +1104,9 @@
   }
 
   .fy-agent-directory-card-actions > .fy-control-button,
-  .fy-agent-directory-card-actions > .fy-agent-directory-lifecycle-host > .fy-control-button {
+  .fy-agent-directory-card-actions
+    > .fy-agent-directory-lifecycle-host
+    > .fy-control-button {
     width: 100%;
     justify-content: center;
   }

--- a/src/pages/agents/Page.css
+++ b/src/pages/agents/Page.css
@@ -135,6 +135,12 @@
   min-width: 0;
 }
 
+.fy-agent-directory-lifecycle-host {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+}
+
 .fy-agent-directory-lifecycle-status {
   display: inline-flex;
   align-items: center;
@@ -738,8 +744,23 @@
 }
 
 .fy-agent-target-option-copy strong {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
   overflow-wrap: anywhere;
   font-size: 12px;
+}
+.fy-agent-target-recommend {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 6px;
+  border-radius: 999px;
+  color: var(--fy-accent-ink);
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0.02em;
+  background: var(--fy-accent);
 }
 
 .fy-agent-target-option-copy small {
@@ -1077,8 +1098,14 @@
     justify-self: stretch;
   }
 
-  .fy-agent-directory-card-actions > .fy-control-button {
+  .fy-agent-directory-card-actions > .fy-control-button,
+  .fy-agent-directory-card-actions > .fy-agent-directory-lifecycle-host {
     flex: 1 1 auto;
+  }
+
+  .fy-agent-directory-card-actions > .fy-control-button,
+  .fy-agent-directory-card-actions > .fy-agent-directory-lifecycle-host > .fy-control-button {
+    width: 100%;
     justify-content: center;
   }
 

--- a/src/pages/agents/useAgentLifecycleAction.ts
+++ b/src/pages/agents/useAgentLifecycleAction.ts
@@ -278,7 +278,11 @@ export function lifecycleSuccessCopy(vendorHandoff: boolean): string {
 
 export function agentLifecycleFailureCopy(
   code: AgentReasonCode | null,
+  sourceKind?: AgentSourceKind | null,
 ): string {
+  if (code === "installer_exited_nonzero" && sourceKind === "cli_tooling") {
+    return "安装未完成，请检查网络及当前用户的安装权限后重试。";
+  }
   return (code && reasonCopy(code)) || AGENT_LIFECYCLE_INCOMPLETE_COPY;
 }
 
@@ -337,6 +341,7 @@ export function useAgentLifecycleAction({
   const runningRef = useRef(false);
   const lastActionRef = useRef<AgentActionId | null>(null);
   const lastSurfaceRef = useRef<AgentSurface | undefined>(undefined);
+  const admitRetryRef = useRef(false);
   const vendorHandoffRef = useRef(false);
   const speedRef = useRef(createDownloadSpeedState());
   const readinessRef = useRef(readiness);
@@ -383,6 +388,7 @@ export function useAgentLifecycleAction({
         ),
       ]);
       if (generationRef.current !== generation) return false;
+      readinessRef.current = data;
       onReadinessChangeRef.current?.(data);
       onInventoryChangeRef.current?.(inventory);
       return true;
@@ -418,8 +424,13 @@ export function useAgentLifecycleAction({
       targetOverride?: AgentInstallationTarget | null,
       nextSurface?: AgentSurface,
     ) => {
+      const admitRetry = admitRetryRef.current;
+      admitRetryRef.current = false;
       const current = readinessRef.current;
-      if (!current || runningRef.current) {
+      if (runningRef.current) {
+        return;
+      }
+      if (!current) {
         return;
       }
       if (action !== "install" && action !== "update" && action !== "launch") {
@@ -427,7 +438,7 @@ export function useAgentLifecycleAction({
       }
       const resolvedSurface = nextSurface ?? surfaceRef.current;
       const gate = resolveLifecycleReadiness(current, resolvedSurface);
-      if (!gate.allowedActions.includes(action)) {
+      if (!gate.allowedActions.includes(action) && !admitRetry) {
         return;
       }
       const previousTarget = targetOverride ?? targetRef.current ?? null;
@@ -483,7 +494,7 @@ export function useAgentLifecycleAction({
           setStage(null);
           const reason = actionErrorReason(caught) ?? "inventory_expired";
           setReasonCode(reason);
-          setError(agentLifecycleFailureCopy(reason));
+          setError(agentLifecycleFailureCopy(reason, gate.sourceKind));
           return;
         }
       }
@@ -584,7 +595,7 @@ export function useAgentLifecycleAction({
         setError(AGENT_LIFECYCLE_TIMEOUT_COPY);
       } else {
         setSuccess(null);
-        setError(agentLifecycleFailureCopy(outcomeReason));
+        setError(agentLifecycleFailureCopy(outcomeReason, gate.sourceKind));
       }
       runningRef.current = false;
       setBusy(false);
@@ -607,18 +618,22 @@ export function useAgentLifecycleAction({
 
   const retry = useCallback(async () => {
     const last = lastActionRef.current;
-    const current = readinessRef.current;
-    if (!last || !current) {
+    const lastSurface = lastSurfaceRef.current;
+    if (runningRef.current) {
+      return;
+    }
+    const generation = generationRef.current;
+    await reread(generation);
+    if (generationRef.current !== generation) {
+      return;
+    }
+    if (!last) {
       await runPrimary();
       return;
     }
-    const gate = resolveLifecycleReadiness(current, lastSurfaceRef.current);
-    if (gate.allowedActions.includes(last)) {
-      await run(last, undefined, lastSurfaceRef.current);
-      return;
-    }
-    await runPrimary();
-  }, [run, runPrimary]);
+    admitRetryRef.current = true;
+    await run(last, undefined, lastSurface);
+  }, [reread, run, runPrimary]);
 
   const cancel = useCallback(async () => {
     if (!jobId || !cancellable) return;
@@ -631,7 +646,15 @@ export function useAgentLifecycleAction({
     } catch (caught) {
       if (generationRef.current !== generation) return;
       setReasonCode(actionErrorReason(caught));
-      setError(agentLifecycleFailureCopy(actionErrorReason(caught)));
+      const sourceKind = readinessRef.current
+        ? resolveLifecycleReadiness(
+            readinessRef.current,
+            lastSurfaceRef.current,
+          ).sourceKind
+        : undefined;
+      setError(
+        agentLifecycleFailureCopy(actionErrorReason(caught), sourceKind),
+      );
     }
   }, [applyJobSnapshot, cancellable, jobId]);
 

--- a/src/pages/auth/AccountView.tsx
+++ b/src/pages/auth/AccountView.tsx
@@ -28,6 +28,7 @@ import {
   accountPageConnectionActionLabel,
   accountPageConnectionActions,
   connectableConnectionsForAccount,
+  linkedConnectionsForAccount,
   connectionStatusPresentation,
   loginRequiredConnectionsForAccount,
   formatAuthenticatedAt,
@@ -106,7 +107,7 @@ function AccountConnection({
               disabled={mutationBusy}
               onClick={() => onAction(connection, action)}
             >
-              {accountPageConnectionActionLabel(action)}
+              {accountPageConnectionActionLabel(action, connection)}
             </Button>
           ))}
           {loginConnectLabel ? (
@@ -153,9 +154,7 @@ function AccountDetail({
   const canReauthenticate = account.allowedActions.includes("reauthenticate");
   const canSetDefault = account.allowedActions.includes("set_default");
   const canRemove = account.allowedActions.includes("remove");
-  const linkedConnections = connections.filter(
-    (connection) => connection.accountId === account.accountId,
-  );
+  const linkedConnections = linkedConnectionsForAccount(account, connections);
   const connectableConnections = connectableConnectionsForAccount(
     account,
     connections,

--- a/src/pages/auth/ConnectionsView.tsx
+++ b/src/pages/auth/ConnectionsView.tsx
@@ -178,7 +178,7 @@ function ConnectionCard({
               disabled={mutationBusy}
               onClick={() => onAction(connection, action)}
             >
-              {connectionActionLabel(action)}
+              {connectionActionLabel(action, connection)}
             </Button>
           ))}
         </div>

--- a/src/pages/auth/MutationDialogs.tsx
+++ b/src/pages/auth/MutationDialogs.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 
 import type {
   ManagedAuthAccountRemovalPreview,
@@ -133,7 +133,8 @@ function connectionActionCopy(
     case "switch_account":
       return {
         title: `切换 ${consumer} 账号`,
-        description: "只更换登录凭证，不修改模型来源。请先确认文件和备份位置。",
+        description:
+          "请选择账号，并确认本次认证文件、模型来源和备份位置的影响。",
       };
     case "disconnect":
       return {
@@ -194,9 +195,27 @@ function ConnectionActionDialogContent({
           account.health === "ready",
       )
     : overview.accounts.filter((account) => account.health === "ready");
-  const [selectedAccountId, setSelectedAccountId] = useState<string | null>(
-    null,
-  );
+  const initialAccountId = requiresAccount
+    ? (candidates.find((account) => account.accountId === preferredAccountId)
+        ?.accountId ??
+      candidates.find((account) => account.accountId !== connection?.accountId)
+        ?.accountId ??
+      candidates[0]?.accountId ??
+      null)
+    : null;
+  const selectionScope = JSON.stringify([
+    connection?.connectionId ?? null,
+    action,
+    preferredAccountId ?? null,
+  ]);
+  const [previousScope, setPreviousScope] = useState(selectionScope);
+  const [selectedAccountId, setSelectedAccountId] = useState(initialAccountId);
+  // Reset only the local selection, not the Dialog's presentation lifetime.
+  // The guarded render adjustment prevents committing a stale preview request.
+  if (previousScope !== selectionScope) {
+    setPreviousScope(selectionScope);
+    setSelectedAccountId(initialAccountId);
+  }
   const copy =
     connection && action
       ? connectionActionCopy(connection, action)
@@ -214,6 +233,8 @@ function ConnectionActionDialogContent({
     null,
   );
   const consumedPreviewRef = useRef<string | null>(null);
+  // A preview is single-use across close/reopen too. A fresh native preview,
+  // rather than clearing this guard, authorizes another confirmation.
   const canConfirm =
     open &&
     !pending &&
@@ -222,32 +243,15 @@ function ConnectionActionDialogContent({
     preview.data?.canApply === true &&
     preview.data.previewId !== consumedPreviewId &&
     (!requiresAccount || selectedAccountId !== null);
-  useLayoutEffect(() => {
-    if (!connection || !action) return;
-    consumedPreviewRef.current = null;
-    setConsumedPreviewId(null);
-    setSelectedAccountId(
-      requiresAccount
-        ? (candidates.find((account) => account.accountId === preferredAccountId)
-            ?.accountId ??
-            candidates.find(
-              (account) => account.accountId !== connection.accountId,
-            )?.accountId ??
-            candidates[0]?.accountId ??
-            null)
-        : null,
-    );
-  }, [connection?.connectionId, action, preferredAccountId]);
-  const confirmLabel =
-    pending
-      ? "正在处理…"
-      : action === "disconnect"
-        ? connection?.authStatus === "disconnected"
-          ? "恢复"
-          : "断开"
-        : action === "switch_to_official"
-          ? "切换"
-          : "确认";
+  const confirmLabel = pending
+    ? "正在处理…"
+    : action === "disconnect"
+      ? connection?.authStatus === "disconnected"
+        ? "恢复"
+        : "断开"
+      : action === "switch_to_official"
+        ? "切换"
+        : "确认";
   return (
     <Dialog
       originRef={originRef}
@@ -311,7 +315,9 @@ function ConnectionActionDialogContent({
                     <ProviderMark provider={account.provider} />
                     <span>
                       <strong>{account.login}</strong>
-                      <small>{managedAuthProviderLabel(account.provider)}</small>
+                      <small>
+                        {managedAuthProviderLabel(account.provider)}
+                      </small>
                     </span>
                   </label>
                 ))}
@@ -357,7 +363,8 @@ function ConnectionActionDialogContent({
                 ) : action === "connect_account" ||
                   action === "switch_account" ? (
                   <p>
-                    顶层 model_provider 已是注释状态，Codex 将走官方登录；提供商表和其它配置保持不变。
+                    顶层 model_provider 已是注释状态，Codex
+                    将走官方登录；提供商表和其它配置保持不变。
                   </p>
                 ) : null
               ) : null}

--- a/src/pages/auth/MutationDialogs.tsx
+++ b/src/pages/auth/MutationDialogs.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 
 import type {
   ManagedAuthAccountRemovalPreview,
@@ -137,8 +137,14 @@ function connectionActionCopy(
       };
     case "disconnect":
       return {
-        title: `断开 ${consumer} 的账号连接？`,
-        description: "账号仍会保存在“账号”中，其他软件连接不受影响。",
+        title:
+          connection.authStatus === "disconnected"
+            ? `恢复 ${consumer} 的第三方模型来源？`
+            : `断开 ${consumer} 的账号连接？`,
+        description:
+          connection.authStatus === "disconnected"
+            ? "将取消注释顶层 model_provider，恢复原来的第三方模型来源。账号仍会保存在“账号”中。"
+            : "账号仍会保存在“账号”中，其他软件连接不受影响。",
       };
     case "switch_to_official":
       return {
@@ -164,16 +170,7 @@ interface ConnectionActionDialogProps {
 }
 
 export function ConnectionActionDialog(props: ConnectionActionDialogProps) {
-  if (!props.connection || !props.action) return null;
-  const key = `${props.connection.connectionId}:${props.action}:${props.preferredAccountId ?? ""}`;
-  return (
-    <ConnectionActionDialogContent
-      key={key}
-      {...props}
-      connection={props.connection}
-      action={props.action}
-    />
-  );
+  return <ConnectionActionDialogContent {...props} />;
 }
 
 function ConnectionActionDialogContent({
@@ -185,14 +182,12 @@ function ConnectionActionDialogContent({
   preferredAccountId,
   onCancel,
   onConfirm,
-}: Omit<ConnectionActionDialogProps, "connection" | "action"> & {
-  connection: ManagedAuthConnectionSummary;
-  action: ManagedAuthConnectionAction;
-}) {
+}: ConnectionActionDialogProps) {
+  const open = connection !== null && action !== null;
   const cancelRef = useRef<HTMLButtonElement>(null);
   const requiresAccount =
     action === "connect_account" || action === "switch_account";
-  const candidates = connection.provider
+  const candidates = connection?.provider
     ? overview.accounts.filter(
         (account) =>
           account.provider === connection.provider &&
@@ -200,151 +195,184 @@ function ConnectionActionDialogContent({
       )
     : overview.accounts.filter((account) => account.health === "ready");
   const [selectedAccountId, setSelectedAccountId] = useState<string | null>(
-    requiresAccount
-      ? (candidates.find((account) => account.accountId === preferredAccountId)
-          ?.accountId ??
-          candidates.find(
-            (account) => account.accountId !== connection.accountId,
-          )?.accountId ??
-          candidates[0]?.accountId ??
-          null)
-      : null,
+    null,
   );
-  const copy = connectionActionCopy(connection, action);
+  const copy =
+    connection && action
+      ? connectionActionCopy(connection, action)
+      : { title: "软件连接", description: "" };
   const preview = useManagedAuthConnectionPreview(
     {
-      connectionId: connection.connectionId,
-      expectedRevision: connection.revision,
-      action,
+      connectionId: connection?.connectionId ?? "closed",
+      expectedRevision: connection?.revision ?? "0",
+      action: action ?? "refresh",
       accountId: selectedAccountId,
     },
-    !pending && (!requiresAccount || selectedAccountId !== null),
+    open && !pending && (!requiresAccount || selectedAccountId !== null),
   );
   const [consumedPreviewId, setConsumedPreviewId] = useState<string | null>(
     null,
   );
   const consumedPreviewRef = useRef<string | null>(null);
   const canConfirm =
+    open &&
     !pending &&
     !preview.isError &&
     !preview.isFetching &&
     preview.data?.canApply === true &&
     preview.data.previewId !== consumedPreviewId &&
     (!requiresAccount || selectedAccountId !== null);
+  useLayoutEffect(() => {
+    if (!connection || !action) return;
+    consumedPreviewRef.current = null;
+    setConsumedPreviewId(null);
+    setSelectedAccountId(
+      requiresAccount
+        ? (candidates.find((account) => account.accountId === preferredAccountId)
+            ?.accountId ??
+            candidates.find(
+              (account) => account.accountId !== connection.accountId,
+            )?.accountId ??
+            candidates[0]?.accountId ??
+            null)
+        : null,
+    );
+  }, [connection?.connectionId, action, preferredAccountId]);
+  const confirmLabel =
+    pending
+      ? "正在处理…"
+      : action === "disconnect"
+        ? connection?.authStatus === "disconnected"
+          ? "恢复"
+          : "断开"
+        : action === "switch_to_official"
+          ? "切换"
+          : "确认";
   return (
     <Dialog
       originRef={originRef}
-      open
+      open={open}
       initialFocusRef={cancelRef}
       onOpenChange={(next) => !next && !pending && onCancel()}
       title={copy.title}
-      description={copy.description}
+      description={copy.description || undefined}
       actions={
-        <>
-          <Button ref={cancelRef} disabled={pending} onClick={onCancel}>
-            取消
-          </Button>
-          <Button
-            className={
-              action === "disconnect" ? "fy-control-button-danger" : undefined
-            }
-            disabled={!canConfirm}
-            onClick={() => {
-              if (
-                !canConfirm ||
-                !preview.data ||
-                consumedPreviewRef.current === preview.data.previewId
-              )
-                return;
-              consumedPreviewRef.current = preview.data.previewId;
-              setConsumedPreviewId(preview.data.previewId);
-              onConfirm(selectedAccountId, preview.data.previewId);
-            }}
-          >
-            {pending
-              ? "正在处理…"
-              : action === "disconnect"
-                ? "断开"
-                : action === "switch_to_official"
-                  ? "切换"
-                  : "确认"}
-          </Button>
-        </>
+        open ? (
+          <>
+            <Button ref={cancelRef} disabled={pending} onClick={onCancel}>
+              取消
+            </Button>
+            <Button
+              className={
+                action === "disconnect" ? "fy-control-button-danger" : undefined
+              }
+              disabled={!canConfirm}
+              onClick={() => {
+                if (
+                  !canConfirm ||
+                  !preview.data ||
+                  consumedPreviewRef.current === preview.data.previewId
+                )
+                  return;
+                consumedPreviewRef.current = preview.data.previewId;
+                setConsumedPreviewId(preview.data.previewId);
+                onConfirm(selectedAccountId, preview.data.previewId);
+              }}
+            >
+              {confirmLabel}
+            </Button>
+          </>
+        ) : undefined
       }
     >
-      {requiresAccount ? (
-        candidates.length === 0 ? (
-          <InlineNotice tone="warning">
-            没有可用的
-            {connection.provider
-              ? ` ${managedAuthProviderLabel(connection.provider)} `
-              : " "}
-            账号，请先添加或重新登录。
-          </InlineNotice>
-        ) : (
-          <fieldset className="fy-auth-account-choice">
-            <legend>选择账号</legend>
-            {candidates.map((account) => (
-              <label key={account.accountId}>
-                <input
-                  type="radio"
-                  name="managed-auth-connection-account"
-                  disabled={pending}
-                  checked={selectedAccountId === account.accountId}
-                  onChange={() => setSelectedAccountId(account.accountId)}
-                />
-                <ProviderMark provider={account.provider} />
-                <span>
-                  <strong>{account.login}</strong>
-                  <small>{managedAuthProviderLabel(account.provider)}</small>
-                </span>
-              </label>
-            ))}
-          </fieldset>
-        )
-      ) : action === "disconnect" ? (
-        <p>
-          当前账号连接将被移除；
-          {connection.requestMode === "third_party_api"
-            ? "当前第三方 API 配置不会被删除。"
-            : "其他软件的账号连接不会改变。"}
-        </p>
-      ) : action === "switch_to_official" ? (
-        <p>
-          当前模型来源：
-          {requestModeLabel(
-            connection.requestMode,
-            connection.requestProviderLabel,
-          )}
-        </p>
-      ) : null}
-      {preview.isFetching ? (
-        <div className="fy-auth-dialog-loading">
-          <Spinner label="正在检查文件影响" />
-          <span>正在检查文件和备份位置</span>
-        </div>
-      ) : preview.data ? (
+      {open && connection && action ? (
         <>
-          <FileWriteDisclosure
-            targets={preview.data.writeTargets}
-            preservedPaths={preview.data.preservedPaths}
-          />
-          {connection.consumer === "codex" &&
-          preview.data.writeTargets.length > 0 ? (
+          {requiresAccount ? (
+            candidates.length === 0 ? (
+              <InlineNotice tone="warning">
+                没有可用的
+                {connection.provider
+                  ? ` ${managedAuthProviderLabel(connection.provider)} `
+                  : " "}
+                账号，请先添加或重新登录。
+              </InlineNotice>
+            ) : (
+              <fieldset className="fy-auth-account-choice">
+                <legend>选择账号</legend>
+                {candidates.map((account) => (
+                  <label key={account.accountId}>
+                    <input
+                      type="radio"
+                      name="managed-auth-connection-account"
+                      disabled={pending}
+                      checked={selectedAccountId === account.accountId}
+                      onChange={() => setSelectedAccountId(account.accountId)}
+                    />
+                    <ProviderMark provider={account.provider} />
+                    <span>
+                      <strong>{account.login}</strong>
+                      <small>{managedAuthProviderLabel(account.provider)}</small>
+                    </span>
+                  </label>
+                ))}
+              </fieldset>
+            )
+          ) : action === "disconnect" ? (
             <p>
-              当前模型来源保持不变。需要更换模型服务时，请另行确认模型来源设置。
+              {connection.authStatus === "disconnected"
+                ? "当前并未连接官方登录；确认后只恢复第三方模型来源，不会删除账号。"
+                : connection.requestMode === "third_party_api"
+                  ? "当前账号连接将被移除；当前第三方 API 配置不会被删除。"
+                  : "当前账号连接将被移除；其他软件的账号连接不会改变。"}
+            </p>
+          ) : action === "switch_to_official" ? (
+            <p>
+              当前模型来源：
+              {requestModeLabel(
+                connection.requestMode,
+                connection.requestProviderLabel,
+              )}
             </p>
           ) : null}
-          {preview.data.previewId === consumedPreviewId && !pending ? (
+          {preview.isFetching ? (
+            <div className="fy-auth-dialog-loading">
+              <Spinner label="正在检查文件影响" />
+              <span>正在检查文件和备份位置</span>
+            </div>
+          ) : preview.data ? (
+            <>
+              <FileWriteDisclosure
+                targets={preview.data.writeTargets}
+                preservedPaths={preview.data.preservedPaths}
+              />
+              {connection.consumer === "codex" ? (
+                preview.data.writeTargets.some((target) =>
+                  target.path.endsWith("config.toml"),
+                ) ? (
+                  <p>
+                    {action === "disconnect"
+                      ? "断开后会取消注释顶层 model_provider，恢复原来的第三方模型来源；[model_providers.*] 表保持不变。"
+                      : "官方连接会注释顶层 model_provider，让 Codex 使用内建官方登录；[model_providers.*] 表保持不变。"}
+                  </p>
+                ) : action === "connect_account" ||
+                  action === "switch_account" ? (
+                  <p>
+                    顶层 model_provider 已是注释状态，Codex 将走官方登录；提供商表和其它配置保持不变。
+                  </p>
+                ) : null
+              ) : null}
+              {preview.data.previewId === consumedPreviewId && !pending ? (
+                <InlineNotice tone="warning">
+                  此次确认已使用。请关闭后重新打开，检查最新状态再操作。
+                </InlineNotice>
+              ) : null}
+            </>
+          ) : preview.isError ? (
             <InlineNotice tone="warning">
-              此次确认已使用。请关闭后重新打开，检查最新状态再操作。
+              无法确认文件影响。请检查账号用途及软件状态，关闭后重新打开；尚未修改任何文件。
             </InlineNotice>
           ) : null}
         </>
-      ) : preview.isError ? (
-        <InlineNotice tone="warning">
-          无法确认文件影响。请检查账号用途及软件状态，关闭后重新打开；尚未修改任何文件。
-        </InlineNotice>
       ) : null}
     </Dialog>
   );

--- a/src/pages/auth/Page.tsx
+++ b/src/pages/auth/Page.tsx
@@ -24,7 +24,6 @@ import {
 import { FeatureTabPanel, FeatureTabs } from "../../shared/ui/FeatureTabs";
 import { usePersistentSearchParams } from "../../shared/ui/usePersistentSearchParams";
 import { Button } from "../../shared/ui/Button";
-import { AnimatePresence } from "../../shared/ui/motion";
 import { useDialogState } from "../../shared/ui/useDialogState";
 import { EmptyState, InlineNotice, Spinner } from "../../shared/ui/primitives";
 import { AccountView } from "./AccountView";
@@ -117,8 +116,7 @@ export function AuthPage() {
     },
     [],
   );
-  const [connectionAction, setConnectionAction, connectionActionKey] =
-    useDialogState<{
+  const [connectionAction, setConnectionAction] = useDialogState<{
       connection: ManagedAuthConnectionSummary;
       action: ManagedAuthConnectionAction;
       preferredAccountId?: string | null;
@@ -638,29 +636,24 @@ export function AuthPage() {
         }}
         onConfirm={() => void confirmRemoveAccount()}
       />
-      <AnimatePresence>
-        {connectionAction && (
-          <ConnectionActionDialog
-            key={connectionActionKey}
-            originRef={dialogOriginRef}
-            connection={connectionAction?.connection ?? null}
-            action={connectionAction?.action ?? null}
-            overview={overview}
-            pending={mutationBusy}
-            preferredAccountId={connectionAction?.preferredAccountId}
-            onCancel={() => setConnectionAction(null)}
-            onConfirm={(accountId, previewId) => {
-              if (!connectionAction) return;
-              void applyConnectionAction(
-                connectionAction.connection,
-                connectionAction.action,
-                accountId,
-                previewId,
-              );
-            }}
-          />
-        )}
-      </AnimatePresence>
+      <ConnectionActionDialog
+        originRef={dialogOriginRef}
+        connection={connectionAction?.connection ?? null}
+        action={connectionAction?.action ?? null}
+        overview={overview}
+        pending={mutationBusy}
+        preferredAccountId={connectionAction?.preferredAccountId}
+        onCancel={() => setConnectionAction(null)}
+        onConfirm={(accountId, previewId) => {
+          if (!connectionAction) return;
+          void applyConnectionAction(
+            connectionAction.connection,
+            connectionAction.action,
+            accountId,
+            previewId,
+          );
+        }}
+      />
     </div>
   );
 }

--- a/src/pages/auth/Page.tsx
+++ b/src/pages/auth/Page.tsx
@@ -117,10 +117,10 @@ export function AuthPage() {
     [],
   );
   const [connectionAction, setConnectionAction] = useDialogState<{
-      connection: ManagedAuthConnectionSummary;
-      action: ManagedAuthConnectionAction;
-      preferredAccountId?: string | null;
-    }>(null);
+    connection: ManagedAuthConnectionSummary;
+    action: ManagedAuthConnectionAction;
+    preferredAccountId?: string | null;
+  }>(null);
 
   const refetchOverview = overviewQuery.refetch;
   const invalidateRequestSources = useCallback(() => {

--- a/src/pages/auth/presentation.ts
+++ b/src/pages/auth/presentation.ts
@@ -296,6 +296,7 @@ export function loginStagePresentation(stage: ManagedAuthLoginStage): {
 
 export function connectionActionLabel(
   action: ManagedAuthConnectionAction,
+  connection?: Pick<ManagedAuthConnectionSummary, "authStatus">,
 ): string {
   switch (action) {
     case "connect_account":
@@ -303,7 +304,9 @@ export function connectionActionLabel(
     case "switch_account":
       return "切换账号";
     case "disconnect":
-      return "断开";
+      return connection?.authStatus === "disconnected"
+        ? "恢复第三方模型来源"
+        : "断开";
     case "refresh":
       return "刷新状态";
     case "restart":
@@ -317,6 +320,7 @@ export function connectionActionLabel(
 
 export function accountPageConnectionActionLabel(
   action: ManagedAuthConnectionAction,
+  connection?: Pick<ManagedAuthConnectionSummary, "authStatus">,
 ): string {
   switch (action) {
     case "connect_account":
@@ -326,7 +330,7 @@ export function accountPageConnectionActionLabel(
     case "switch_to_official":
       return "切回官方";
     default:
-      return connectionActionLabel(action);
+      return connectionActionLabel(action, connection);
   }
 }
 
@@ -334,19 +338,42 @@ const ACCOUNT_PAGE_CONNECTION_ACTIONS: ManagedAuthConnectionAction[] = [
   "switch_to_official",
   "connect_account",
   "switch_account",
+  "disconnect",
 ];
 
 export function accountPageConnectionActions(
   connection: ManagedAuthConnectionSummary,
   accountId: string,
 ): ManagedAuthConnectionAction[] {
-  return ACCOUNT_PAGE_CONNECTION_ACTIONS.filter((action) => {
+  const actions = ACCOUNT_PAGE_CONNECTION_ACTIONS.filter((action) => {
     if (!connection.allowedActions.includes(action)) return false;
     if (action === "switch_to_official") {
       return connection.accountId === accountId;
     }
+    if (
+      connection.accountId === accountId &&
+      connection.authStatus === "disconnected"
+    ) {
+      return (
+        action === "connect_account" ||
+        action === "switch_account" ||
+        action === "disconnect"
+      );
+    }
     return connection.accountId !== accountId;
   });
+  return actions;
+}
+
+export function linkedConnectionsForAccount(
+  account: ManagedAuthAccountSummary,
+  connections: ManagedAuthConnectionSummary[],
+): ManagedAuthConnectionSummary[] {
+  return connections.filter(
+    (connection) =>
+      connection.accountId === account.accountId &&
+      connection.authStatus !== "disconnected",
+  );
 }
 
 export function connectableConnectionsForAccount(
@@ -356,7 +383,10 @@ export function connectableConnectionsForAccount(
   if (account.health !== "ready") return [];
   return connections.filter((connection) => {
     if (connection.provider !== account.provider) return false;
-    if (connection.accountId === account.accountId) return false;
+    const alreadyLive =
+      connection.accountId === account.accountId &&
+      connection.authStatus !== "disconnected";
+    if (alreadyLive) return false;
     return (
       connection.allowedActions.includes("connect_account") ||
       connection.allowedActions.includes("switch_account")

--- a/src/shared/features/agent-install-readiness.ts
+++ b/src/shared/features/agent-install-readiness.ts
@@ -108,8 +108,12 @@ export type AgentActionId = (typeof AGENT_ACTION_IDS)[number];
 export const AGENT_SURFACES = ["cli", "desktop"] as const;
 export type AgentSurface = (typeof AGENT_SURFACES)[number];
 
+function isCliToolingAgent(agentId: AgentCatalogId): boolean {
+  return agentId === "grokbuild" || agentId === "claude-code";
+}
+
 export function surfacesForAgent(agentId: AgentCatalogId): AgentSurface[] {
-  if (agentId === "grokbuild") {
+  if (isCliToolingAgent(agentId)) {
     return ["cli"];
   }
   return ["desktop"];
@@ -485,7 +489,7 @@ export function parseAgentInstallReadiness(
     expectedAgentId === "codex"
       ? value.sourceKind === "codex_desktop" &&
         value.authOwnership === "fyagent_managed"
-      : expectedAgentId === "grokbuild"
+      : isCliToolingAgent(expectedAgentId)
         ? value.sourceKind === "cli_tooling"
         : value.sourceKind === "managed_desktop";
   if (!matchesKind) {

--- a/src/shared/features/useAppearance.ts
+++ b/src/shared/features/useAppearance.ts
@@ -40,7 +40,7 @@ export function useAppearance() {
     const visibility = () => {
       if (document.hidden) controller.settle();
     };
-    refresh(preference.current);
+    refresh(readThemePreference());
     window.addEventListener("resize", controller.settle);
     document.addEventListener("visibilitychange", visibility);
     window.addEventListener("storage", storageChange);

--- a/src/shared/ui/Dialog.tsx
+++ b/src/shared/ui/Dialog.tsx
@@ -196,7 +196,13 @@ function DialogLayer({
       element.style.removeProperty("width");
     }
     const box = element.getBoundingClientRect();
-    const liveOrigin = dialogOriginGeometry(source.current, box);
+    // Resolve the explicit return anchor before every exit path, including
+    // immediate settlement when native animation cannot run.
+    const presentationSource =
+      !present && !dialogOriginGeometry(source.current, box).sourced
+        ? returnSource.current
+        : source.current;
+    const liveOrigin = dialogOriginGeometry(presentationSource, box);
     element.dataset.motionOrigin = liveOrigin.sourced ? "trigger" : "neutral";
     const duration =
       motionDuration(present ? "dialog-enter" : "dialog-exit") * 1000;
@@ -233,10 +239,7 @@ function DialogLayer({
     try {
       handle = runDialogPresentation({
         planes,
-        source:
-          !present && !dialogOriginGeometry(source.current, box).sourced
-            ? returnSource.current
-            : source.current,
+        source: presentationSource,
         windowNode: element,
         entering: present,
         first: !hasAnimated.current,

--- a/src/shared/ui/Dialog.tsx
+++ b/src/shared/ui/Dialog.tsx
@@ -196,10 +196,8 @@ function DialogLayer({
       element.style.removeProperty("width");
     }
     const box = element.getBoundingClientRect();
-    element.dataset.motionOrigin = dialogOriginGeometry(source.current, box)
-      .sourced
-      ? "trigger"
-      : "neutral";
+    const liveOrigin = dialogOriginGeometry(source.current, box);
+    element.dataset.motionOrigin = liveOrigin.sourced ? "trigger" : "neutral";
     const duration =
       motionDuration(present ? "dialog-enter" : "dialog-exit") * 1000;
     let handle: ReturnType<typeof runDialogPresentation> | null = null;

--- a/src/shared/ui/LifecycleTargetPicker.tsx
+++ b/src/shared/ui/LifecycleTargetPicker.tsx
@@ -18,6 +18,10 @@ function scopeCopy(scope: AgentInstallationTarget["scope"]): string {
   }
 }
 
+function isRootApplications(target: AgentInstallationTarget): boolean {
+  return target.label.startsWith("/Applications");
+}
+
 export function LifecycleTargetPicker({
   id,
   action,
@@ -98,7 +102,12 @@ export function LifecycleTargetPicker({
                 onChange={() => onChange(target)}
               />
               <span className="fy-agent-target-option-copy">
-                <strong>{target.label}</strong>
+                <strong>
+                  {target.label}
+                  {isRootApplications(target) ? (
+                    <span className="fy-agent-target-recommend">推荐</span>
+                  ) : null}
+                </strong>
                 <small>{scopeCopy(target.scope)}</small>
               </span>
             </label>

--- a/src/shared/ui/ThemeReveal.ts
+++ b/src/shared/ui/ThemeReveal.ts
@@ -82,11 +82,13 @@ export function themeRevealClipPath(
 
 function revealClipAnimations(): Animation[] {
   if (typeof document.getAnimations !== "function") return [];
-  return document.getAnimations().filter(
-    (animation) =>
-      (animation.effect as KeyframeEffect | null)?.pseudoElement ===
-      "::view-transition-new(root)",
-  );
+  return document
+    .getAnimations()
+    .filter(
+      (animation) =>
+        (animation.effect as KeyframeEffect | null)?.pseudoElement ===
+        "::view-transition-new(root)",
+    );
 }
 
 function releaseRevealClips(): void {

--- a/src/shared/ui/ThemeReveal.ts
+++ b/src/shared/ui/ThemeReveal.ts
@@ -1,4 +1,4 @@
-import { fySpatialEasing, motionDuration } from "./motion";
+import { fyThemeRevealEasing, motionDuration } from "./motion";
 
 type NativeTransition = {
   ready: Promise<void>;
@@ -12,28 +12,85 @@ type RevealRequest = {
   animation?: Animation;
 };
 
+function themeRevealReferenceBox() {
+  const root = document.documentElement;
+  const viewport = window.visualViewport;
+  return {
+    width: Math.max(
+      window.innerWidth || 0,
+      root.clientWidth || 0,
+      root.getBoundingClientRect().width || 0,
+      viewport?.width ?? 0,
+    ),
+    height: Math.max(
+      window.innerHeight || 0,
+      root.clientHeight || 0,
+      root.getBoundingClientRect().height || 0,
+      viewport?.height ?? 0,
+    ),
+  };
+}
+
+function themeRevealRadiusPadding() {
+  return Math.max(24, (window.devicePixelRatio || 1) * 8);
+}
+
 export function themeRevealGeometry(
   source: HTMLElement,
   origin?: { x: number; y: number },
 ) {
   const rect = source.getBoundingClientRect();
+  const { width, height } = themeRevealReferenceBox();
   const x = Math.min(
-    window.innerWidth,
+    width,
     Math.max(0, origin?.x ?? rect.left + rect.width / 2),
   );
   const y = Math.min(
-    window.innerHeight,
+    height,
     Math.max(0, origin?.y ?? rect.top + rect.height / 2),
   );
   return {
     x,
     y,
     radius:
-      Math.hypot(
-        Math.max(x, window.innerWidth - x),
-        Math.max(y, window.innerHeight - y),
-      ) + 1,
+      Math.hypot(Math.max(x, width - x), Math.max(y, height - y)) +
+      themeRevealRadiusPadding(),
   };
+}
+
+export function themeRevealClipPath(
+  x: number,
+  y: number,
+  radius: number,
+  width: number,
+  height: number,
+) {
+  const safeWidth = width > 0 ? width : 1;
+  const safeHeight = height > 0 ? height : 1;
+  const xPercent = (x / safeWidth) * 100;
+  const yPercent = (y / safeHeight) * 100;
+  const radiusPercent =
+    (radius / (Math.hypot(safeWidth, safeHeight) / Math.SQRT2)) * 100;
+  return {
+    xPercent,
+    yPercent,
+    radiusPercent,
+    start: `circle(0% at ${xPercent}% ${yPercent}%)`,
+    end: `circle(${radiusPercent}% at ${xPercent}% ${yPercent}%)`,
+  };
+}
+
+function revealClipAnimations(): Animation[] {
+  if (typeof document.getAnimations !== "function") return [];
+  return document.getAnimations().filter(
+    (animation) =>
+      (animation.effect as KeyframeEffect | null)?.pseudoElement ===
+      "::view-transition-new(root)",
+  );
+}
+
+function releaseRevealClips(): void {
+  for (const animation of revealClipAnimations()) animation.cancel();
 }
 
 /** Only presentation: preference, routing and native synchronization have other owners.
@@ -48,8 +105,9 @@ export class ThemeReveal {
     const request = this.active;
     if (commit) request?.commit();
     this.active = undefined;
-    request?.animation?.cancel();
     request?.transition?.skipTransition();
+    request?.animation?.cancel();
+    releaseRevealClips();
     delete document.documentElement.dataset.themeReveal;
   }
 
@@ -77,7 +135,6 @@ export class ThemeReveal {
       commit();
       return;
     }
-    const { x, y, radius } = themeRevealGeometry(source, origin);
     let committed = false;
     const request: RevealRequest = {
       commit: () => {
@@ -98,16 +155,16 @@ export class ThemeReveal {
       void transition.ready.then(() => {
         if (this.active !== request) return;
         try {
+          const { x, y, radius } = themeRevealGeometry(source, origin);
+          const { width, height } = themeRevealReferenceBox();
+          const clip = themeRevealClipPath(x, y, radius, width, height);
           const animation = root.animate(
             {
-              clipPath: [
-                `circle(0px at ${x}px ${y}px)`,
-                `circle(${radius}px at ${x}px ${y}px)`,
-              ],
+              clipPath: [clip.start, clip.end],
             },
             {
               duration,
-              easing: fySpatialEasing,
+              easing: fyThemeRevealEasing,
               fill: "both",
               pseudoElement: "::view-transition-new(root)",
             },

--- a/src/shared/ui/motion.ts
+++ b/src/shared/ui/motion.ts
@@ -19,6 +19,9 @@ export function useReducedMotion(): boolean {
 
 export const fySpatialEase = [0.32, 0.72, 0, 1] as const;
 export const fySpatialEasing = `cubic-bezier(${fySpatialEase.join(",")})`;
+/** Full-window radius travel; the spatial curve crawls the last corner. */
+export const fyThemeRevealEase = [0.25, 0.08, 0.25, 1] as const;
+export const fyThemeRevealEasing = `cubic-bezier(${fyThemeRevealEase.join(",")})`;
 export const fySelectionTransition = {
   type: "tween",
   duration: 0.3,

--- a/src/shared/ui/usePressFeedback.ts
+++ b/src/shared/ui/usePressFeedback.ts
@@ -33,12 +33,12 @@ export function usePressFeedback<T extends HTMLElement>(
 
   useLayoutEffect(() => {
     gate.current = { disabled, reduce, visible };
-    if (reduce || !visible) {
+    if (reduce || !visible || disabled) {
       epoch.current += 1;
       animation.current?.stop();
       held.current = false;
       scale.set(1);
-    } else if (disabled && held.current) releaseRef.current?.();
+    }
   }, [disabled, reduce, visible, scale]);
 
   useEffect(() => {
@@ -55,8 +55,12 @@ export function usePressFeedback<T extends HTMLElement>(
         return;
       }
       const recover = () => {
-        if (epoch.current === revision)
-          animation.current = animate(scale, 1, fyPressRecovery);
+        if (epoch.current !== revision) return;
+        if (gate.current.disabled) {
+          scale.set(1);
+          return;
+        }
+        animation.current = animate(scale, 1, fyPressRecovery);
       };
       // Down/up within one frame still receives a short dip. The native click
       // and business action never wait for this decorative recovery.

--- a/tests/browser/agent-directory.spec.ts
+++ b/tests/browser/agent-directory.spec.ts
@@ -58,7 +58,7 @@ async function installAgentDirectoryOverrides(page: Page): Promise<void> {
           : agentId === "qoderwork" || agentId === "opencode"
             ? "not_installed"
             : "installed";
-      const grokCli = agentId === "grokbuild";
+      const grokCli = agentId === "grokbuild" || agentId === "claude-code";
       return {
         contractVersion: 4,
         agentId,

--- a/tests/browser/blue-themes.spec.ts
+++ b/tests/browser/blue-themes.spec.ts
@@ -191,12 +191,29 @@ test("theme reveal has one real circular track and survives quick reversal and r
       return {
         frames: effect.getKeyframes().map((frame) => frame.clipPath),
         duration: effect.getTiming().duration,
+        easing: effect.getTiming().easing,
       };
     });
     expect(frames.duration).toBe(560);
-    expect(frames.frames[0]).toBe(
-      `circle(0px at ${await trigger.getAttribute("data-test-pointer")})`,
+    expect(String(frames.easing).replace(/\s/g, "")).toBe(
+      "cubic-bezier(0.25,0.08,0.25,1)",
     );
+    expect(String(frames.frames[0])).toMatch(/^circle\(0% at /);
+    const pointer = await trigger.getAttribute("data-test-pointer");
+    const expected = await page.evaluate((pointerText) => {
+      const [x, y] = pointerText
+        .split(" ")
+        .map((part) => Number.parseFloat(part));
+      return {
+        xPercent: (x / window.innerWidth) * 100,
+        yPercent: (y / window.innerHeight) * 100,
+      };
+    }, pointer);
+    const startClip = String(frames.frames[0]);
+    const parsed = /^circle\(0% at ([\d.]+)% ([\d.]+)%\)/.exec(startClip);
+    expect(parsed).toBeTruthy();
+    expect(Number(parsed?.[1])).toBeCloseTo(expected.xPercent, 1);
+    expect(Number(parsed?.[2])).toBeCloseTo(expected.yPercent, 1);
     await trigger.evaluate((element) => (element as HTMLButtonElement).click());
     await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
     await page.setViewportSize({ width: 1000, height: 700 });

--- a/tests/browser/blue-themes.spec.ts
+++ b/tests/browser/blue-themes.spec.ts
@@ -200,6 +200,8 @@ test("theme reveal has one real circular track and survives quick reversal and r
     );
     expect(String(frames.frames[0])).toMatch(/^circle\(0% at /);
     const pointer = await trigger.getAttribute("data-test-pointer");
+    if (pointer === null)
+      throw new Error("Theme trigger did not record a pointer");
     const expected = await page.evaluate((pointerText) => {
       const [x, y] = pointerText
         .split(" ")

--- a/tests/browser/dialog-origins.spec.ts
+++ b/tests/browser/dialog-origins.spec.ts
@@ -78,8 +78,21 @@ test("transient Skill menu dialogs return to the explicitly owned persistent tri
     await expect(dialog).toHaveAttribute("data-motion-origin", "trigger");
     await expect(dialog).toHaveAttribute("data-motion-settled", "true");
     await expect(source).toHaveCount(0);
+    // Record the short-lived exit in-page: a remote assertion may arrive
+    // after the real 360ms exit has already removed the dialog.
+    const exitEvidence = await dialog.evaluateHandle((root) => {
+      const origins: Array<string | null> = [];
+      const observer = new MutationObserver(() => {
+        if (root.getAttribute("data-motion-phase") === "exit")
+          origins.push(root.getAttribute("data-motion-origin"));
+      });
+      observer.observe(root, {
+        attributes: true,
+        attributeFilter: ["data-motion-phase", "data-motion-origin"],
+      });
+      return { origins, observer };
+    });
     await page.keyboard.press("Escape");
-    await expect(dialog).toHaveAttribute("data-motion-origin", "trigger");
     await expect(dialog)
       .toHaveCount(0)
       .catch(async (error) => {
@@ -104,6 +117,13 @@ test("transient Skill menu dialogs return to the explicitly owned persistent tri
         });
         throw error;
       });
+    const exitOrigins = await exitEvidence.evaluate(({ origins, observer }) => {
+      observer.disconnect();
+      return origins;
+    });
+    await exitEvidence.dispose();
+    expect(exitOrigins.length).toBeGreaterThan(0);
+    expect(new Set(exitOrigins)).toEqual(new Set(["trigger"]));
     await expect(trigger).toBeFocused();
   }
   await expectHealthyPage(page, health);

--- a/tests/browser/support/features.ts
+++ b/tests/browser/support/features.ts
@@ -1480,7 +1480,7 @@ export async function installRichTauriFeatureFixture(
             return [];
           case "get_agent_install_readiness": {
             const agentId = String(payload.agentId);
-            const grokCli = agentId === "grokbuild";
+            const grokCli = agentId === "grokbuild" || agentId === "claude-code";
             return {
               contractVersion: 4,
               agentId,

--- a/tests/codexUserHelperContract.test.ts
+++ b/tests/codexUserHelperContract.test.ts
@@ -663,6 +663,8 @@ describe("Codex current-user helper static contract", () => {
     const installerRuntime = installerHelperRuntime(runtime);
     expect(grokRuntime).toContain("Command::new");
     expect(grokRuntime).toContain("powershell.exe");
+    expect(grokRuntime).toContain(".raw_arg(&command_line)");
+    expect(grokRuntime).toContain("call {quoted_program}");
     expect(grokRuntime).not.toContain("std::env::var");
     expect(installerRuntime).not.toMatch(
       /std::process::Command|Command::new|CreateProcess|cmd\.exe|powershell|tauri/iu,

--- a/tests/renderer/app/appearance.test.ts
+++ b/tests/renderer/app/appearance.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { initializeAppearance } from "@/app/appearance";
+import {
+  persistTheme,
+  readThemePreference,
+  THEME_STORAGE_KEY,
+} from "@/shared/design-system/appearance";
+
+afterEach(() => {
+  localStorage.clear();
+  delete document.documentElement.dataset.theme;
+});
+
+describe("startup appearance restore", () => {
+  it("applies a stored explicit preference before route loading", () => {
+    persistTheme("dark");
+    expect(readThemePreference()).toBe("dark");
+    initializeAppearance();
+    expect(document.documentElement.dataset.theme).toBe("dark");
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
+  });
+
+  it("falls back to light when storage is empty or invalid", () => {
+    initializeAppearance();
+    expect(document.documentElement.dataset.theme).toBe("light");
+    localStorage.setItem(THEME_STORAGE_KEY, "not-a-theme");
+    initializeAppearance();
+    expect(document.documentElement.dataset.theme).toBe("light");
+  });
+});

--- a/tests/renderer/features/agent-install-readiness.test.ts
+++ b/tests/renderer/features/agent-install-readiness.test.ts
@@ -49,6 +49,7 @@ function readiness(
 ): AgentInstallReadiness {
   const codex = agentId === "codex";
   const grok = agentId === "grokbuild";
+  const claudeCli = agentId === "claude-code";
   return {
     contractVersion: AGENT_INSTALL_READINESS_CONTRACT_VERSION,
     agentId,
@@ -69,7 +70,7 @@ function readiness(
       agentId === "opencode" ? "provider_connection_required" : "unknown",
     sourceKind: codex
       ? "codex_desktop"
-      : grok
+      : grok || claudeCli
         ? "cli_tooling"
         : "managed_desktop",
     allowedActions: [],
@@ -328,32 +329,44 @@ describe("Agent install readiness wire contract", () => {
     ).toThrow("Agent action job is unavailable");
   });
 
-  it("maps desktop-only Agent lifecycle surfaces except Grok CLI", () => {
+  it("maps desktop-only Agent lifecycle surfaces except Grok and Claude CLI", () => {
     expect(AGENT_CATALOG_IDS.map(surfacesForAgent)).toEqual([
       ["desktop"],
       ["desktop"],
       ["desktop"],
       ["cli"],
       ["desktop"],
-      ["desktop"],
+      ["cli"],
       ["desktop"],
     ]);
     expect(isLegalAgentSurface("qoderwork", "cli")).toBe(false);
-    expect(isLegalAgentSurface("claude-code", "cli")).toBe(false);
+    expect(isLegalAgentSurface("claude-code", "cli")).toBe(true);
     expect(isLegalAgentSurface("opencode", "cli")).toBe(false);
-    expect(isLegalAgentSurface("claude-code", "desktop")).toBe(true);
+    expect(isLegalAgentSurface("claude-code", "desktop")).toBe(false);
     expect(isLegalAgentSurface("opencode", "desktop")).toBe(true);
     expect(isLegalAgentSurface("grokbuild", "desktop")).toBe(false);
     expect(isLegalAgentSurface("grokbuild", "cli")).toBe(true);
   });
 
-  it("parses compact Claude and OpenCode desktop readiness without dual-surface aggregation", () => {
+  it("parses compact Claude CLI and OpenCode desktop readiness without dual-surface aggregation", () => {
     const claude = parseAgentInstallReadiness(
       readiness("claude-code"),
       "claude-code",
     );
-    expect(claude.sourceKind).toBe("managed_desktop");
+    expect(claude.sourceKind).toBe("cli_tooling");
     expect(claude.surfaces).toBeUndefined();
+    expect(
+      parseAgentInstallReadiness(
+        {
+          ...readiness("claude-code"),
+          installState: "not_installed",
+          updateState: "update_available",
+          remoteVersion: "2.1.261",
+          allowedActions: ["install"],
+        },
+        "claude-code",
+      ).allowedActions,
+    ).toEqual(["install"]);
 
     const openCode = parseAgentInstallReadiness(
       {
@@ -395,7 +408,8 @@ describe("Agent install readiness wire contract", () => {
       parseAgentInstallReadiness(
         {
           ...readiness("claude-code"),
-          surfaces: [surfaceRow("cli", "installed")],
+          sourceKind: "managed_desktop",
+          surfaces: [surfaceRow("desktop", "installed")],
         },
         "claude-code",
       ),
@@ -481,7 +495,7 @@ describe("Agent install readiness wire contract", () => {
         surface: "cli",
       }),
     ).toThrow("Agent action job is unavailable");
-    expect(() =>
+    expect(
       parseAgentActionJobSnapshot({
         contractVersion: AGENT_ACTION_CONTRACT_VERSION,
         jobId: "job-1",
@@ -492,6 +506,19 @@ describe("Agent install readiness wire contract", () => {
         reasonCode: null,
         transfer: null,
         surface: "cli",
+      }).surface,
+    ).toBe("cli");
+    expect(() =>
+      parseAgentActionJobSnapshot({
+        contractVersion: AGENT_ACTION_CONTRACT_VERSION,
+        jobId: "job-1",
+        agentId: "claude-code",
+        action: "install",
+        stage: "checking",
+        cancellable: true,
+        reasonCode: null,
+        transfer: null,
+        surface: "desktop",
       }),
     ).toThrow("Agent action job is unavailable");
     expect(() =>

--- a/tests/renderer/features/useAppearance.test.tsx
+++ b/tests/renderer/features/useAppearance.test.tsx
@@ -14,6 +14,14 @@ afterEach(() => {
 });
 
 describe("shell appearance lifetime", () => {
+  it("restores a stored explicit preference when the shell control mounts", () => {
+    localStorage.setItem(THEME_STORAGE_KEY, "dark");
+    const { result, unmount } = renderHook(useAppearance);
+    expect(result.current.theme).toBe("dark");
+    expect(document.documentElement.dataset.theme).toBe("dark");
+    unmount();
+  });
+
   it("follows an existing system preference until the user makes an explicit choice", () => {
     let dark = false;
     const listeners = new Map<string, Set<() => void>>();

--- a/tests/renderer/pages/agents/AgentInstallReadinessSection.test.tsx
+++ b/tests/renderer/pages/agents/AgentInstallReadinessSection.test.tsx
@@ -25,6 +25,7 @@ function readiness(
 ): AgentInstallReadiness {
   const codex = agentId === "codex";
   const grok = agentId === "grokbuild";
+  const claudeCli = agentId === "claude-code";
   return {
     contractVersion: AGENT_INSTALL_READINESS_CONTRACT_VERSION,
     agentId,
@@ -44,7 +45,7 @@ function readiness(
     authState: "unknown",
     sourceKind: codex
       ? "codex_desktop"
-      : grok
+      : grok || claudeCli
         ? "cli_tooling"
         : "managed_desktop",
     allowedActions: codex ? [] : ["install", "auth_login"],
@@ -355,22 +356,23 @@ describe("AgentInstallReadinessSection", () => {
     expect(port.getInventory).not.toHaveBeenCalledWith("opencode", "cli");
   });
 
-  it("labels the Claude physical component Claude Desktop", async () => {
-    const port = portFor(
-      desktopReadiness("claude-code", {
-        installState: "not_installed",
-        allowedActions: ["install"],
-      }),
-    );
+  it("shows Claude Code as CLI install without Desktop chrome", async () => {
+    const port = portFor({
+      ...readiness("claude-code"),
+      installState: "not_installed",
+      allowedActions: ["install"],
+    });
     render(<AgentInstallReadinessSection agentId="claude-code" port={port} />);
     const region = await screen.findByRole("region", { name: "安装与更新" });
     expect(
-      within(region).getByRole("heading", { name: "Claude Desktop" }),
-    ).toBeVisible();
+      within(region).queryByRole("heading", { name: "Claude Desktop" }),
+    ).not.toBeInTheDocument();
     expect(
       within(region).queryByRole("heading", { name: "命令行" }),
     ).not.toBeInTheDocument();
     expect(within(region).getByRole("button", { name: "安装" })).toBeVisible();
+    expect(region.querySelector('[data-surface="cli"]')).not.toBeNull();
+    expect(region.querySelector('[data-surface="desktop"]')).toBeNull();
   });
 
   it.each([

--- a/tests/renderer/pages/agents/Page.test.tsx
+++ b/tests/renderer/pages/agents/Page.test.tsx
@@ -691,6 +691,124 @@ describe("V3 Agent directory and configuration shell", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("opens an install-target dialog from the directory instead of leaving the list", async () => {
+    const user = userEvent.setup();
+    const ports = configuredPorts();
+    const actionJob = deferred<AgentActionJobSnapshot>();
+    const dests: AgentInstallationInventory = {
+      ...installationInventory("qoderwork"),
+      state: "not_observed",
+      candidates: [],
+      freshDestinations: [
+        {
+          destinationId: `d1:${"d".repeat(32)}`,
+          destinationRevision: `r1:${"e".repeat(64)}`,
+          scope: "current_user",
+          owner: "vendor_installer",
+          packageKind: "app_bundle",
+          requiresElevation: false,
+          writable: true,
+          eligible: true,
+          reasonCodes: [],
+          locationLabel: "当前用户应用目录",
+        },
+        {
+          destinationId: `d1:${"f".repeat(32)}`,
+          destinationRevision: `r1:${"g".repeat(64)}`,
+          scope: "all_users",
+          owner: "vendor_installer",
+          packageKind: "app_bundle",
+          requiresElevation: false,
+          writable: true,
+          eligible: true,
+          reasonCodes: [],
+          locationLabel: "/Applications",
+        },
+      ],
+    };
+    ports.agentInstallReadiness.get = vi.fn(async (agentId: AgentCatalogId) => {
+      if (agentId === "qoderwork") {
+        return readiness("qoderwork", "not_installed", {
+          allowedActions: ["install"],
+          releaseId: `v1:${"a".repeat(64)}`,
+          inventoryState: "multiple",
+          requiresTargetSelection: true,
+        });
+      }
+      return readiness(agentId, "installed");
+    });
+    ports.agentInstallReadiness.getInventory = vi.fn(async (agentId) =>
+      agentId === "qoderwork" ? dests : installationInventory(agentId),
+    );
+    ports.agentInstallReadiness.startAction = vi.fn(
+      async (): Promise<AgentActionResult> => ({
+        contractVersion: AGENT_ACTION_CONTRACT_VERSION,
+        agentId: "qoderwork",
+        action: "install",
+        jobId: "job-1",
+        stage: "checking",
+        reasonCode: null,
+      }),
+    );
+    ports.agentInstallReadiness.getActionJob = vi.fn(
+      async () => actionJob.promise,
+    );
+    renderPage(ports);
+
+    expect(
+      await screen.findByRole("button", { name: "重新扫描" }),
+    ).toBeEnabled();
+    await user.click(
+      within(directoryArticle("QoderWork CN")).getByRole("button", {
+        name: "选择安装目标",
+      }),
+    );
+    const dialog = await screen.findByRole("dialog", {
+      name: "选择 QoderWork CN 的安装位置",
+    });
+    expect(within(dialog).getByText("推荐")).toBeVisible();
+    expect(
+      within(dialog).getByRole("radio", { name: /\/Applications/ }),
+    ).toBeChecked();
+    expect(screen.getByTestId("agents-page")).toHaveAttribute(
+      "data-view",
+      "directory",
+    );
+    await user.click(within(dialog).getByRole("button", { name: "确认安装" }));
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("dialog", {
+          name: "选择 QoderWork CN 的安装位置",
+        }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(
+      await within(directoryArticle("QoderWork CN")).findByText(
+        "正在检查来源",
+      ),
+    ).toBeVisible();
+    await waitFor(() =>
+      expect(ports.agentInstallReadiness.startAction).toHaveBeenCalledWith({
+        agentId: "qoderwork",
+        action: "install",
+        expectedReleaseId: `v1:${"a".repeat(64)}`,
+        inventoryId: `i1:${"a".repeat(32)}`,
+        targetId: `d1:${"f".repeat(32)}`,
+        expectedTargetRevision: `r1:${"g".repeat(64)}`,
+      }),
+    );
+    actionJob.resolve({
+      contractVersion: AGENT_ACTION_CONTRACT_VERSION,
+      jobId: "job-1",
+      agentId: "qoderwork",
+      action: "install",
+      stage: "succeeded",
+      cancellable: false,
+      reasonCode: null,
+      transfer: null,
+    });
+  });
+
   it("does not enable configure after a succeeded job until readback proves installation", async () => {
     const user = userEvent.setup();
     const ports = configuredPorts();

--- a/tests/renderer/pages/agents/useAgentLifecycleAction.test.tsx
+++ b/tests/renderer/pages/agents/useAgentLifecycleAction.test.tsx
@@ -19,6 +19,7 @@ import {
   AGENT_LIFECYCLE_SUCCEEDED_COPY,
   AGENT_LIFECYCLE_VENDOR_HANDOFF_COPY,
   AGENT_LIFECYCLE_TIMEOUT_COPY,
+  agentLifecycleFailureCopy,
   deriveAgentLifecyclePrimaryAction,
   isTerminalAgentJobStage,
   jobStageCopy,
@@ -325,6 +326,12 @@ describe("Windows external-installer state copy", () => {
     );
     expect(reasonCopy("installer_timed_out")).toContain("完成或关闭向导");
     expect(reasonCopy("installer_exited_nonzero")).toContain("未能完成");
+    expect(
+      agentLifecycleFailureCopy("installer_exited_nonzero", "cli_tooling"),
+    ).toContain("网络");
+    expect(
+      agentLifecycleFailureCopy("installer_exited_nonzero", "cli_tooling"),
+    ).not.toContain("安装向导");
     expect(isTerminalAgentJobStage("incomplete")).toBe(true);
     expect(isTerminalAgentJobStage("awaiting_user")).toBe(false);
   });
@@ -718,6 +725,52 @@ describe("useAgentLifecycleAction", () => {
     });
     expect(startAction).toHaveBeenCalledTimes(2);
     expect(result.current.success).toBe(AGENT_LIFECYCLE_SUCCEEDED_COPY);
+  });
+
+  it("retries the last action after operation_conflict even if reread omitted it", async () => {
+    const poisoned = readiness({
+      installState: "unknown",
+      allowedActions: [],
+      reasonCodes: ["interactive_user_unavailable"],
+    });
+    const startAction = vi
+      .fn<AgentInstallReadinessPort["startAction"]>()
+      .mockRejectedValueOnce(
+        Object.assign(new Error("conflict"), {
+          reasonCode: "operation_conflict",
+        }),
+      )
+      .mockResolvedValueOnce(actionResult({ jobId: null, stage: "succeeded" }));
+    const port = createPort({
+      get: vi.fn(async () => poisoned),
+      startAction,
+    });
+    const { result, rerender } = renderHook(
+      ({ data }) =>
+        useAgentLifecycleAction({
+          agentId: "qoderwork",
+          port,
+          readiness: data,
+          target: lifecycleTarget(),
+        }),
+      { initialProps: { data: readiness() } },
+    );
+
+    await act(async () => {
+      await result.current.run("install");
+    });
+    expect(result.current.canRetry).toBe(true);
+
+    rerender({ data: poisoned });
+    expect(result.current.primaryAction).toBeNull();
+
+    await act(async () => {
+      await result.current.retry();
+    });
+    expect(startAction).toHaveBeenCalledTimes(2);
+    expect(startAction).toHaveBeenLastCalledWith(
+      expect.objectContaining({ agentId: "qoderwork", action: "install" }),
+    );
   });
 
   it("cancels a cancellable job and rereads after the poll observes it", async () => {

--- a/tests/renderer/pages/auth/MutationDialogs.test.tsx
+++ b/tests/renderer/pages/auth/MutationDialogs.test.tsx
@@ -1,0 +1,97 @@
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+import { ConnectionActionDialog } from "@/pages/auth/MutationDialogs";
+import { FeatureProvider } from "@/shared/features/provider";
+import { createBrowserFeaturePorts } from "@/shared/platform/browser/features";
+import { TooltipProvider } from "@/shared/ui/primitives";
+import {
+  CONNECTION_PREVIEW_ID,
+  OPENAI_ACCOUNT_ID,
+  connectionPreviewFixture,
+  managedAuthOverviewFixture,
+} from "../../fixtures/managedAuth";
+
+describe("ConnectionActionDialog", () => {
+  it("resets only selection on reopen and never reuses a consumed preview", async () => {
+    const user = userEvent.setup();
+    const overview = managedAuthOverviewFixture();
+    const otherAccountId = `ma1:${"e".repeat(32)}`;
+    overview.accounts.push({
+      ...overview.accounts[0],
+      accountId: otherAccountId,
+      login: "other@example.com",
+      isDefault: false,
+      connectedConsumerCount: 0,
+    });
+    const ports = createBrowserFeaturePorts();
+    let previewId = CONNECTION_PREVIEW_ID;
+    ports.managedAuth.previewConnectionAction = vi.fn(async (request) => ({
+      ...connectionPreviewFixture(request),
+      previewId,
+    }));
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+    const view = (open: boolean) => (
+      <MemoryRouter>
+        <TooltipProvider>
+          <FeatureProvider ports={ports}>
+            <ConnectionActionDialog
+              connection={open ? overview.connections[0] : null}
+              action={open ? "switch_account" : null}
+              preferredAccountId={OPENAI_ACCOUNT_ID}
+              overview={overview}
+              pending={false}
+              onCancel={onCancel}
+              onConfirm={onConfirm}
+            />
+          </FeatureProvider>
+        </TooltipProvider>
+      </MemoryRouter>
+    );
+    const result = render(view(true));
+    const dialog = screen.getByRole("dialog", { name: "切换 Codex 账号" });
+    expect(
+      within(dialog).getByRole("radio", { name: /person@example.com/ }),
+    ).toBeChecked();
+    await user.click(
+      within(dialog).getByRole("radio", { name: /other@example.com/ }),
+    );
+    const confirm = within(dialog).getByRole("button", { name: "确认" });
+    await waitFor(() => expect(confirm).toBeEnabled());
+    act(() => {
+      confirm.click();
+      confirm.click();
+    });
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm).toHaveBeenLastCalledWith(
+      otherAccountId,
+      CONNECTION_PREVIEW_ID,
+    );
+
+    result.rerender(view(false));
+    result.rerender(view(true));
+    const reopened = screen.getByRole("dialog", { name: "切换 Codex 账号" });
+    expect(
+      within(reopened).getByRole("radio", { name: /person@example.com/ }),
+    ).toBeChecked();
+    await screen.findByText(
+      "此次确认已使用。请关闭后重新打开，检查最新状态再操作。",
+    );
+    expect(
+      within(reopened).getByRole("button", { name: "确认" }),
+    ).toBeDisabled();
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+
+    previewId = "423e4567-e89b-42d3-a456-426614174000";
+    result.rerender(view(false));
+    result.rerender(view(true));
+    const freshConfirm = screen.getByRole("button", { name: "确认" });
+    await waitFor(() => expect(freshConfirm).toBeEnabled());
+    await user.click(freshConfirm);
+    expect(onConfirm).toHaveBeenCalledTimes(2);
+    expect(onConfirm).toHaveBeenLastCalledWith(OPENAI_ACCOUNT_ID, previewId);
+  });
+});

--- a/tests/renderer/pages/auth/Page.test.tsx
+++ b/tests/renderer/pages/auth/Page.test.tsx
@@ -166,6 +166,124 @@ describe("AuthPage", () => {
     );
   });
 
+  it("lets a saved-only Codex account connect even when the card still names that account", async () => {
+    const user = userEvent.setup();
+    const overview = managedAuthOverviewFixture();
+    overview.connections[0] = {
+      ...overview.connections[0],
+      accountId: OPENAI_ACCOUNT_ID,
+      authStatus: "disconnected",
+      requestMode: "official_subscription",
+      requestProviderLabel: "openai",
+      allowedActions: ["connect_account", "refresh"],
+    };
+    overview.accounts[0] = {
+      ...overview.accounts[0],
+      connectedConsumerCount: 1,
+    };
+    const applyConnectionAction = vi.fn(async () => {
+      const next = managedAuthOverviewFixture();
+      return mutationResultFixture(next);
+    });
+    renderPage(
+      managedPorts({
+        getOverview: vi.fn(async () => overview),
+        applyConnectionAction,
+      }),
+    );
+
+    const connectSection = (
+      await screen.findByRole("heading", { name: "连接到软件" })
+    ).closest("section");
+    expect(connectSection).not.toBeNull();
+    await user.click(
+      within(connectSection!).getByRole("button", { name: "用此账号连接" }),
+    );
+    const dialog = screen.getByRole("dialog", { name: "连接 Codex 账号" });
+    await user.click(within(dialog).getByRole("button", { name: "确认" }));
+
+    expect(applyConnectionAction).toHaveBeenCalledWith(
+      {
+        connectionId: CODEX_CONNECTION_ID,
+        expectedRevision: CONNECTION_REVISION,
+        action: "connect_account",
+        accountId: OPENAI_ACCOUNT_ID,
+      },
+      "323e4567-e89b-42d3-a456-426614174000",
+    );
+  });
+
+  it("lets a disconnected Codex slot restore the unofficial model source", async () => {
+    const user = userEvent.setup();
+    const overview = managedAuthOverviewFixture();
+    overview.connections[0] = {
+      ...overview.connections[0],
+      accountId: OPENAI_ACCOUNT_ID,
+      authStatus: "disconnected",
+      requestMode: "official_subscription",
+      requestProviderLabel: "openai",
+      allowedActions: ["connect_account", "disconnect", "refresh"],
+    };
+    overview.accounts[0] = {
+      ...overview.accounts[0],
+      connectedConsumerCount: 1,
+    };
+    const applyConnectionAction = vi.fn(async () => {
+      const next = managedAuthOverviewFixture();
+      return mutationResultFixture(next);
+    });
+    const previewConnectionAction = vi.fn(async (request) => ({
+      ...connectionPreviewFixture(request),
+      writeTargets:
+        request.action === "disconnect"
+          ? [
+              {
+                path: "~/.codex/config.toml",
+                backupPath: "~/.codex/config.toml.fyagent.backup",
+                exists: true,
+              },
+            ]
+          : connectionPreviewFixture(request).writeTargets,
+      preservedPaths:
+        request.action === "disconnect"
+          ? ["~/.codex/auth.json"]
+          : connectionPreviewFixture(request).preservedPaths,
+    }));
+    renderPage(
+      managedPorts({
+        getOverview: vi.fn(async () => overview),
+        applyConnectionAction,
+        previewConnectionAction,
+      }),
+    );
+
+    const connectSection = (
+      await screen.findByRole("heading", { name: "连接到软件" })
+    ).closest("section");
+    expect(connectSection).not.toBeNull();
+    await user.click(
+      within(connectSection!).getByRole("button", {
+        name: "恢复第三方模型来源",
+      }),
+    );
+    const dialog = screen.getByRole("dialog", {
+      name: "恢复 Codex 的第三方模型来源？",
+    });
+    expect(await within(dialog).findByText("将修改")).toBeVisible();
+    expect(within(dialog).getByText("~/.codex/config.toml")).toBeVisible();
+    await user.click(within(dialog).getByRole("button", { name: "恢复" }));
+
+    expect(applyConnectionAction).toHaveBeenCalledWith(
+      {
+        connectionId: CODEX_CONNECTION_ID,
+        expectedRevision: CONNECTION_REVISION,
+        action: "disconnect",
+        accountId: null,
+      },
+      "323e4567-e89b-42d3-a456-426614174000",
+    );
+  });
+
   it("starts a Codex connection login when the saved account cannot connect yet", async () => {
     const user = userEvent.setup();
     const overview = managedAuthOverviewFixture();

--- a/tests/renderer/platform/agentInstallReadinessPort.test.ts
+++ b/tests/renderer/platform/agentInstallReadinessPort.test.ts
@@ -12,6 +12,7 @@ vi.mock("@tauri-apps/api/core", () => ({ invoke }));
 function wire(agentId = "qoderwork") {
   const codex = agentId === "codex";
   const grok = agentId === "grokbuild";
+  const claudeCli = agentId === "claude-code";
   return {
     contractVersion: AGENT_INSTALL_READINESS_CONTRACT_VERSION,
     agentId,
@@ -31,7 +32,7 @@ function wire(agentId = "qoderwork") {
     authState: "unknown",
     sourceKind: codex
       ? "codex_desktop"
-      : grok
+      : grok || claudeCli
         ? "cli_tooling"
         : "managed_desktop",
     allowedActions: [],

--- a/tests/renderer/shared/Dialog.test.tsx
+++ b/tests/renderer/shared/Dialog.test.tsx
@@ -16,6 +16,55 @@ import { TabsPrimitive } from "@/shared/ui/vendor";
 import { AnimatePresence } from "@/shared/ui/motion";
 
 describe("shared desktop dialog", () => {
+  it.each(["visible", "hidden", "removed"] as const)(
+    "resolves a %s explicit return target before a no-animation exit",
+    async (targetState) => {
+      const source = document.createElement("button");
+      const anchor = document.createElement("button");
+      document.body.append(source, anchor);
+      vi.spyOn(
+        HTMLElement.prototype,
+        "getBoundingClientRect",
+      ).mockImplementation(function (this: HTMLElement) {
+        return this.getAttribute("role") === "dialog"
+          ? new DOMRect(200, 160, 480, 320)
+          : new DOMRect(600, 60, 100, 40);
+      });
+      const originRef = { current: source, returnTarget: anchor };
+      const view = (open: boolean) => (
+        <Dialog
+          open={open}
+          originRef={originRef}
+          title="菜单操作"
+          onOpenChange={() => undefined}
+        />
+      );
+      const result = render(view(true));
+      const dialog = screen.getByRole("dialog");
+      await waitFor(() =>
+        expect(dialog).toHaveAttribute("data-motion-settled", "true"),
+      );
+      source.remove();
+      if (targetState === "hidden") anchor.hidden = true;
+      if (targetState === "removed") anchor.remove();
+      const exitOrigins: Array<string | undefined> = [];
+      const observer = new MutationObserver(() => {
+        if (dialog.dataset.motionPhase === "exit")
+          exitOrigins.push(dialog.dataset.motionOrigin);
+      });
+      observer.observe(dialog, { attributes: true });
+      result.rerender(view(false));
+      await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+      observer.disconnect();
+      anchor.remove();
+      expect(exitOrigins.length).toBeGreaterThan(0);
+      expect(new Set(exitOrigins)).toEqual(
+        new Set([targetState === "visible" ? "trigger" : "neutral"]),
+      );
+      expect(document.body.style.pointerEvents).not.toBe("none");
+    },
+  );
+
   it("does not let a never-opened sibling retain an exiting modal owner", async () => {
     const user = userEvent.setup();
     function Pane({ close }: { close: () => void }) {

--- a/tests/renderer/shared/FeatureChrome.test.tsx
+++ b/tests/renderer/shared/FeatureChrome.test.tsx
@@ -205,6 +205,15 @@ describe("FeatureList", () => {
     );
     expect(definitionBlock).not.toMatch(/minmax\(90px/);
     expect(featuresCss).toMatch(
+      /\.fy-feature-definition\s+dt,\s*\.fy-feature-definition\s+dd\s*\{[^}]*border-bottom:\s*var\(--fy-radius-separator\)\s+solid\s+var\(--fy-divider\);/s,
+    );
+    expect(featuresCss).toMatch(
+      /\.fy-feature-definition\s+dt:has\(\+\s*dd\s+\.fy-feature-path\),\s*\.fy-feature-definition\s+dd:has\(\.fy-feature-path\)\s*\{[^}]*border-bottom:\s*none;/s,
+    );
+    expect(featuresCss).toMatch(
+      /\.fy-feature-path:not\(:has\(\.fy-feature-path-value\)\)|\.fy-feature-path\s*\{[^}]*justify-content:\s*flex-end;/s,
+    );
+    expect(featuresCss).not.toMatch(
       /\.fy-feature-definition\s+dd:has\(\s*>\s*\.fy-feature-path:not\(:has\(\.fy-feature-path-value\)\)\s*\)\s*\{[^}]*min-width:\s*min-content;/s,
     );
   });

--- a/tests/renderer/shared/ThemeReveal.test.ts
+++ b/tests/renderer/shared/ThemeReveal.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { ThemeReveal, themeRevealGeometry } from "@/shared/ui/ThemeReveal";
+import { ThemeReveal, themeRevealClipPath, themeRevealGeometry } from "@/shared/ui/ThemeReveal";
 import {
   applyTheme,
   parseThemePreference,
@@ -67,11 +67,21 @@ function setup() {
   });
   const animationDone = deferred();
   const cancel = vi.fn();
-  const animate = vi.fn(() => ({
+  const animation: {
+    effect: { pseudoElement: string };
+    playState: AnimationPlayState;
+    finished: Promise<void>;
+    cancel: ReturnType<typeof vi.fn>;
+  } = {
     effect: { pseudoElement: "::view-transition-new(root)" },
-    finished: animationDone.promise,
+    playState: "running",
+    finished: Promise.resolve(),
     cancel,
-  }));
+  };
+  animation.finished = animationDone.promise.then(() => {
+    animation.playState = "finished";
+  });
+  const animate = vi.fn(() => animation);
   Object.defineProperty(document.documentElement, "animate", {
     configurable: true,
     value: animate,
@@ -111,9 +121,19 @@ describe("appearance preference and browser-owned reveal", () => {
     expect(result.radius).toBeGreaterThan(
       Math.hypot(innerWidth - 18, innerHeight - 26),
     );
+    const clip = themeRevealClipPath(
+      result.x,
+      result.y,
+      result.radius,
+      innerWidth,
+      innerHeight,
+    );
+    expect(clip.start).toMatch(/^circle\(0% at /);
+    expect(clip.xPercent).toBeCloseTo((18 / innerWidth) * 100);
+    expect(clip.yPercent).toBeCloseTo((26 / innerHeight) * 100);
   });
   it("commits once and holds CSS suppression through the whole reveal", async () => {
-    const { controller, source, cycles, animate, animationDone } = setup();
+    const { controller, source, cycles, animate, animationDone, cancel } = setup();
     const commit = vi.fn();
     controller.run(commit, source);
     cycles[0].update();
@@ -122,16 +142,24 @@ describe("appearance preference and browser-owned reveal", () => {
     await Promise.resolve();
     expect(commit).toHaveBeenCalledTimes(1);
     expect(animate).toHaveBeenCalledWith(
-      expect.anything(),
+      expect.objectContaining({
+        clipPath: [
+          expect.stringMatching(/^circle\(0% at /),
+          expect.stringMatching(/^circle\([\d.]+% at /),
+        ],
+      }),
       expect.objectContaining({
         duration: 560,
+        easing: "cubic-bezier(0.25,0.08,0.25,1)",
         pseudoElement: "::view-transition-new(root)",
       }),
     );
     expect(document.documentElement.dataset.themeReveal).toBe("active");
     animationDone.resolve();
     await Promise.resolve();
+    await Promise.resolve();
     expect(document.documentElement.dataset.themeReveal).toBeUndefined();
+    expect(cancel).toHaveBeenCalledTimes(1);
   });
   it("rejects stale update/ready/finished callbacks after rapid reversal", async () => {
     const { controller, source, cycles, animate } = setup();

--- a/tests/renderer/shared/motionDuration.test.ts
+++ b/tests/renderer/shared/motionDuration.test.ts
@@ -4,6 +4,8 @@ import {
   parseMotionDuration,
   fySpatialEase,
   fySpatialEasing,
+  fyThemeRevealEase,
+  fyThemeRevealEasing,
 } from "@/shared/ui/motion";
 import fs from "node:fs";
 
@@ -58,4 +60,13 @@ it("keeps CSS and native/Motion spatial curves aligned", () => {
     .map(Number);
   expect(curve).toEqual(fySpatialEase);
   expect(fySpatialEasing).toBe("cubic-bezier(0.32,0.72,0,1)");
+});
+it("keeps the shared theme-reveal curve aligned with its CSS token", () => {
+  const css = fs.readFileSync("src/app/styles/tokens.css", "utf8");
+  const curve = css
+    .match(/--fy-motion-theme-ease:\s*cubic-bezier\(([^)]+)\)/)?.[1]
+    .split(",")
+    .map(Number);
+  expect(curve).toEqual(fyThemeRevealEase);
+  expect(fyThemeRevealEasing).toBe("cubic-bezier(0.25,0.08,0.25,1)");
 });


### PR DESCRIPTION
## Scope and rationale

Review the September 6-7, 2026 integration using UTC+8 committer dates: 64 existing non-merge commits, including the seven development commits not yet in main. Keep this as a direct review session; no separate Trellis task.

- Centralize the shared Codex source selector and targeted TOML patch contract. Distinguish auth-only deltas from full official connections, Provider/source writes, disconnect and process restart evidence.
- Document actual best-effort theme persistence and cross-file compensation limits; keep ownership guides short and linked to focused contracts.
- Repair reproduced integration failures without relaxing gates: eight reviewed platform source digests, DOM-ref/null typing, auth-dialog state initialization and single-use preview regression, shared radius token, and formatting.

No dependencies, release version, workflow triggers, permissions, branch protections or security gates are changed. Unrelated open PRs are not included.

## Related work

Direct requested SPEC review. Review commits: ee5745ca and 77e50e83; follow-up cd8c3fcc scopes the macOS application-launch guard to permit only the separate HTTP browser helper, retaining the application ban and normalizing CRLF for Windows. The owning SPEC and reviewed digest were updated together. Trellis session 83 records the scope and evidence. Existing development work covers Claude CLI, appearance, WorkBuddy identity, Windows npm shims and managed auth.

## Evidence

- SPEC navigation: 82 documents; zero missing relative targets or missing layer-index entries. The new focused contract includes all seven required sections.
- Frontend full gate: 179 test files; 1579 passed, one existing conditional skip. Desktop mock: seven passed.
- Focused auth/Agent regression: 35 tests passed, including same-tick double confirmation, consumed preview rejection across reopen, fresh-preview retry and account selection reset.
- Lint, TypeScript, Rust formatting, Rust check, Clippy and check:contracts passed locally on macOS arm64.
- The complete `mise run check` passed on macOS arm64 at cd8c3fcc (exit 0): 3511 Rust tests passed, zero failed, six existing ignored; release-contract rerun 616 passed with one existing conditional skip; native-fetch four passed. Exact-head hosted CI and merge-group CI remain required.
- No real account credentials, vendor login, native Windows interactive installation or packaged-app theme relaunch were exercised by this review. Portable/static tests do not claim that evidence.

### Final local validation at `79790c39`

- Follow-up `61986e69` resolves an explicit dialog return anchor before both native animation and immediate settlement. A red/green regression preserves visible, hidden and removed target distinctions. Browser exit evidence is recorded in-page before the short-lived dialog disappears; animation durations, retries and rejection assertions are unchanged. The owning dialog lifecycle SPEC and Trellis session 84 are updated.
- Complete `mise run check`: exit 0 on macOS arm64. Frontend: 179 files, 1582 passed / one existing conditional skip. Rust: 3511 passed / zero failed / six existing ignored. Desktop mock: seven passed. Release contracts: 616 passed / one existing conditional skip. Native-fetch: four passed.
- Complete `mise run test:browser`: exit 0, production build/boot and 526 browser regressions passed across four Chromium sizes and WebKit. The transient-menu return case additionally passed twice in each of these five projects.
- Rechecked 82 SPEC documents: no broken relative links or missing index entries. The original UTC+8 scope remains 44 non-merge commits on September 6 and 20 on September 7.
- Supplemental production profiling: six tests passed serially with one worker in `presentation-performance.spec.ts` and `navigation-performance.spec.ts`, at 1x/4x CPU cost. Presentation frame p95 was 33.4ms in both runs (655/644 warm frame samples); 1x had no long tasks, 4x retained one 53ms long task. Navigation p95 was 28.1ms / 47.4ms; 4x retained 98ms and 51ms long tasks. Existing thresholds and actual animation durations were unchanged. This is browser profiling, not native WebView/GPU or before/after improvement evidence.
- Hosted run 34121938027 passed on product-code head `79790c39`: macOS, Windows, Windows native X64/ARM64, frontend/browser, repository contracts and CI / Required all succeeded. The non-requested Desktop Acceptance Contract job was correctly skipped by classification.
- Final head `1de954e3` adds only the Windows batch-launch SPEC clarification and session 85. Rust official documentation distinguishes its historical batch support from this project's explicit cmd dispatch; raw_arg does not escape its input. Runtime, tests, configuration and build inputs are byte-identical to `79790c39`, verified with a Git diff excluding `.trellis`. `mise run check:contracts` passed again for the documentation correction.
- Final-head hosted run 34123878026 passed on `1de954e3`, including CI / Required and every requested domain. No check bypass was used.
- Merge-group run 34125659911 validates candidate `9bb4ec6c02ab35604167b07d0fea2640353057bd`. Its parents were read back as current main `2cedbb6a216e00f995e0a9a3f89ad4a7925028ba` and exact reviewed head `1de954e39e7086ff7a0b1386b4567579825f8569`; the candidate file tree matches that reviewed head. Merge-group CI / Required and every requested domain passed. GitHub confirmed MERGED at 2026-09-07T13:31:25Z (21:31:25 UTC+8), with this exact candidate as the main merge commit. Local main, local dev/laiyongjie and both remote-tracking branches were safely fast-forwarded to the same SHA; the checkout is clean. The development-branch push convention check also passed (run 34127989828). Unrelated detached worktrees were left untouched.

## Risk and rollback

The repair retains mounted dialog presentation and the native preview authority; the final reviewed source bytes are sealed rather than bypassing platform validation. The recommendation badge uses the existing token with the same value. Other presentation edits only normalize formatting. Account/source disclosure no longer falsely promises that switching an account cannot affect routing.

Revert the narrow repair/spec commits together when rolling back. A source rollback must also restore its corresponding reviewed digest. No release artifacts are published by this PR.

## Contract and provenance impact

- [x] Durable contracts and regression tests are updated with the final implementation.
- [x] No upstream import or provenance rewrite; existing merge ancestry is retained.
- [x] No CI workflow changes; the reviewed platform identity inventory is repaired without exclusions or disabled checks.

## Checklist

- [x] Complete local aggregate gate (`mise run check`, exit 0).
- [x] Confirm exact-head hosted CI and merge-group CI before merge; verify merged SHA on main.
- [x] Test observable success and rejection paths without casts, skipped gates or test-budget changes.
- [x] Current renderer copy remains Chinese; no locale-backed key or localization schema is changed.
- [x] No secrets, personal configuration, build output or environment files are included.
- [x] Distinguish local checks, hosted native checks and unperformed vendor/HIL evidence.
